### PR TITLE
Move demo apps to separate integration-test directory

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -139,3 +139,45 @@ jobs:
 
       - name: Run integration tests
         run: make test-integration
+
+  demo-test:
+    name: Demo Apps
+    runs-on: ubuntu-latest
+    needs: [integration-test]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+
+      - name: Cache Docker image
+        id: docker-cache
+        uses: actions/cache@v5
+        with:
+          path: .docker-cache
+          key: scylla-docker-${{ hashFiles('test/docker-compose.yml') }}
+
+      - name: Save Docker image to cache
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: make docker-cache-save
+
+      - name: Cache certificates
+        id: cert-cache
+        uses: actions/cache@v5
+        with:
+          path: .cert-cache
+          key: scylla-certs-${{ hashFiles('Makefile') }}
+
+      - name: Save certificates to cache
+        if: steps.cert-cache.outputs.cache-hit != 'true'
+        run: make cert-cache-save
+
+      - name: Compile demo apps
+        run: make compile-demo
+
+      - name: Run demo apps
+        run: make test-demo

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,25 @@
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>2.17.1</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/integration-test/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/integration-test/java/com/scylladb/alternator/demo/Demo2.java
+++ b/src/integration-test/java/com/scylladb/alternator/demo/Demo2.java
@@ -1,4 +1,4 @@
-package com.scylladb.alternator.test;
+package com.scylladb.alternator.demo;
 
 import com.scylladb.alternator.AlternatorDynamoDbClient;
 import java.net.URI;

--- a/src/integration-test/java/com/scylladb/alternator/demo/Demo3.java
+++ b/src/integration-test/java/com/scylladb/alternator/demo/Demo3.java
@@ -1,4 +1,4 @@
-package com.scylladb.alternator.test;
+package com.scylladb.alternator.demo;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
 

--- a/src/integration-test/java/com/scylladb/alternator/demo/Demo4.java
+++ b/src/integration-test/java/com/scylladb/alternator/demo/Demo4.java
@@ -1,4 +1,4 @@
-package com.scylladb.alternator.test;
+package com.scylladb.alternator.demo;
 
 import com.scylladb.alternator.AlternatorDynamoDbClient;
 import java.net.URI;

--- a/src/integration-test/java/com/scylladb/alternator/demo/Demo5.java
+++ b/src/integration-test/java/com/scylladb/alternator/demo/Demo5.java
@@ -1,4 +1,4 @@
-package com.scylladb.alternator.test;
+package com.scylladb.alternator.demo;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
 

--- a/src/integration-test/java/com/scylladb/alternator/demo/LazyQueryPlanDemo.java
+++ b/src/integration-test/java/com/scylladb/alternator/demo/LazyQueryPlanDemo.java
@@ -1,4 +1,4 @@
-package com.scylladb.alternator.test;
+package com.scylladb.alternator.demo;
 
 import com.scylladb.alternator.internal.LazyQueryPlan;
 import java.net.URI;


### PR DESCRIPTION
## Summary

- Move demo applications from `src/test/java/com/scylladb/alternator/test/` to `src/integration-test/java/com/scylladb/alternator/demo/`
- Add `compile-demo` and `test-demo` Makefile targets
- Add separate CI job for running demo apps after integration tests

## Changes

- **pom.xml**: Added `build-helper-maven-plugin` to include `src/integration-test/java` as additional test source
- **Makefile**: Added `compile-demo` and `test-demo` targets; `test-integration` now only runs IT tests
- **CI workflow**: Added new `demo-test` job that runs after integration tests

## Test plan

- [x] Verify `make compile-demo` compiles demo apps
- [x] Verify `make test-demo` runs demo apps against Scylla cluster
- [x] Verify `make test-integration` runs only IT tests (no demos)
- [x] Verify CI pipeline passes with separate demo job