### PR TITLE
Add lint and lint-fix targets to Makefile and CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,22 @@ env:
   IS_CICD: 1
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+
+      - name: Check code formatting
+        run: make lint
+
   compile:
     name: Compile Java Module
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/scylla-image.tar
 CERT_CACHE_DIR := $(MAKEFILE_PATH)/.cert-cache
 CERT_DIR := $(MAKEFILE_PATH)/test/scylla
 
-.PHONY: clean verify fix compile compile-test test test-unit test-integration release-prepare release release-dry-run
+.PHONY: clean verify lint lint-fix compile compile-test test test-unit test-integration release-prepare release release-dry-run
 
 clean:
 	${mvn} clean
@@ -41,10 +41,11 @@ verify:
 	${mvn} javadoc:test-javadoc javadoc:test-aggregate javadoc:test-aggregate-jar javadoc:test-jar javadoc:test-resource-bundle
 	${mvn} javadoc:jar javadoc:aggregate javadoc:aggregate-jar javadoc:resource-bundle
 
-fix:
-	${mvn} com.coveo:fmt-maven-plugin:format
-	echo y | ${mvn} javadoc:fix
-	echo y | ${mvn} javadoc:test-fix
+lint:
+	${mvn} com.spotify.fmt:fmt-maven-plugin:check
+
+lint-fix:
+	${mvn} com.spotify.fmt:fmt-maven-plugin:format
 
 compile:
 	${mvn} compile

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -14,9 +14,7 @@ import java.util.Set;
  * @since 1.0.5
  */
 public class AlternatorConfig {
-  /**
-   * Default minimum request body size (in bytes) that triggers compression.
-   */
+  /** Default minimum request body size (in bytes) that triggers compression. */
   public static final int DEFAULT_MIN_COMPRESSION_SIZE_BYTES = 1024;
 
   /**
@@ -37,7 +35,8 @@ public class AlternatorConfig {
   public static final Set<String> BASE_REQUIRED_HEADERS =
       Collections.unmodifiableSet(
           new HashSet<>(
-              Arrays.asList("Host", "X-Amz-Target", "Content-Type", "Content-Length", "Accept-Encoding")));
+              Arrays.asList(
+                  "Host", "X-Amz-Target", "Content-Type", "Content-Length", "Accept-Encoding")));
 
   /**
    * HTTP headers required when compression is enabled.
@@ -75,13 +74,13 @@ public class AlternatorConfig {
   /**
    * Package-private constructor. Use {@link AlternatorConfig#builder()} to create instances.
    *
-   * @param datacenter              the datacenter name
-   * @param rack                    the rack name
-   * @param compressionAlgorithm    the compression algorithm to use
+   * @param datacenter the datacenter name
+   * @param rack the rack name
+   * @param compressionAlgorithm the compression algorithm to use
    * @param minCompressionSizeBytes minimum request size in bytes to trigger compression
-   * @param optimizeHeaders         whether to enable HTTP header optimization
-   * @param headersWhitelist        the set of headers to preserve when optimization is enabled
-   * @param authenticationEnabled   whether authentication is enabled
+   * @param optimizeHeaders whether to enable HTTP header optimization
+   * @param headersWhitelist the set of headers to preserve when optimization is enabled
+   * @param authenticationEnabled whether authentication is enabled
    */
   protected AlternatorConfig(
       String datacenter,
@@ -187,8 +186,8 @@ public class AlternatorConfig {
    * Checks if authentication is enabled.
    *
    * <p>When authentication is disabled, the client will use anonymous credentials and exclude
-   * authentication headers ({@code Authorization}, {@code X-Amz-Date}, {@code X-Amz-Content-Sha256})
-   * from requests when header optimization is enabled.
+   * authentication headers ({@code Authorization}, {@code X-Amz-Date}, {@code
+   * X-Amz-Content-Sha256}) from requests when header optimization is enabled.
    *
    * <p>This is useful when connecting to Alternator clusters that have authentication disabled.
    *
@@ -238,11 +237,8 @@ public class AlternatorConfig {
     private boolean headersWhitelistWasSet = false;
     private boolean authenticationEnabled = true;
 
-    /**
-     * Package-private constructor. Use {@link AlternatorConfig#builder()} to create instances.
-     */
-    Builder() {
-    }
+    /** Package-private constructor. Use {@link AlternatorConfig#builder()} to create instances. */
+    Builder() {}
 
     /**
      * Sets whether authentication is enabled. Package-private - authentication is auto-detected
@@ -332,8 +328,7 @@ public class AlternatorConfig {
      * @since 1.0.5
      */
     public Builder withCompressionAlgorithm(RequestCompressionAlgorithm algorithm) {
-      this.compressionAlgorithm =
-          algorithm != null ? algorithm : RequestCompressionAlgorithm.NONE;
+      this.compressionAlgorithm = algorithm != null ? algorithm : RequestCompressionAlgorithm.NONE;
       return this;
     }
 
@@ -396,11 +391,11 @@ public class AlternatorConfig {
      * All other headers will be removed. Header names are matched case-insensitively per RFC 7230.
      *
      * <p>The provided whitelist must include all headers required for the current configuration.
-     * Use {@link #getRequiredHeaders()} to see which headers are required. If required headers
-     * are missing, an {@link IllegalArgumentException} will be thrown at build time.
+     * Use {@link #getRequiredHeaders()} to see which headers are required. If required headers are
+     * missing, an {@link IllegalArgumentException} will be thrown at build time.
      *
-     * <p>Default: Computed automatically based on compression and authentication settings.
-     * See {@link AlternatorConfig#getRequiredHeaders()}.
+     * <p>Default: Computed automatically based on compression and authentication settings. See
+     * {@link AlternatorConfig#getRequiredHeaders()}.
      *
      * <p>Example:
      *
@@ -466,7 +461,9 @@ public class AlternatorConfig {
 
         if (!missing.isEmpty()) {
           throw new IllegalArgumentException(
-              "Custom headers whitelist is missing required headers: " + missing + ". "
+              "Custom headers whitelist is missing required headers: "
+                  + missing
+                  + ". "
                   + "Use getRequiredHeaders() to see all required headers for the current configuration.");
         }
       }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -4,12 +4,10 @@ import com.scylladb.alternator.internal.AlternatorLiveNodes;
 import java.net.URI;
 import java.util.Collection;
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientAsyncConfiguration;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.internal.http.loader.DefaultSdkAsyncHttpClientBuilder;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -29,8 +27,8 @@ import software.amazon.awssdk.utils.AttributeMap;
  *
  * <p>The builder implements {@link DynamoDbAsyncClientBuilder}, ensuring compatibility with
  * standard AWS SDK v2 patterns while adding Alternator-specific configuration via methods like
- * {@link AlternatorDynamoDbAsyncClientBuilder#withDatacenter(String)} and
- * {@link AlternatorDynamoDbAsyncClientBuilder#withRack(String)}.
+ * {@link AlternatorDynamoDbAsyncClientBuilder#withDatacenter(String)} and {@link
+ * AlternatorDynamoDbAsyncClientBuilder#withRack(String)}.
  *
  * <p>Example usage:
  *
@@ -58,8 +56,8 @@ import software.amazon.awssdk.utils.AttributeMap;
 public class AlternatorDynamoDbAsyncClient {
 
   /**
-   * Creates a new builder instance using the standard builder pattern, similar to
-   * {@link DynamoDbAsyncClient#builder()}.
+   * Creates a new builder instance using the standard builder pattern, similar to {@link
+   * DynamoDbAsyncClient#builder()}.
    *
    * @return a new {@link AlternatorDynamoDbAsyncClientBuilder} configured for Alternator load
    *     balancing
@@ -79,8 +77,8 @@ public class AlternatorDynamoDbAsyncClient {
    * datacenter/rack configuration, then creates an {@link AlternatorEndpointProvider} during the
    * {@link #build()} phase.
    *
-   * <p>Note: Some AWS-specific features are not supported by Alternator and will throw
-   * {@link UnsupportedOperationException}, including endpoint discovery, FIPS mode, and dual-stack
+   * <p>Note: Some AWS-specific features are not supported by Alternator and will throw {@link
+   * UnsupportedOperationException}, including endpoint discovery, FIPS mode, and dual-stack
    * networking.
    */
   public static class AlternatorDynamoDbAsyncClientBuilder implements DynamoDbAsyncClientBuilder {
@@ -100,8 +98,8 @@ public class AlternatorDynamoDbAsyncClient {
     /**
      * Sets the target datacenter for load balancing.
      *
-     * <p>When specified, only nodes from this datacenter will be used for load balancing.
-     * If not set, all nodes will be used.
+     * <p>When specified, only nodes from this datacenter will be used for load balancing. If not
+     * set, all nodes will be used.
      *
      * @param datacenter the datacenter name
      * @return this builder instance
@@ -114,8 +112,8 @@ public class AlternatorDynamoDbAsyncClient {
     /**
      * Sets the target rack for load balancing.
      *
-     * <p>When specified along with a datacenter, only nodes from this rack will be used
-     * for load balancing.
+     * <p>When specified along with a datacenter, only nodes from this rack will be used for load
+     * balancing.
      *
      * @param rack the rack name
      * @return this builder instance
@@ -149,7 +147,8 @@ public class AlternatorDynamoDbAsyncClient {
      * @return this builder instance
      * @throws IllegalArgumentException if minCompressionSizeBytes is negative
      */
-    public AlternatorDynamoDbAsyncClientBuilder withMinCompressionSizeBytes(int minCompressionSizeBytes) {
+    public AlternatorDynamoDbAsyncClientBuilder withMinCompressionSizeBytes(
+        int minCompressionSizeBytes) {
       configBuilder.withMinCompressionSizeBytes(minCompressionSizeBytes);
       return this;
     }
@@ -157,8 +156,8 @@ public class AlternatorDynamoDbAsyncClient {
     /**
      * Enables or disables HTTP header optimization.
      *
-     * <p>When enabled, outgoing requests will have their HTTP headers filtered to include
-     * only those in the configured whitelist, reducing network traffic overhead.
+     * <p>When enabled, outgoing requests will have their HTTP headers filtered to include only
+     * those in the configured whitelist, reducing network traffic overhead.
      *
      * @param optimizeHeaders true to enable header filtering, false to disable
      * @return this builder instance
@@ -187,9 +186,9 @@ public class AlternatorDynamoDbAsyncClient {
      * certificates. Never use this in production as it makes connections vulnerable to
      * man-in-the-middle attacks.
      *
-     * <p>This method configures the HTTP client to trust all certificates. If you've already
-     * set a custom HTTP client via {@link #httpClient(SdkAsyncHttpClient)} or
-     * {@link #httpClientBuilder(SdkAsyncHttpClient.Builder)}, this method will have no effect.
+     * <p>This method configures the HTTP client to trust all certificates. If you've already set a
+     * custom HTTP client via {@link #httpClient(SdkAsyncHttpClient)} or {@link
+     * #httpClientBuilder(SdkAsyncHttpClient.Builder)}, this method will have no effect.
      *
      * @return this builder instance
      */
@@ -216,8 +215,8 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
-     * Sets the AWS credentials provider. This method matches
-     * {@link DynamoDbAsyncClientBuilder#credentialsProvider(AwsCredentialsProvider)}.
+     * Sets the AWS credentials provider. This method matches {@link
+     * DynamoDbAsyncClientBuilder#credentialsProvider(AwsCredentialsProvider)}.
      *
      * <p>The credentials are used for authentication with Alternator. Common providers include:
      *
@@ -228,8 +227,8 @@ public class AlternatorDynamoDbAsyncClient {
      *       environment-based credentials
      * </ul>
      *
-     * <p>If no credentials provider is set, the client will automatically use anonymous
-     * credentials and exclude authentication headers when header optimization is enabled.
+     * <p>If no credentials provider is set, the client will automatically use anonymous credentials
+     * and exclude authentication headers when header optimization is enabled.
      *
      * @param credentialsProvider the AWS credentials provider
      * @return this builder instance
@@ -271,8 +270,8 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
-     * Sets a custom async HTTP client. This method matches
-     * {@link DynamoDbAsyncClientBuilder#httpClient(SdkAsyncHttpClient)}.
+     * Sets a custom async HTTP client. This method matches {@link
+     * DynamoDbAsyncClientBuilder#httpClient(SdkAsyncHttpClient)}.
      *
      * <p>Use this to configure custom HTTP client settings such as connection pooling, timeouts, or
      * proxy settings. If not specified, the AWS SDK will create a default HTTP client.
@@ -288,8 +287,8 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
-     * Sets a custom async HTTP client builder. This method matches
-     * {@link DynamoDbAsyncClientBuilder#httpClientBuilder(SdkAsyncHttpClient.Builder)}.
+     * Sets a custom async HTTP client builder. This method matches {@link
+     * DynamoDbAsyncClientBuilder#httpClientBuilder(SdkAsyncHttpClient.Builder)}.
      *
      * <p>Use this to configure HTTP client settings using a builder pattern. This is an alternative
      * to {@link #httpClient(SdkAsyncHttpClient)} when you want to customize the HTTP client
@@ -317,8 +316,8 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
-     * Sets client override configuration. This method matches
-     * {@link DynamoDbAsyncClientBuilder#overrideConfiguration(ClientOverrideConfiguration)}.
+     * Sets client override configuration. This method matches {@link
+     * DynamoDbAsyncClientBuilder#overrideConfiguration(ClientOverrideConfiguration)}.
      *
      * <p>Use this to configure advanced client settings such as:
      *
@@ -340,8 +339,8 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
-     * Sets client override configuration using a builder consumer. This method matches
-     * {@link DynamoDbAsyncClientBuilder#overrideConfiguration(Consumer)}.
+     * Sets client override configuration using a builder consumer. This method matches {@link
+     * DynamoDbAsyncClientBuilder#overrideConfiguration(Consumer)}.
      *
      * <p>This is a convenience method that allows configuring the override settings inline without
      * creating a separate {@link ClientOverrideConfiguration} instance.
@@ -366,8 +365,8 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
-     * Sets async client configuration. This method matches
-     * {@link DynamoDbAsyncClientBuilder#asyncConfiguration(ClientAsyncConfiguration)}.
+     * Sets async client configuration. This method matches {@link
+     * DynamoDbAsyncClientBuilder#asyncConfiguration(ClientAsyncConfiguration)}.
      *
      * <p>Use this to configure async-specific settings such as the future completion executor.
      *
@@ -382,8 +381,8 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
-     * Sets async client configuration using a builder consumer. This method matches
-     * {@link DynamoDbAsyncClientBuilder#asyncConfiguration(Consumer)}.
+     * Sets async client configuration using a builder consumer. This method matches {@link
+     * DynamoDbAsyncClientBuilder#asyncConfiguration(Consumer)}.
      *
      * @param builderConsumer a consumer that configures the async configuration builder
      * @return this builder instance
@@ -398,8 +397,9 @@ public class AlternatorDynamoDbAsyncClient {
     /**
      * This method is not supported by AlternatorDynamoDbAsyncClient.
      *
-     * <p>The endpoint provider is automatically configured to use {@link AlternatorEndpointProvider}
-     * for load balancing. Use {@link #endpointOverride(URI)} to specify the seed endpoint instead.
+     * <p>The endpoint provider is automatically configured to use {@link
+     * AlternatorEndpointProvider} for load balancing. Use {@link #endpointOverride(URI)} to specify
+     * the seed endpoint instead.
      *
      * @param endpointProvider ignored
      * @return never returns
@@ -450,8 +450,8 @@ public class AlternatorDynamoDbAsyncClient {
     /**
      * This method is not supported by AlternatorDynamoDbAsyncClient.
      *
-     * <p>FIPS (Federal Information Processing Standards) mode is an AWS-specific feature that is not
-     * applicable to Alternator.
+     * <p>FIPS (Federal Information Processing Standards) mode is an AWS-specific feature that is
+     * not applicable to Alternator.
      *
      * @param fipsEnabled ignored
      * @return never returns
@@ -498,7 +498,8 @@ public class AlternatorDynamoDbAsyncClient {
      *   <li>Discover all nodes in the Alternator cluster via the {@code /localnodes} API
      *   <li>Distribute requests across discovered nodes using round-robin load balancing
      *   <li>Periodically refresh the node list (every 5 seconds) to handle topology changes
-     *   <li>Filter nodes by datacenter/rack if configured via {@link #withDatacenter} and {@link #withRack}
+     *   <li>Filter nodes by datacenter/rack if configured via {@link #withDatacenter} and {@link
+     *       #withRack}
      * </ul>
      *
      * <p>If you need access to Alternator-specific APIs (such as {@code getLiveNodes()} or {@code
@@ -523,8 +524,8 @@ public class AlternatorDynamoDbAsyncClient {
      * <ul>
      *   <li>{@link AlternatorDynamoDbAsyncClientWrapper#getLiveNodes()} - Get current live nodes
      *   <li>{@link AlternatorDynamoDbAsyncClientWrapper#nextAsURI()} - Get next node in round-robin
-     *   <li>{@link AlternatorDynamoDbAsyncClientWrapper#checkIfRackDatacenterFeatureIsSupported()} -
-     *       Check server capabilities
+     *   <li>{@link AlternatorDynamoDbAsyncClientWrapper#checkIfRackDatacenterFeatureIsSupported()}
+     *       - Check server capabilities
      *   <li>{@link AlternatorDynamoDbAsyncClientWrapper#getAlternatorEndpointProvider()} - Access
      *       the endpoint provider
      * </ul>
@@ -610,7 +611,8 @@ public class AlternatorDynamoDbAsyncClient {
 
       // Build the underlying client and wrap it with Alternator metadata
       DynamoDbAsyncClient client = delegate.build();
-      return new AlternatorDynamoDbAsyncClientWrapper(client, liveNodes, alternatorEndpointProvider);
+      return new AlternatorDynamoDbAsyncClientWrapper(
+          client, liveNodes, alternatorEndpointProvider);
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
@@ -87,7 +87,8 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
    * @return true if rack/datacenter filtering is supported, false otherwise
    * @throws AlternatorLiveNodes.FailedToCheck if the check cannot be completed
    */
-  public boolean checkIfRackDatacenterFeatureIsSupported() throws AlternatorLiveNodes.FailedToCheck {
+  public boolean checkIfRackDatacenterFeatureIsSupported()
+      throws AlternatorLiveNodes.FailedToCheck {
     return liveNodes.checkIfRackDatacenterFeatureIsSupported();
   }
 
@@ -111,9 +112,7 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
     return endpointProvider;
   }
 
-  /**
-   * Closes the underlying DynamoDbAsyncClient.
-   */
+  /** Closes the underlying DynamoDbAsyncClient. */
   @Override
   public void close() {
     client.close();

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -4,11 +4,9 @@ import com.scylladb.alternator.internal.AlternatorLiveNodes;
 import java.net.URI;
 import java.util.Collection;
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -27,9 +25,9 @@ import software.amazon.awssdk.utils.AttributeMap;
  * integrating {@link AlternatorEndpointProvider} for client-side load balancing.
  *
  * <p>The builder implements {@link DynamoDbClientBuilder}, ensuring compatibility with standard AWS
- * SDK v2 patterns while adding Alternator-specific configuration via methods like
- * {@link AlternatorDynamoDbClientBuilder#withDatacenter(String)} and
- * {@link AlternatorDynamoDbClientBuilder#withRack(String)}.
+ * SDK v2 patterns while adding Alternator-specific configuration via methods like {@link
+ * AlternatorDynamoDbClientBuilder#withDatacenter(String)} and {@link
+ * AlternatorDynamoDbClientBuilder#withRack(String)}.
  *
  * <p>Example usage:
  *
@@ -57,8 +55,8 @@ import software.amazon.awssdk.utils.AttributeMap;
 public class AlternatorDynamoDbClient {
 
   /**
-   * Creates a new builder instance using the standard builder pattern, similar to
-   * {@link DynamoDbClient#builder()}.
+   * Creates a new builder instance using the standard builder pattern, similar to {@link
+   * DynamoDbClient#builder()}.
    *
    * @return a new {@link AlternatorDynamoDbClientBuilder} configured for Alternator load balancing
    */
@@ -69,17 +67,17 @@ public class AlternatorDynamoDbClient {
   /**
    * Builder implementation for constructing DynamoDB clients with Alternator load balancing.
    *
-   * <p>This builder implements {@link DynamoDbClientBuilder} and delegates most configuration
-   * to the standard AWS SDK {@link DynamoDbClient} builder while automatically integrating
-   * {@link AlternatorEndpointProvider} for node discovery and load balancing.
+   * <p>This builder implements {@link DynamoDbClientBuilder} and delegates most configuration to
+   * the standard AWS SDK {@link DynamoDbClient} builder while automatically integrating {@link
+   * AlternatorEndpointProvider} for node discovery and load balancing.
    *
    * <p>The builder tracks the seed URI (via {@link #endpointOverride(URI)}) and optional
-   * datacenter/rack configuration, then creates an {@link AlternatorEndpointProvider} during
-   * the {@link #build()} phase.
+   * datacenter/rack configuration, then creates an {@link AlternatorEndpointProvider} during the
+   * {@link #build()} phase.
    *
-   * <p>Note: Some AWS-specific features are not supported by Alternator and will throw
-   * {@link UnsupportedOperationException}, including endpoint discovery, FIPS mode, and
-   * dual-stack networking.
+   * <p>Note: Some AWS-specific features are not supported by Alternator and will throw {@link
+   * UnsupportedOperationException}, including endpoint discovery, FIPS mode, and dual-stack
+   * networking.
    */
   public static class AlternatorDynamoDbClientBuilder implements DynamoDbClientBuilder {
     private final DynamoDbClientBuilder delegate;
@@ -98,8 +96,8 @@ public class AlternatorDynamoDbClient {
     /**
      * Sets the target datacenter for load balancing.
      *
-     * <p>When specified, only nodes from this datacenter will be used for load balancing.
-     * If not set, all nodes will be used.
+     * <p>When specified, only nodes from this datacenter will be used for load balancing. If not
+     * set, all nodes will be used.
      *
      * @param datacenter the datacenter name
      * @return this builder instance
@@ -112,8 +110,8 @@ public class AlternatorDynamoDbClient {
     /**
      * Sets the target rack for load balancing.
      *
-     * <p>When specified along with a datacenter, only nodes from this rack will be used
-     * for load balancing.
+     * <p>When specified along with a datacenter, only nodes from this rack will be used for load
+     * balancing.
      *
      * @param rack the rack name
      * @return this builder instance
@@ -147,7 +145,8 @@ public class AlternatorDynamoDbClient {
      * @return this builder instance
      * @throws IllegalArgumentException if minCompressionSizeBytes is negative
      */
-    public AlternatorDynamoDbClientBuilder withMinCompressionSizeBytes(int minCompressionSizeBytes) {
+    public AlternatorDynamoDbClientBuilder withMinCompressionSizeBytes(
+        int minCompressionSizeBytes) {
       configBuilder.withMinCompressionSizeBytes(minCompressionSizeBytes);
       return this;
     }
@@ -155,8 +154,8 @@ public class AlternatorDynamoDbClient {
     /**
      * Enables or disables HTTP header optimization.
      *
-     * <p>When enabled, outgoing requests will have their HTTP headers filtered to include
-     * only those in the configured whitelist, reducing network traffic overhead.
+     * <p>When enabled, outgoing requests will have their HTTP headers filtered to include only
+     * those in the configured whitelist, reducing network traffic overhead.
      *
      * @param optimizeHeaders true to enable header filtering, false to disable
      * @return this builder instance
@@ -185,9 +184,9 @@ public class AlternatorDynamoDbClient {
      * certificates. Never use this in production as it makes connections vulnerable to
      * man-in-the-middle attacks.
      *
-     * <p>This method configures the HTTP client to trust all certificates. If you've already
-     * set a custom HTTP client via {@link #httpClient(SdkHttpClient)} or
-     * {@link #httpClientBuilder(SdkHttpClient.Builder)}, this method will have no effect.
+     * <p>This method configures the HTTP client to trust all certificates. If you've already set a
+     * custom HTTP client via {@link #httpClient(SdkHttpClient)} or {@link
+     * #httpClientBuilder(SdkHttpClient.Builder)}, this method will have no effect.
      *
      * @return this builder instance
      */
@@ -200,8 +199,8 @@ public class AlternatorDynamoDbClient {
      * Sets the AWS region. This method matches {@link DynamoDbClientBuilder#region(Region)}.
      *
      * <p>Note: The region is not used by Alternator for routing (the endpoint provider handles
-     * that), but it is required by the AWS SDK and may appear in logs, traces, or metrics.
-     * If not specified, a default "fake-aws-region" will be used.
+     * that), but it is required by the AWS SDK and may appear in logs, traces, or metrics. If not
+     * specified, a default "fake-aws-region" will be used.
      *
      * @param region the AWS region
      * @return this builder instance
@@ -214,25 +213,27 @@ public class AlternatorDynamoDbClient {
     }
 
     /**
-     * Sets the AWS credentials provider. This method matches
-     * {@link DynamoDbClientBuilder#credentialsProvider(AwsCredentialsProvider)}.
+     * Sets the AWS credentials provider. This method matches {@link
+     * DynamoDbClientBuilder#credentialsProvider(AwsCredentialsProvider)}.
      *
      * <p>The credentials are used for authentication with Alternator. Common providers include:
+     *
      * <ul>
-     *   <li>{@link software.amazon.awssdk.auth.credentials.StaticCredentialsProvider} for
-     *       hardcoded credentials</li>
+     *   <li>{@link software.amazon.awssdk.auth.credentials.StaticCredentialsProvider} for hardcoded
+     *       credentials
      *   <li>{@link software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider} for
-     *       environment-based credentials</li>
+     *       environment-based credentials
      * </ul>
      *
-     * <p>If no credentials provider is set, the client will automatically use anonymous
-     * credentials and exclude authentication headers when header optimization is enabled.
+     * <p>If no credentials provider is set, the client will automatically use anonymous credentials
+     * and exclude authentication headers when header optimization is enabled.
      *
      * @param credentialsProvider the AWS credentials provider
      * @return this builder instance
      */
     @Override
-    public AlternatorDynamoDbClientBuilder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+    public AlternatorDynamoDbClientBuilder credentialsProvider(
+        AwsCredentialsProvider credentialsProvider) {
       if (credentialsProvider != null) {
         this.credentialsProviderSet = true;
         configBuilder.authenticationEnabled(true);
@@ -244,14 +245,15 @@ public class AlternatorDynamoDbClient {
     /**
      * Sets the endpoint override (seed URI) for Alternator cluster discovery.
      *
-     * <p>This is the initial Alternator node that will be contacted to discover all other nodes
-     * in the cluster via the {@code /localnodes} API. Once the cluster topology is discovered,
+     * <p>This is the initial Alternator node that will be contacted to discover all other nodes in
+     * the cluster via the {@code /localnodes} API. Once the cluster topology is discovered,
      * requests will be distributed across all discovered nodes using round-robin load balancing.
      *
      * <p>The endpoint should be a complete URI including protocol and port, for example:
+     *
      * <ul>
-     *   <li>{@code https://localhost:8043} for HTTPS</li>
-     *   <li>{@code http://192.168.1.100:8000} for HTTP</li>
+     *   <li>{@code https://localhost:8043} for HTTPS
+     *   <li>{@code http://192.168.1.100:8000} for HTTP
      * </ul>
      *
      * <p>This method is required - the build will fail if no endpoint is specified.
@@ -266,12 +268,11 @@ public class AlternatorDynamoDbClient {
     }
 
     /**
-     * Sets a custom HTTP client. This method matches
-     * {@link DynamoDbClientBuilder#httpClient(SdkHttpClient)}.
+     * Sets a custom HTTP client. This method matches {@link
+     * DynamoDbClientBuilder#httpClient(SdkHttpClient)}.
      *
-     * <p>Use this to configure custom HTTP client settings such as connection pooling,
-     * timeouts, or proxy settings. If not specified, the AWS SDK will create a default
-     * HTTP client.
+     * <p>Use this to configure custom HTTP client settings such as connection pooling, timeouts, or
+     * proxy settings. If not specified, the AWS SDK will create a default HTTP client.
      *
      * @param httpClient the HTTP client to use
      * @return this builder instance
@@ -284,18 +285,19 @@ public class AlternatorDynamoDbClient {
     }
 
     /**
-     * Sets a custom HTTP client builder. This method matches
-     * {@link DynamoDbClientBuilder#httpClientBuilder(SdkHttpClient.Builder)}.
+     * Sets a custom HTTP client builder. This method matches {@link
+     * DynamoDbClientBuilder#httpClientBuilder(SdkHttpClient.Builder)}.
      *
-     * <p>Use this to configure HTTP client settings using a builder pattern. This is
-     * an alternative to {@link #httpClient(SdkHttpClient)} when you want to customize
-     * the HTTP client configuration without creating the client instance directly.
+     * <p>Use this to configure HTTP client settings using a builder pattern. This is an alternative
+     * to {@link #httpClient(SdkHttpClient)} when you want to customize the HTTP client
+     * configuration without creating the client instance directly.
      *
      * @param httpClientBuilder the HTTP client builder to use
      * @return this builder instance
      */
     @Override
-    public AlternatorDynamoDbClientBuilder httpClientBuilder(SdkHttpClient.Builder httpClientBuilder) {
+    public AlternatorDynamoDbClientBuilder httpClientBuilder(
+        SdkHttpClient.Builder httpClientBuilder) {
       this.httpClientSet = true;
       delegate.httpClientBuilder(httpClientBuilder);
       return this;
@@ -312,34 +314,37 @@ public class AlternatorDynamoDbClient {
     }
 
     /**
-     * Sets client override configuration. This method matches
-     * {@link DynamoDbClientBuilder#overrideConfiguration(ClientOverrideConfiguration)}.
+     * Sets client override configuration. This method matches {@link
+     * DynamoDbClientBuilder#overrideConfiguration(ClientOverrideConfiguration)}.
      *
      * <p>Use this to configure advanced client settings such as:
+     *
      * <ul>
-     *   <li>Retry policies</li>
-     *   <li>Request timeout settings</li>
-     *   <li>Additional request headers</li>
-     *   <li>Metric publishers</li>
+     *   <li>Retry policies
+     *   <li>Request timeout settings
+     *   <li>Additional request headers
+     *   <li>Metric publishers
      * </ul>
      *
      * @param overrideConfiguration the client override configuration
      * @return this builder instance
      */
     @Override
-    public AlternatorDynamoDbClientBuilder overrideConfiguration(ClientOverrideConfiguration overrideConfiguration) {
+    public AlternatorDynamoDbClientBuilder overrideConfiguration(
+        ClientOverrideConfiguration overrideConfiguration) {
       delegate.overrideConfiguration(overrideConfiguration);
       return this;
     }
 
     /**
-     * Sets client override configuration using a builder consumer. This method matches
-     * {@link DynamoDbClientBuilder#overrideConfiguration(Consumer)}.
+     * Sets client override configuration using a builder consumer. This method matches {@link
+     * DynamoDbClientBuilder#overrideConfiguration(Consumer)}.
      *
-     * <p>This is a convenience method that allows configuring the override settings
-     * inline without creating a separate {@link ClientOverrideConfiguration} instance.
+     * <p>This is a convenience method that allows configuring the override settings inline without
+     * creating a separate {@link ClientOverrideConfiguration} instance.
      *
      * <p>Example:
+     *
      * <pre>{@code
      * builder.overrideConfiguration(c -> c
      *     .apiCallTimeout(Duration.ofSeconds(10))
@@ -351,7 +356,8 @@ public class AlternatorDynamoDbClient {
      * @return this builder instance
      */
     @Override
-    public AlternatorDynamoDbClientBuilder overrideConfiguration(Consumer<ClientOverrideConfiguration.Builder> builderConsumer) {
+    public AlternatorDynamoDbClientBuilder overrideConfiguration(
+        Consumer<ClientOverrideConfiguration.Builder> builderConsumer) {
       delegate.overrideConfiguration(builderConsumer);
       return this;
     }
@@ -359,43 +365,45 @@ public class AlternatorDynamoDbClient {
     /**
      * This method is not supported by AlternatorDynamoDbClient.
      *
-     * <p>The endpoint provider is automatically configured to use
-     * {@link AlternatorEndpointProvider} for load balancing. Use
-     * {@link #endpointOverride(URI)} to specify the seed endpoint instead.
+     * <p>The endpoint provider is automatically configured to use {@link
+     * AlternatorEndpointProvider} for load balancing. Use {@link #endpointOverride(URI)} to specify
+     * the seed endpoint instead.
      *
      * @param endpointProvider ignored
      * @return never returns
      * @throws UnsupportedOperationException always thrown
      */
     @Override
-    public AlternatorDynamoDbClientBuilder endpointProvider(DynamoDbEndpointProvider endpointProvider) {
+    public AlternatorDynamoDbClientBuilder endpointProvider(
+        DynamoDbEndpointProvider endpointProvider) {
       throw new UnsupportedOperationException(
           "AlternatorDynamoDbClient does not support custom endpoint providers. "
-          + "Use endpointOverride(URI) to specify the seed endpoint instead.");
+              + "Use endpointOverride(URI) to specify the seed endpoint instead.");
     }
 
     /**
      * This method is not supported by AlternatorDynamoDbClient.
      *
-     * <p>Alternator uses its own node discovery mechanism via the {@code /localnodes} API,
-     * which is incompatible with AWS endpoint discovery.
+     * <p>Alternator uses its own node discovery mechanism via the {@code /localnodes} API, which is
+     * incompatible with AWS endpoint discovery.
      *
      * @param endpointDiscoveryEnabled ignored
      * @return never returns
      * @throws UnsupportedOperationException always thrown
      */
     @Override
-    public AlternatorDynamoDbClientBuilder endpointDiscoveryEnabled(boolean endpointDiscoveryEnabled) {
+    public AlternatorDynamoDbClientBuilder endpointDiscoveryEnabled(
+        boolean endpointDiscoveryEnabled) {
       throw new UnsupportedOperationException(
           "AlternatorDynamoDbClient does not support AWS endpoint discovery. "
-          + "Node discovery is handled automatically via the /localnodes API.");
+              + "Node discovery is handled automatically via the /localnodes API.");
     }
 
     /**
      * This method is not supported by AlternatorDynamoDbClient.
      *
-     * <p>Alternator uses its own node discovery mechanism via the {@code /localnodes} API,
-     * which is incompatible with AWS endpoint discovery.
+     * <p>Alternator uses its own node discovery mechanism via the {@code /localnodes} API, which is
+     * incompatible with AWS endpoint discovery.
      *
      * @return never returns
      * @throws UnsupportedOperationException always thrown
@@ -404,14 +412,14 @@ public class AlternatorDynamoDbClient {
     public AlternatorDynamoDbClientBuilder enableEndpointDiscovery() {
       throw new UnsupportedOperationException(
           "AlternatorDynamoDbClient does not support AWS endpoint discovery. "
-          + "Node discovery is handled automatically via the /localnodes API.");
+              + "Node discovery is handled automatically via the /localnodes API.");
     }
 
     /**
      * This method is not supported by AlternatorDynamoDbClient.
      *
-     * <p>FIPS (Federal Information Processing Standards) mode is an AWS-specific feature
-     * that is not applicable to Alternator.
+     * <p>FIPS (Federal Information Processing Standards) mode is an AWS-specific feature that is
+     * not applicable to Alternator.
      *
      * @param fipsEnabled ignored
      * @return never returns
@@ -426,8 +434,8 @@ public class AlternatorDynamoDbClient {
     /**
      * This method is not supported by AlternatorDynamoDbClient.
      *
-     * <p>Dual-stack networking (IPv4/IPv6) is an AWS-specific feature that is not
-     * applicable to Alternator.
+     * <p>Dual-stack networking (IPv4/IPv6) is an AWS-specific feature that is not applicable to
+     * Alternator.
      *
      * @param dualstackEnabled ignored
      * @return never returns
@@ -458,7 +466,8 @@ public class AlternatorDynamoDbClient {
      *   <li>Discover all nodes in the Alternator cluster via the {@code /localnodes} API
      *   <li>Distribute requests across discovered nodes using round-robin load balancing
      *   <li>Periodically refresh the node list (every 5 seconds) to handle topology changes
-     *   <li>Filter nodes by datacenter/rack if configured via {@link #withDatacenter} and {@link #withRack}
+     *   <li>Filter nodes by datacenter/rack if configured via {@link #withDatacenter} and {@link
+     *       #withRack}
      * </ul>
      *
      * <p>If you need access to Alternator-specific APIs (such as {@code getLiveNodes()} or {@code

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapper.java
@@ -87,7 +87,8 @@ public class AlternatorDynamoDbClientWrapper implements AutoCloseable {
    * @return true if rack/datacenter filtering is supported, false otherwise
    * @throws AlternatorLiveNodes.FailedToCheck if the check cannot be completed
    */
-  public boolean checkIfRackDatacenterFeatureIsSupported() throws AlternatorLiveNodes.FailedToCheck {
+  public boolean checkIfRackDatacenterFeatureIsSupported()
+      throws AlternatorLiveNodes.FailedToCheck {
     return liveNodes.checkIfRackDatacenterFeatureIsSupported();
   }
 
@@ -111,9 +112,7 @@ public class AlternatorDynamoDbClientWrapper implements AutoCloseable {
     return endpointProvider;
   }
 
-  /**
-   * Closes the underlying DynamoDbClient.
-   */
+  /** Closes the underlying DynamoDbClient. */
   @Override
   public void close() {
     client.close();

--- a/src/main/java/com/scylladb/alternator/internal/LazyQueryPlan.java
+++ b/src/main/java/com/scylladb/alternator/internal/LazyQueryPlan.java
@@ -12,6 +12,7 @@ import java.util.*;
  * (for reproducible sequences) or generated randomly (for non-deterministic behavior).
  *
  * <p>Example usage:
+ *
  * <pre>{@code
  * List<URI> activeNodes = Arrays.asList(uri1, uri2, uri3);
  * List<URI> quarantinedNodes = Arrays.asList(uri4, uri5);
@@ -121,8 +122,8 @@ public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
   }
 
   /**
-   * Returns an iterator over the nodes in this query plan. Note that this returns the same
-   * instance (after resetting), so only one iteration can be active at a time.
+   * Returns an iterator over the nodes in this query plan. Note that this returns the same instance
+   * (after resetting), so only one iteration can be active at a time.
    *
    * @return this query plan as an iterator, reset to the beginning
    */
@@ -133,8 +134,8 @@ public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
   }
 
   /**
-   * Returns a copy of all nodes in this query plan in their shuffled order. This is useful when
-   * you need to examine the full sequence without consuming the iterator.
+   * Returns a copy of all nodes in this query plan in their shuffled order. This is useful when you
+   * need to examine the full sequence without consuming the iterator.
    *
    * @return an unmodifiable list of all nodes in shuffled order (active nodes first, then
    *     quarantined)

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
@@ -62,8 +62,7 @@ public class AlternatorConfigCompressionTest {
 
   @Test
   public void testNullCompressionAlgorithmDefaultsToNone() {
-    AlternatorConfig config =
-        AlternatorConfig.builder().withCompressionAlgorithm(null).build();
+    AlternatorConfig config = AlternatorConfig.builder().withCompressionAlgorithm(null).build();
 
     assertEquals(RequestCompressionAlgorithm.NONE, config.getCompressionAlgorithm());
     assertFalse(config.getCompressionAlgorithm().isEnabled());

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
@@ -169,8 +169,7 @@ public class AlternatorConfigHeadersTest {
 
   @Test
   public void testAuthenticationDisabled() {
-    AlternatorConfig config =
-        AlternatorConfig.builder().authenticationEnabled(false).build();
+    AlternatorConfig config = AlternatorConfig.builder().authenticationEnabled(false).build();
 
     assertFalse(config.isAuthenticationEnabled());
   }
@@ -178,10 +177,7 @@ public class AlternatorConfigHeadersTest {
   @Test
   public void testAuthenticationDisabledUsesNoAuthWhitelist() {
     AlternatorConfig config =
-        AlternatorConfig.builder()
-            .authenticationEnabled(false)
-            .withOptimizeHeaders(true)
-            .build();
+        AlternatorConfig.builder().authenticationEnabled(false).withOptimizeHeaders(true).build();
 
     Set<String> whitelist = config.getHeadersWhitelist();
 

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
@@ -505,7 +505,8 @@ public class AlternatorDynamoDbClientIT {
     }
 
     // Custom whitelist headers should be present
-    assertTrue("User-Agent should be present (custom whitelist)", seenHeaders.contains("User-Agent"));
+    assertTrue(
+        "User-Agent should be present (custom whitelist)", seenHeaders.contains("User-Agent"));
     assertTrue("Host header should be present", seenHeaders.contains("Host"));
 
     // Headers not in custom whitelist should be filtered
@@ -615,7 +616,9 @@ public class AlternatorDynamoDbClientIT {
     }
 
     // Verify both features work together
-    assertTrue("Content-Encoding should be present for compression", seenHeaders.contains("Content-Encoding"));
+    assertTrue(
+        "Content-Encoding should be present for compression",
+        seenHeaders.contains("Content-Encoding"));
     assertTrue("Compression should have been applied", compressionHeaderSeen.get());
 
     // Note: Header filtering happens at HTTP client level (after SDK interceptors run).

--- a/src/test/java/com/scylladb/alternator/AlternatorLiveNodesTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorLiveNodesTest.java
@@ -25,10 +25,11 @@ public class AlternatorLiveNodesTest {
 
   @Test
   public void testConstructorWithMultipleNodes() throws URISyntaxException {
-    List<URI> nodes = Arrays.asList(
-        new URI("http://node1.example.com:8000"),
-        new URI("http://node2.example.com:8000"),
-        new URI("http://node3.example.com:8000"));
+    List<URI> nodes =
+        Arrays.asList(
+            new URI("http://node1.example.com:8000"),
+            new URI("http://node2.example.com:8000"),
+            new URI("http://node3.example.com:8000"));
     AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(nodes, "http", 8000, "", "");
     assertNotNull(liveNodes);
   }
@@ -45,10 +46,11 @@ public class AlternatorLiveNodesTest {
 
   @Test
   public void testNextAsURIRoundRobin() throws URISyntaxException {
-    List<URI> nodes = Arrays.asList(
-        new URI("http://node1.example.com:8000"),
-        new URI("http://node2.example.com:8000"),
-        new URI("http://node3.example.com:8000"));
+    List<URI> nodes =
+        Arrays.asList(
+            new URI("http://node1.example.com:8000"),
+            new URI("http://node2.example.com:8000"),
+            new URI("http://node3.example.com:8000"));
     AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(nodes, "http", 8000, "", "");
 
     Set<URI> returnedNodes = new HashSet<>();
@@ -74,9 +76,9 @@ public class AlternatorLiveNodesTest {
 
   @Test
   public void testGetLiveNodes() throws URISyntaxException {
-    List<URI> nodes = Arrays.asList(
-        new URI("http://node1.example.com:8000"),
-        new URI("http://node2.example.com:8000"));
+    List<URI> nodes =
+        Arrays.asList(
+            new URI("http://node1.example.com:8000"), new URI("http://node2.example.com:8000"));
     AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(nodes, "http", 8000, "", "");
 
     List<URI> result = liveNodes.getLiveNodes();
@@ -102,10 +104,11 @@ public class AlternatorLiveNodesTest {
 
   @Test
   public void testNewQueryPlan() throws URISyntaxException {
-    List<URI> nodes = Arrays.asList(
-        new URI("http://node1.example.com:8000"),
-        new URI("http://node2.example.com:8000"),
-        new URI("http://node3.example.com:8000"));
+    List<URI> nodes =
+        Arrays.asList(
+            new URI("http://node1.example.com:8000"),
+            new URI("http://node2.example.com:8000"),
+            new URI("http://node3.example.com:8000"));
     AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(nodes, "http", 8000, "", "");
 
     LazyQueryPlan plan = liveNodes.newQueryPlan();
@@ -123,10 +126,11 @@ public class AlternatorLiveNodesTest {
 
   @Test
   public void testNewQueryPlanWithSeed() throws URISyntaxException {
-    List<URI> nodes = Arrays.asList(
-        new URI("http://node1.example.com:8000"),
-        new URI("http://node2.example.com:8000"),
-        new URI("http://node3.example.com:8000"));
+    List<URI> nodes =
+        Arrays.asList(
+            new URI("http://node1.example.com:8000"),
+            new URI("http://node2.example.com:8000"),
+            new URI("http://node3.example.com:8000"));
     AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(nodes, "http", 8000, "", "");
 
     long seed = 42L;
@@ -148,14 +152,15 @@ public class AlternatorLiveNodesTest {
 
   @Test
   public void testNewQueryPlanWithQuarantinedNodes() throws URISyntaxException {
-    List<URI> nodes = Arrays.asList(
-        new URI("http://node1.example.com:8000"),
-        new URI("http://node2.example.com:8000"));
+    List<URI> nodes =
+        Arrays.asList(
+            new URI("http://node1.example.com:8000"), new URI("http://node2.example.com:8000"));
     AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(nodes, "http", 8000, "", "");
 
-    List<URI> quarantined = Arrays.asList(
-        new URI("http://quarantined1.example.com:8000"),
-        new URI("http://quarantined2.example.com:8000"));
+    List<URI> quarantined =
+        Arrays.asList(
+            new URI("http://quarantined1.example.com:8000"),
+            new URI("http://quarantined2.example.com:8000"));
 
     LazyQueryPlan plan = liveNodes.newQueryPlan(quarantined);
 

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClientTest.java
@@ -170,8 +170,7 @@ public class HeadersFilteringSdkAsyncHttpClientTest {
   @Test
   public void testFiltersAllSdkMetadataHeaders() {
     // Use the default required headers whitelist
-    AlternatorConfig config =
-        AlternatorConfig.builder().authenticationEnabled(true).build();
+    AlternatorConfig config = AlternatorConfig.builder().authenticationEnabled(true).build();
     Set<String> whitelist = config.getRequiredHeaders();
 
     MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
@@ -437,10 +436,7 @@ public class HeadersFilteringSdkAsyncHttpClientTest {
 
     MockResponseHandler handler = new MockResponseHandler();
     AsyncExecuteRequest executeRequest =
-        AsyncExecuteRequest.builder()
-            .request(originalRequest)
-            .responseHandler(handler)
-            .build();
+        AsyncExecuteRequest.builder().request(originalRequest).responseHandler(handler).build();
 
     filteringClient.execute(executeRequest);
 

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
@@ -170,8 +170,7 @@ public class HeadersFilteringSdkHttpClientTest {
   @Test
   public void testFiltersAllSdkMetadataHeaders() {
     // Use the default required headers whitelist
-    AlternatorConfig config =
-        AlternatorConfig.builder().authenticationEnabled(true).build();
+    AlternatorConfig config = AlternatorConfig.builder().authenticationEnabled(true).build();
     Set<String> whitelist = config.getRequiredHeaders();
 
     MockSdkHttpClient mockClient = new MockSdkHttpClient();

--- a/src/test/java/com/scylladb/alternator/LazyQueryPlanTest.java
+++ b/src/test/java/com/scylladb/alternator/LazyQueryPlanTest.java
@@ -255,7 +255,8 @@ public class LazyQueryPlanTest {
   private List<URI> createUriList(String prefix, int count) throws URISyntaxException {
     List<URI> uris = new ArrayList<>();
     for (int i = 1; i <= count; i++) {
-      uris.add(new URI("http", null, prefix + "-node" + i + ".example.com", 8000, null, null, null));
+      uris.add(
+          new URI("http", null, prefix + "-node" + i + ".example.com", 8000, null, null, null));
     }
     return uris;
   }

--- a/src/test/java/com/scylladb/alternator/test/Demo3.java
+++ b/src/test/java/com/scylladb/alternator/test/Demo3.java
@@ -104,9 +104,7 @@ public class Demo3 {
 
     // Build the async client using AlternatorDynamoDbAsyncClient
     AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder b =
-        AlternatorDynamoDbAsyncClient.builder()
-            .region(region)
-            .asyncConfiguration(cas);
+        AlternatorDynamoDbAsyncClient.builder().region(region).asyncConfiguration(cas);
 
     // Set datacenter and rack if specified
     if (datacenter != null && !datacenter.isEmpty()) {

--- a/src/test/java/com/scylladb/alternator/test/LazyQueryPlanDemo.java
+++ b/src/test/java/com/scylladb/alternator/test/LazyQueryPlanDemo.java
@@ -130,8 +130,8 @@ public class LazyQueryPlanDemo {
       LazyQueryPlan nullActive = new LazyQueryPlan(null, quarantinedNodes);
       System.out.println("ERROR: Should have thrown IllegalArgumentException");
     } catch (IllegalArgumentException e) {
-      System.out.println("Correctly threw IllegalArgumentException for null activeNodes: "
-          + e.getMessage());
+      System.out.println(
+          "Correctly threw IllegalArgumentException for null activeNodes: " + e.getMessage());
     }
 
     try {
@@ -139,7 +139,8 @@ public class LazyQueryPlanDemo {
       exhausted.next();
       System.out.println("ERROR: Should have thrown NoSuchElementException");
     } catch (NoSuchElementException e) {
-      System.out.println("Correctly threw NoSuchElementException when exhausted: " + e.getMessage());
+      System.out.println(
+          "Correctly threw NoSuchElementException when exhausted: " + e.getMessage());
     }
     System.out.println();
 
@@ -170,7 +171,8 @@ public class LazyQueryPlanDemo {
   private static List<URI> createUriList(String prefix, int count) throws URISyntaxException {
     List<URI> uris = new ArrayList<>();
     for (int i = 1; i <= count; i++) {
-      uris.add(new URI("http", null, prefix + "-node" + i + ".example.com", 8000, null, null, null));
+      uris.add(
+          new URI("http", null, prefix + "-node" + i + ".example.com", 8000, null, null, null));
     }
     return uris;
   }


### PR DESCRIPTION
## Summary

- Add `make lint` target that checks code formatting using google-java-format via fmt-maven-plugin
- Add `make lint-fix` target to fix code formatting and javadocs
- Update fmt-maven-plugin to spotify fork (actively maintained with Java 17+ support)
- Add lint job to CI workflow that runs on all PRs and pushes to main
- Apply formatting fixes to existing source files to pass the new lint check

## Test plan

- [x] Verify `make lint` passes locally
- [x] Verify `make compile compile-test` still works after formatting changes
- [x] Verify CI lint job passes