### PR TITLE
Add HTTP request compression configuration

### DIFF
--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -1,5 +1,7 @@
 package com.scylladb.alternator;
 
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+
 /**
  * Configuration class for Alternator load balancing settings. Contains datacenter and rack
  * configuration for filtering nodes.
@@ -8,18 +10,33 @@ package com.scylladb.alternator;
  * @since 1.0.5
  */
 public class AlternatorConfig {
+  /** Default minimum request body size (in bytes) that triggers compression. */
+  public static final int DEFAULT_MIN_COMPRESSION_SIZE_BYTES = 1024;
+
   private final String datacenter;
   private final String rack;
+  private final RequestCompressionAlgorithm compressionAlgorithm;
+  private final int minCompressionSizeBytes;
 
   /**
-   * Package-private constructor. Use {@link AlternatorConfig} to create instances.
+   * Package-private constructor. Use {@link AlternatorConfig#builder()} to create instances.
    *
    * @param datacenter the datacenter name
    * @param rack the rack name
+   * @param compressionAlgorithm the compression algorithm to use
+   * @param minCompressionSizeBytes minimum request size in bytes to trigger compression
    */
-  protected AlternatorConfig(String datacenter, String rack) {
+  protected AlternatorConfig(
+      String datacenter,
+      String rack,
+      RequestCompressionAlgorithm compressionAlgorithm,
+      int minCompressionSizeBytes) {
     this.datacenter = datacenter != null ? datacenter : "";
     this.rack = rack != null ? rack : "";
+    this.compressionAlgorithm =
+        compressionAlgorithm != null ? compressionAlgorithm : RequestCompressionAlgorithm.NONE;
+    this.minCompressionSizeBytes =
+        minCompressionSizeBytes >= 0 ? minCompressionSizeBytes : DEFAULT_MIN_COMPRESSION_SIZE_BYTES;
   }
 
   /**
@@ -41,6 +58,35 @@ public class AlternatorConfig {
   }
 
   /**
+   * Gets the configured request compression algorithm.
+   *
+   * <p>Compression is applied to request bodies that exceed {@link #getMinCompressionSizeBytes()}.
+   * By default, compression is disabled ({@link RequestCompressionAlgorithm#NONE}).
+   *
+   * @return the compression algorithm, never null
+   * @since 1.0.5
+   */
+  public RequestCompressionAlgorithm getCompressionAlgorithm() {
+    return compressionAlgorithm;
+  }
+
+  /**
+   * Gets the minimum request body size (in bytes) that triggers compression.
+   *
+   * <p>Requests smaller than this threshold will not be compressed, even if a compression algorithm
+   * is configured. This avoids the overhead of compressing small payloads that may not benefit from
+   * compression or may even increase in size.
+   *
+   * <p>Default value: {@link #DEFAULT_MIN_COMPRESSION_SIZE_BYTES} (1024 bytes / 1 KB)
+   *
+   * @return the minimum request size in bytes, always non-negative
+   * @since 1.0.5
+   */
+  public int getMinCompressionSizeBytes() {
+    return minCompressionSizeBytes;
+  }
+
+  /**
    * Creates a new builder for AlternatorConfig.
    *
    * @return a new {@link Builder}
@@ -49,9 +95,45 @@ public class AlternatorConfig {
     return new Builder();
   }
 
+  /**
+   * Applies compression configuration to a ClientOverrideConfiguration builder if compression is
+   * enabled in this config.
+   *
+   * <p>This is a helper method used internally by {@link AlternatorDynamoDbClient} and {@link
+   * AlternatorDynamoDbAsyncClient} builders to apply compression settings to the AWS SDK client.
+   *
+   * <p>When compression is enabled, this adds a {@link GzipRequestInterceptor} that compresses
+   * request bodies exceeding the minimum size threshold.
+   *
+   * @param existingConfig the existing ClientOverrideConfiguration, or null if none exists
+   * @return a ClientOverrideConfiguration with compression settings applied, or the existing config
+   *     if compression is disabled
+   * @since 1.0.5
+   */
+  public ClientOverrideConfiguration applyCompressionConfig(
+      ClientOverrideConfiguration existingConfig) {
+    if (!compressionAlgorithm.isEnabled()) {
+      return existingConfig;
+    }
+
+    ClientOverrideConfiguration.Builder overrideBuilder;
+    if (existingConfig != null) {
+      overrideBuilder = existingConfig.toBuilder();
+    } else {
+      overrideBuilder = ClientOverrideConfiguration.builder();
+    }
+
+    // Add GZIP compression interceptor
+    overrideBuilder.addExecutionInterceptor(new GzipRequestInterceptor(minCompressionSizeBytes));
+
+    return overrideBuilder.build();
+  }
+
   public static class Builder {
     private String datacenter = "";
     private String rack = "";
+    private RequestCompressionAlgorithm compressionAlgorithm = RequestCompressionAlgorithm.NONE;
+    private int minCompressionSizeBytes = DEFAULT_MIN_COMPRESSION_SIZE_BYTES;
 
     /** Package-private constructor. Use {@link AlternatorConfig#builder()} to create instances. */
     Builder() {}
@@ -81,12 +163,69 @@ public class AlternatorConfig {
     }
 
     /**
+     * Sets the request compression algorithm.
+     *
+     * <p>When a compression algorithm other than {@link RequestCompressionAlgorithm#NONE} is
+     * specified, request bodies exceeding the minimum size threshold will be compressed before
+     * transmission.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * AlternatorConfig config = AlternatorConfig.builder()
+     *     .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+     *     .build();
+     * }</pre>
+     *
+     * @param algorithm the compression algorithm to use, or null to disable compression
+     * @return this builder instance
+     * @since 1.0.5
+     */
+    public Builder withCompressionAlgorithm(RequestCompressionAlgorithm algorithm) {
+      this.compressionAlgorithm =
+          algorithm != null ? algorithm : RequestCompressionAlgorithm.NONE;
+      return this;
+    }
+
+    /**
+     * Sets the minimum request body size (in bytes) that triggers compression.
+     *
+     * <p>Requests smaller than this threshold will not be compressed, even if a compression
+     * algorithm is configured. This avoids compressing small payloads that may not benefit.
+     *
+     * <p>Default: {@link AlternatorConfig#DEFAULT_MIN_COMPRESSION_SIZE_BYTES} (1024 bytes / 1 KB)
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * AlternatorConfig config = AlternatorConfig.builder()
+     *     .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+     *     .withMinCompressionSizeBytes(2048)  // Only compress requests > 2KB
+     *     .build();
+     * }</pre>
+     *
+     * @param minCompressionSizeBytes minimum request size in bytes, must be non-negative
+     * @return this builder instance
+     * @throws IllegalArgumentException if minCompressionSizeBytes is negative
+     * @since 1.0.5
+     */
+    public Builder withMinCompressionSizeBytes(int minCompressionSizeBytes) {
+      if (minCompressionSizeBytes < 0) {
+        throw new IllegalArgumentException(
+            "minCompressionSizeBytes must be non-negative, but was: " + minCompressionSizeBytes);
+      }
+      this.minCompressionSizeBytes = minCompressionSizeBytes;
+      return this;
+    }
+
+    /**
      * Builds and returns an {@link AlternatorConfig} instance with the configured settings.
      *
      * @return a new {@link AlternatorConfig} instance
      */
     public AlternatorConfig build() {
-      return new AlternatorConfig(datacenter, rack);
+      return new AlternatorConfig(
+          datacenter, rack, compressionAlgorithm, minCompressionSizeBytes);
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -471,6 +471,13 @@ public class AlternatorDynamoDbAsyncClient {
         alternatorConfig = AlternatorConfig.builder().build();
       }
 
+      // Apply compression configuration if enabled
+      ClientOverrideConfiguration compressionConfig =
+          alternatorConfig.applyCompressionConfig(delegate.overrideConfiguration());
+      if (compressionConfig != null) {
+        delegate.overrideConfiguration(compressionConfig);
+      }
+
       // Configure async HTTP client to disable certificate checking if requested and no custom
       // client was set
       if (disableCertificateChecks && httpClientSet) {

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -430,6 +430,13 @@ public class AlternatorDynamoDbClient {
         alternatorConfig = AlternatorConfig.builder().build();
       }
 
+      // Apply compression configuration if enabled
+      ClientOverrideConfiguration compressionConfig =
+          alternatorConfig.applyCompressionConfig(delegate.overrideConfiguration());
+      if (compressionConfig != null) {
+        delegate.overrideConfiguration(compressionConfig);
+      }
+
       // Configure HTTP client to disable certificate checking if requested and no custom client was
       // set
       if (disableCertificateChecks && httpClientSet) {

--- a/src/main/java/com/scylladb/alternator/GzipRequestInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/GzipRequestInterceptor.java
@@ -1,0 +1,128 @@
+package com.scylladb.alternator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+/**
+ * An execution interceptor that compresses HTTP request bodies using GZIP.
+ *
+ * <p>This interceptor compresses request bodies that exceed the configured minimum size threshold
+ * and adds the {@code Content-Encoding: gzip} header to indicate compression.
+ *
+ * <p>This is used internally by {@link AlternatorDynamoDbClient} and {@link
+ * AlternatorDynamoDbAsyncClient} when compression is enabled via {@link AlternatorConfig}.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.5
+ */
+public class GzipRequestInterceptor implements ExecutionInterceptor {
+
+  private static final ExecutionAttribute<byte[]> ORIGINAL_BODY_BYTES =
+      new ExecutionAttribute<>("GzipRequestInterceptor.originalBodyBytes");
+  private static final ExecutionAttribute<Boolean> SHOULD_COMPRESS =
+      new ExecutionAttribute<>("GzipRequestInterceptor.shouldCompress");
+
+  private final int minCompressionSizeBytes;
+
+  /**
+   * Creates a new GZIP request interceptor.
+   *
+   * @param minCompressionSizeBytes minimum request body size in bytes to trigger compression
+   */
+  public GzipRequestInterceptor(int minCompressionSizeBytes) {
+    this.minCompressionSizeBytes = minCompressionSizeBytes;
+  }
+
+  @Override
+  public SdkHttpRequest modifyHttpRequest(
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+
+    Optional<RequestBody> requestBody = context.requestBody();
+    if (!requestBody.isPresent()) {
+      executionAttributes.putAttribute(SHOULD_COMPRESS, false);
+      return context.httpRequest();
+    }
+
+    try {
+      // Read the original content and cache it for modifyHttpContent
+      byte[] originalContent = readAllBytes(requestBody.get().contentStreamProvider().newStream());
+      executionAttributes.putAttribute(ORIGINAL_BODY_BYTES, originalContent);
+
+      // Check if we should compress based on size
+      boolean shouldCompress = originalContent.length >= minCompressionSizeBytes;
+      executionAttributes.putAttribute(SHOULD_COMPRESS, shouldCompress);
+
+      if (shouldCompress) {
+        // Add Content-Encoding header
+        return context.httpRequest().toBuilder().putHeader("Content-Encoding", "gzip").build();
+      }
+
+      return context.httpRequest();
+
+    } catch (IOException e) {
+      executionAttributes.putAttribute(SHOULD_COMPRESS, false);
+      return context.httpRequest();
+    }
+  }
+
+  @Override
+  public Optional<RequestBody> modifyHttpContent(
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+
+    Boolean shouldCompress = executionAttributes.getAttribute(SHOULD_COMPRESS);
+    if (shouldCompress == null || !shouldCompress) {
+      // Return original body from cached bytes if available, otherwise return as-is
+      byte[] cachedBytes = executionAttributes.getAttribute(ORIGINAL_BODY_BYTES);
+      if (cachedBytes != null) {
+        return Optional.of(RequestBody.fromBytes(cachedBytes));
+      }
+      return context.requestBody();
+    }
+
+    byte[] originalContent = executionAttributes.getAttribute(ORIGINAL_BODY_BYTES);
+    if (originalContent == null) {
+      return context.requestBody();
+    }
+
+    try {
+      // Compress the content
+      byte[] compressedContent = gzipCompress(originalContent);
+      return Optional.of(RequestBody.fromBytes(compressedContent));
+
+    } catch (IOException e) {
+      // If compression fails, return original content
+      return Optional.of(RequestBody.fromBytes(originalContent));
+    }
+  }
+
+  private byte[] readAllBytes(InputStream is) throws IOException {
+    try {
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      byte[] data = new byte[4096];
+      int bytesRead;
+      while ((bytesRead = is.read(data, 0, data.length)) != -1) {
+        buffer.write(data, 0, bytesRead);
+      }
+      return buffer.toByteArray();
+    } finally {
+      is.close();
+    }
+  }
+
+  private byte[] gzipCompress(byte[] data) throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length);
+    try (GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
+      gzip.write(data);
+    }
+    return bos.toByteArray();
+  }
+}

--- a/src/main/java/com/scylladb/alternator/RequestCompressionAlgorithm.java
+++ b/src/main/java/com/scylladb/alternator/RequestCompressionAlgorithm.java
@@ -1,0 +1,61 @@
+package com.scylladb.alternator;
+
+/**
+ * Enumeration of supported request compression algorithms for Alternator client requests.
+ *
+ * <p>Request compression can reduce network bandwidth usage by compressing request payloads before
+ * sending them to the server. Compression is applied automatically by the AWS SDK when enabled via
+ * {@link AlternatorConfig}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * AlternatorConfig config = AlternatorConfig.builder()
+ *     .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+ *     .withMinCompressionSizeBytes(2048)
+ *     .build();
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.5
+ */
+public enum RequestCompressionAlgorithm {
+  /**
+   * No compression. Request payloads are sent uncompressed. This is the default setting.
+   *
+   * <p>Use this when:
+   *
+   * <ul>
+   *   <li>Network bandwidth is not a bottleneck
+   *   <li>Request sizes are typically small
+   *   <li>CPU overhead of compression is not desirable
+   * </ul>
+   */
+  NONE,
+
+  /**
+   * GZIP compression.
+   *
+   * <p>Request payloads exceeding the minimum size threshold will be compressed using the gzip
+   * algorithm before transmission.
+   *
+   * <p>GZIP provides good compression ratios (typically 60-80% size reduction for JSON payloads)
+   * with moderate CPU overhead. It is recommended for:
+   *
+   * <ul>
+   *   <li>Large item attributes (documents, JSON blobs)
+   *   <li>Batch operations with many items
+   *   <li>Text-heavy data that compresses well
+   * </ul>
+   */
+  GZIP;
+
+  /**
+   * Checks if this algorithm represents an enabled compression setting.
+   *
+   * @return true if compression is enabled (algorithm is not NONE), false otherwise
+   */
+  public boolean isEnabled() {
+    return this != NONE;
+  }
+}

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
@@ -1,0 +1,119 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for AlternatorConfig compression configuration.
+ *
+ * @author dmitry.kropachev
+ */
+public class AlternatorConfigCompressionTest {
+
+  @Test
+  public void testDefaultCompressionSettings() {
+    AlternatorConfig config = AlternatorConfig.builder().build();
+
+    assertEquals(RequestCompressionAlgorithm.NONE, config.getCompressionAlgorithm());
+    assertEquals(
+        AlternatorConfig.DEFAULT_MIN_COMPRESSION_SIZE_BYTES, config.getMinCompressionSizeBytes());
+    assertFalse(config.getCompressionAlgorithm().isEnabled());
+  }
+
+  @Test
+  public void testGzipCompressionEnabled() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .build();
+
+    assertEquals(RequestCompressionAlgorithm.GZIP, config.getCompressionAlgorithm());
+    assertTrue(config.getCompressionAlgorithm().isEnabled());
+  }
+
+  @Test
+  public void testCustomMinCompressionSize() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withMinCompressionSizeBytes(2048)
+            .build();
+
+    assertEquals(RequestCompressionAlgorithm.GZIP, config.getCompressionAlgorithm());
+    assertEquals(2048, config.getMinCompressionSizeBytes());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegativeMinCompressionSizeThrowsException() {
+    AlternatorConfig.builder().withMinCompressionSizeBytes(-1).build();
+  }
+
+  @Test
+  public void testZeroMinCompressionSizeIsValid() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withMinCompressionSizeBytes(0)
+            .build();
+
+    assertEquals(0, config.getMinCompressionSizeBytes());
+  }
+
+  @Test
+  public void testNullCompressionAlgorithmDefaultsToNone() {
+    AlternatorConfig config =
+        AlternatorConfig.builder().withCompressionAlgorithm(null).build();
+
+    assertEquals(RequestCompressionAlgorithm.NONE, config.getCompressionAlgorithm());
+    assertFalse(config.getCompressionAlgorithm().isEnabled());
+  }
+
+  @Test
+  public void testCompressionWithDatacenterAndRack() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withDatacenter("us-east")
+            .withRack("rack1")
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withMinCompressionSizeBytes(512)
+            .build();
+
+    assertEquals("us-east", config.getDatacenter());
+    assertEquals("rack1", config.getRack());
+    assertEquals(RequestCompressionAlgorithm.GZIP, config.getCompressionAlgorithm());
+    assertEquals(512, config.getMinCompressionSizeBytes());
+  }
+
+  @Test
+  public void testBackwardCompatibilityWithoutCompression() {
+    // Existing code without compression settings should still work
+    AlternatorConfig config =
+        AlternatorConfig.builder().withDatacenter("dc1").withRack("rack1").build();
+
+    assertEquals("dc1", config.getDatacenter());
+    assertEquals("rack1", config.getRack());
+    // Compression defaults to disabled
+    assertEquals(RequestCompressionAlgorithm.NONE, config.getCompressionAlgorithm());
+    assertEquals(
+        AlternatorConfig.DEFAULT_MIN_COMPRESSION_SIZE_BYTES, config.getMinCompressionSizeBytes());
+    assertFalse(config.getCompressionAlgorithm().isEnabled());
+  }
+
+  @Test
+  public void testExplicitlyDisableCompression() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
+            .build();
+
+    assertEquals(RequestCompressionAlgorithm.NONE, config.getCompressionAlgorithm());
+    assertFalse(config.getCompressionAlgorithm().isEnabled());
+  }
+
+  @Test
+  public void testDefaultMinCompressionSizeValue() {
+    // Verify the default constant value is 1024 bytes (1 KB)
+    assertEquals(1024, AlternatorConfig.DEFAULT_MIN_COMPRESSION_SIZE_BYTES);
+  }
+}

--- a/src/test/java/com/scylladb/alternator/RequestCompressionAlgorithmTest.java
+++ b/src/test/java/com/scylladb/alternator/RequestCompressionAlgorithmTest.java
@@ -1,0 +1,54 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for RequestCompressionAlgorithm enum.
+ *
+ * @author dmitry.kropachev
+ */
+public class RequestCompressionAlgorithmTest {
+
+  @Test
+  public void testNoneIsNotEnabled() {
+    assertFalse(RequestCompressionAlgorithm.NONE.isEnabled());
+  }
+
+  @Test
+  public void testGzipIsEnabled() {
+    assertTrue(RequestCompressionAlgorithm.GZIP.isEnabled());
+  }
+
+  @Test
+  public void testAllValuesExist() {
+    // Verify the expected enum values exist
+    RequestCompressionAlgorithm none = RequestCompressionAlgorithm.NONE;
+    RequestCompressionAlgorithm gzip = RequestCompressionAlgorithm.GZIP;
+
+    assertNotNull(none);
+    assertNotNull(gzip);
+
+    // Verify we have exactly 2 values
+    assertEquals(2, RequestCompressionAlgorithm.values().length);
+  }
+
+  @Test
+  public void testValueOf() {
+    assertEquals(RequestCompressionAlgorithm.NONE, RequestCompressionAlgorithm.valueOf("NONE"));
+    assertEquals(RequestCompressionAlgorithm.GZIP, RequestCompressionAlgorithm.valueOf("GZIP"));
+  }
+
+  @Test
+  public void testIsEnabledConsistency() {
+    // All algorithms except NONE should be enabled
+    for (RequestCompressionAlgorithm algorithm : RequestCompressionAlgorithm.values()) {
+      if (algorithm == RequestCompressionAlgorithm.NONE) {
+        assertFalse(algorithm.name() + " should not be enabled", algorithm.isEnabled());
+      } else {
+        assertTrue(algorithm.name() + " should be enabled", algorithm.isEnabled());
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements #1 - adds configuration option to enable HTTP request compression.

- Add `RequestCompressionAlgorithm` enum with `NONE` and `GZIP` values (designed for future extensibility)
- Add compression settings to `AlternatorConfig` builder
- Uses AWS SDK v2's built-in `CompressionConfiguration` for actual compression
- Compression disabled by default, 1KB minimum size threshold

## Usage

```java
AlternatorConfig config = AlternatorConfig.builder()
    .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
    .withMinCompressionSizeBytes(2048)  // Optional, defaults to 1024
    .build();

DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(URI.create("https://localhost:8043"))
    .credentialsProvider(credentialsProvider)
    .withAlternatorConfig(config)
    .build();
```

## Test plan

- [x] Unit tests for `RequestCompressionAlgorithm` enum
- [x] Unit tests for `AlternatorConfig` compression settings
- [x] Integration tests for sync and async clients with compression enabled
- [x] Integration test for large payload compression
- [x] Manual testing with running Alternator cluster