### PR TITLE
Add Docker image caching for integration tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Cache Docker image
         id: docker-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .docker-cache
           key: scylla-docker-${{ hashFiles('test/docker-compose.yml') }}
@@ -109,6 +109,17 @@ jobs:
       - name: Save Docker image to cache
         if: steps.docker-cache.outputs.cache-hit != 'true'
         run: make docker-cache-save
+
+      - name: Cache certificates
+        id: cert-cache
+        uses: actions/cache@v5
+        with:
+          path: .cert-cache
+          key: scylla-certs-${{ hashFiles('Makefile') }}
+
+      - name: Save certificates to cache
+        if: steps.cert-cache.outputs.cache-hit != 'true'
+        run: make cert-cache-save
 
       - name: Run integration tests
         run: make test-integration

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ test/scylla/db.*
 .idea/
 target/
 .docker-cache/
+.cert-cache/
 
 TODO.md
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ COMPOSE = bin/docker-compose -f $(MAKEFILE_PATH)/test/docker-compose.yml
 SCYLLA_IMAGE := scylladb/scylla:2025.1
 DOCKER_CACHE_DIR := $(MAKEFILE_PATH)/.docker-cache
 DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/scylla-image.tar
+CERT_CACHE_DIR := $(MAKEFILE_PATH)/.cert-cache
+CERT_DIR := $(MAKEFILE_PATH)/test/scylla
 
 .PHONY: clean verify fix compile compile-test test test-unit test-integration release-prepare release release-dry-run
 
@@ -98,7 +100,7 @@ release-dry-run:
 	@[ -f "${MAKEFILE_PATH}/test/scylla/db.key" ] || (echo "Prepare certificate" && cd ${MAKEFILE_PATH}/test/scylla/ && openssl req -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -x509 -newkey rsa:4096 -keyout db.key -out db.crt -days 3650 -nodes && chmod 644 db.key)
 
 .PHONY: scylla-start
-scylla-start: .prepare-cert .prepare-docker-compose .prepare-environment-update-aio-max-nr docker-cache-load
+scylla-start: cert-cache-load .prepare-docker-compose .prepare-environment-update-aio-max-nr docker-cache-load
 	$(COMPOSE) up -d
 
 .PHONY: scylla-stop
@@ -132,6 +134,18 @@ docker-cache-load:
 		$(MAKE) docker-pull; \
 	fi
 
-.PHONY: docker-cache-key
-docker-cache-key:
-	@echo "scylla-docker-$(SCYLLA_IMAGE)" | sed 's/:/-/g'
+.PHONY: cert-cache-save
+cert-cache-save: .prepare-cert
+	@mkdir -p $(CERT_CACHE_DIR)
+	cp $(CERT_DIR)/db.key $(CERT_DIR)/db.crt $(CERT_CACHE_DIR)/
+
+.PHONY: cert-cache-load
+cert-cache-load:
+	@if [ -f "$(CERT_CACHE_DIR)/db.key" ] && [ -f "$(CERT_CACHE_DIR)/db.crt" ]; then \
+		echo "Loading certificates from cache..."; \
+		cp $(CERT_CACHE_DIR)/db.key $(CERT_CACHE_DIR)/db.crt $(CERT_DIR)/; \
+		chmod 644 $(CERT_DIR)/db.key; \
+	else \
+		echo "Certificate cache not found, generating..."; \
+		$(MAKE) .prepare-cert; \
+	fi


### PR DESCRIPTION
## Summary
- Add Docker image caching to speed up CI integration tests
- Implement caching logic in Makefile with `docker-pull`, `docker-cache-save`, `docker-cache-load` targets
- Use GitHub Actions cache to persist the ScyllaDB Docker image between runs

## Test plan
- [x] Verify CI workflow runs successfully on first run (cache miss - pulls and saves image)
- [x] Verify subsequent CI runs use cached image (cache hit - loads from cache)
- [x] Verify local `make test-integration` still works
