### PR TITLE
Add RoutingScope with fallback support

### DIFF
--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -1,6 +1,7 @@
 package com.scylladb.alternator;
 
 import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.routing.RoutingScope;
 import java.net.URI;
 import java.util.Collection;
 import java.util.function.Consumer;
@@ -25,9 +26,8 @@ import software.amazon.awssdk.utils.AttributeMap;
  * integrating {@link AlternatorEndpointProvider} for client-side load balancing.
  *
  * <p>The builder implements {@link DynamoDbClientBuilder}, ensuring compatibility with standard AWS
- * SDK v2 patterns while adding Alternator-specific configuration via methods like {@link
- * AlternatorDynamoDbClientBuilder#withDatacenter(String)} and {@link
- * AlternatorDynamoDbClientBuilder#withRack(String)}.
+ * SDK v2 patterns while adding Alternator-specific configuration via {@link
+ * AlternatorDynamoDbClientBuilder#withRoutingScope}.
  *
  * <p>Example usage:
  *
@@ -94,30 +94,30 @@ public class AlternatorDynamoDbClient {
     }
 
     /**
-     * Sets the target datacenter for load balancing.
+     * Sets the routing scope for node targeting with fallback support.
      *
-     * <p>When specified, only nodes from this datacenter will be used for load balancing. If not
-     * set, all nodes will be used.
+     * <p>The routing scope defines which nodes should be used for load balancing and provides
+     * hierarchical fallback capabilities. Common usage patterns:
      *
-     * @param datacenter the datacenter name
+     * <pre>{@code
+     * // Target rack with fallback to datacenter and cluster
+     * builder.withRoutingScope(RackScope.of("dc1", "rack1",
+     *     DatacenterScope.of("dc1",
+     *         ClusterScope.create())));
+     *
+     * // Target datacenter with fallback to cluster
+     * builder.withRoutingScope(DatacenterScope.of("dc1", ClusterScope.create()));
+     *
+     * // Strict datacenter targeting (no fallback)
+     * builder.withRoutingScope(DatacenterScope.of("dc1", null));
+     * }</pre>
+     *
+     * @param routingScope the routing scope, or {@code null} to use all nodes
      * @return this builder instance
+     * @since 1.0.5
      */
-    public AlternatorDynamoDbClientBuilder withDatacenter(String datacenter) {
-      configBuilder.withDatacenter(datacenter);
-      return this;
-    }
-
-    /**
-     * Sets the target rack for load balancing.
-     *
-     * <p>When specified along with a datacenter, only nodes from this rack will be used for load
-     * balancing.
-     *
-     * @param rack the rack name
-     * @return this builder instance
-     */
-    public AlternatorDynamoDbClientBuilder withRack(String rack) {
-      configBuilder.withRack(rack);
+    public AlternatorDynamoDbClientBuilder withRoutingScope(RoutingScope routingScope) {
+      configBuilder.withRoutingScope(routingScope);
       return this;
     }
 
@@ -455,7 +455,7 @@ public class AlternatorDynamoDbClient {
      * <ol>
      *   <li>Validates that {@link #endpointOverride(URI)} was called (required)
      *   <li>Initializes {@link AlternatorConfig} with default values if not configured
-     *   <li>Creates an {@link AlternatorEndpointProvider} with the seed URI and DC/rack settings
+     *   <li>Creates an {@link AlternatorEndpointProvider} with the seed URI and routing scope
      *   <li>Sets a default region ("fake-aws-region") if none was specified
      *   <li>Builds the underlying {@link DynamoDbClient} with all configurations applied
      * </ol>
@@ -466,8 +466,7 @@ public class AlternatorDynamoDbClient {
      *   <li>Discover all nodes in the Alternator cluster via the {@code /localnodes} API
      *   <li>Distribute requests across discovered nodes using round-robin load balancing
      *   <li>Periodically refresh the node list (every 5 seconds) to handle topology changes
-     *   <li>Filter nodes by datacenter/rack if configured via {@link #withDatacenter} and {@link
-     *       #withRack}
+     *   <li>Filter nodes by routing scope if configured via {@link #withRoutingScope}
      * </ul>
      *
      * <p>If you need access to Alternator-specific APIs (such as {@code getLiveNodes()} or {@code
@@ -515,6 +514,9 @@ public class AlternatorDynamoDbClient {
         delegate.credentialsProvider(AnonymousCredentialsProvider.create());
       }
 
+      // Set the seed node on the config
+      configBuilder.withSeedNode(seedUri);
+
       // Build the AlternatorConfig from the internal builder
       AlternatorConfig alternatorConfig = configBuilder.build();
 
@@ -560,9 +562,8 @@ public class AlternatorDynamoDbClient {
       }
 
       // Create AlternatorLiveNodes and start node discovery
-      AlternatorLiveNodes liveNodes =
-          AlternatorLiveNodes.pickSupportedDatacenterRack(
-              seedUri, alternatorConfig.getDatacenter(), alternatorConfig.getRack());
+      // Fallback is handled automatically at runtime based on the routing scope's fallback chain
+      AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(alternatorConfig);
       liveNodes.start();
 
       // Create AlternatorEndpointProvider with the live nodes

--- a/src/main/java/com/scylladb/alternator/routing/ClusterScope.java
+++ b/src/main/java/com/scylladb/alternator/routing/ClusterScope.java
@@ -1,0 +1,91 @@
+package com.scylladb.alternator.routing;
+
+/**
+ * A routing scope that targets all nodes in the Alternator cluster without filtering.
+ *
+ * <p>ClusterScope is the broadest scope and typically serves as the terminal fallback in a scope
+ * chain. It does not apply any datacenter or rack filtering to the node list.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Direct cluster-wide targeting
+ * RoutingScope scope = ClusterScope.create();
+ *
+ * // As a fallback in a scope chain
+ * RoutingScope scope = DatacenterScope.of("dc1", ClusterScope.create());
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @see RoutingScope
+ * @see DatacenterScope
+ * @see RackScope
+ * @since 1.0.5
+ */
+public final class ClusterScope implements RoutingScope {
+
+  private static final ClusterScope INSTANCE = new ClusterScope();
+
+  private ClusterScope() {}
+
+  /**
+   * Creates a new ClusterScope instance.
+   *
+   * <p>This method returns a singleton instance since ClusterScope has no configuration state.
+   *
+   * @return a ClusterScope instance
+   */
+  public static ClusterScope create() {
+    return INSTANCE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getName() {
+    return "Cluster";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getDescription() {
+    return "Cluster (all nodes)";
+  }
+
+  /**
+   * Returns {@code null} since ClusterScope is a terminal scope with no fallback.
+   *
+   * @return {@code null}
+   */
+  @Override
+  public RoutingScope getFallback() {
+    return null;
+  }
+
+  /**
+   * Returns an empty string since ClusterScope does not filter nodes.
+   *
+   * @return empty string
+   */
+  @Override
+  public String getLocalNodesQuery() {
+    return "";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return "ClusterScope{}";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof ClusterScope;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    return ClusterScope.class.hashCode();
+  }
+}

--- a/src/main/java/com/scylladb/alternator/routing/DatacenterScope.java
+++ b/src/main/java/com/scylladb/alternator/routing/DatacenterScope.java
@@ -1,0 +1,116 @@
+package com.scylladb.alternator.routing;
+
+/**
+ * A routing scope that targets nodes in a specific datacenter.
+ *
+ * <p>DatacenterScope filters the node list to include only nodes from the specified datacenter.
+ * When no nodes are available in the datacenter, requests can fall back to a broader scope.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Datacenter targeting with fallback to cluster
+ * RoutingScope scope = DatacenterScope.of("dc1", ClusterScope.create());
+ *
+ * // Strict datacenter targeting (no fallback)
+ * RoutingScope scope = DatacenterScope.of("dc1", null);
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @see RoutingScope
+ * @see ClusterScope
+ * @see RackScope
+ * @since 1.0.5
+ */
+public final class DatacenterScope implements RoutingScope {
+
+  private final String datacenter;
+  private final RoutingScope fallback;
+
+  private DatacenterScope(String datacenter, RoutingScope fallback) {
+    if (datacenter == null || datacenter.isEmpty()) {
+      throw new IllegalArgumentException("datacenter cannot be null or empty");
+    }
+    this.datacenter = datacenter;
+    this.fallback = fallback;
+  }
+
+  /**
+   * Creates a new DatacenterScope for the specified datacenter with an optional fallback.
+   *
+   * @param datacenter the datacenter name (must not be null or empty)
+   * @param fallback the fallback scope to use when no nodes are available in this datacenter, or
+   *     {@code null} for strict targeting
+   * @return a new DatacenterScope instance
+   * @throws IllegalArgumentException if datacenter is null or empty
+   */
+  public static DatacenterScope of(String datacenter, RoutingScope fallback) {
+    return new DatacenterScope(datacenter, fallback);
+  }
+
+  /**
+   * Returns the datacenter name this scope targets.
+   *
+   * @return the datacenter name
+   */
+  public String getDatacenter() {
+    return datacenter;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getName() {
+    return "Datacenter";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getDescription() {
+    return "Datacenter " + datacenter;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public RoutingScope getFallback() {
+    return fallback;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getLocalNodesQuery() {
+    return "dc=" + datacenter;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return "DatacenterScope{datacenter='" + datacenter + "', fallback=" + fallback + "}";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof DatacenterScope)) {
+      return false;
+    }
+    DatacenterScope other = (DatacenterScope) obj;
+    if (!datacenter.equals(other.datacenter)) {
+      return false;
+    }
+    if (fallback == null) {
+      return other.fallback == null;
+    }
+    return fallback.equals(other.fallback);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    int result = datacenter.hashCode();
+    result = 31 * result + (fallback != null ? fallback.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/com/scylladb/alternator/routing/RackScope.java
+++ b/src/main/java/com/scylladb/alternator/routing/RackScope.java
@@ -1,0 +1,149 @@
+package com.scylladb.alternator.routing;
+
+/**
+ * A routing scope that targets nodes in a specific rack within a datacenter.
+ *
+ * <p>RackScope is the most specific scope, filtering nodes to only those in a particular rack
+ * within a datacenter. When no nodes are available in the rack, requests can fall back to a broader
+ * scope such as DatacenterScope or ClusterScope.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Rack targeting with hierarchical fallback
+ * RoutingScope scope = RackScope.of("dc1", "rack1",
+ *     DatacenterScope.of("dc1",
+ *         ClusterScope.create()));
+ *
+ * // Rack targeting with fallback to another rack
+ * RoutingScope scope = RackScope.of("dc1", "rack1",
+ *     RackScope.of("dc1", "rack2",
+ *         DatacenterScope.of("dc1", ClusterScope.create())));
+ *
+ * // Strict rack targeting (no fallback)
+ * RoutingScope scope = RackScope.of("dc1", "rack1", null);
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @see RoutingScope
+ * @see ClusterScope
+ * @see DatacenterScope
+ * @since 1.0.5
+ */
+public final class RackScope implements RoutingScope {
+
+  private final String datacenter;
+  private final String rack;
+  private final RoutingScope fallback;
+
+  private RackScope(String datacenter, String rack, RoutingScope fallback) {
+    if (datacenter == null || datacenter.isEmpty()) {
+      throw new IllegalArgumentException("datacenter cannot be null or empty");
+    }
+    if (rack == null || rack.isEmpty()) {
+      throw new IllegalArgumentException("rack cannot be null or empty");
+    }
+    this.datacenter = datacenter;
+    this.rack = rack;
+    this.fallback = fallback;
+  }
+
+  /**
+   * Creates a new RackScope for the specified rack within a datacenter with an optional fallback.
+   *
+   * @param datacenter the datacenter name (must not be null or empty)
+   * @param rack the rack name (must not be null or empty)
+   * @param fallback the fallback scope to use when no nodes are available in this rack, or {@code
+   *     null} for strict targeting
+   * @return a new RackScope instance
+   * @throws IllegalArgumentException if datacenter or rack is null or empty
+   */
+  public static RackScope of(String datacenter, String rack, RoutingScope fallback) {
+    return new RackScope(datacenter, rack, fallback);
+  }
+
+  /**
+   * Returns the datacenter name containing this rack.
+   *
+   * @return the datacenter name
+   */
+  public String getDatacenter() {
+    return datacenter;
+  }
+
+  /**
+   * Returns the rack name this scope targets.
+   *
+   * @return the rack name
+   */
+  public String getRack() {
+    return rack;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getName() {
+    return "Rack";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getDescription() {
+    return "Rack " + rack + " in Datacenter " + datacenter;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public RoutingScope getFallback() {
+    return fallback;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getLocalNodesQuery() {
+    return "dc=" + datacenter + "&rack=" + rack;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return "RackScope{datacenter='"
+        + datacenter
+        + "', rack='"
+        + rack
+        + "', fallback="
+        + fallback
+        + "}";
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof RackScope)) {
+      return false;
+    }
+    RackScope other = (RackScope) obj;
+    if (!datacenter.equals(other.datacenter)) {
+      return false;
+    }
+    if (!rack.equals(other.rack)) {
+      return false;
+    }
+    if (fallback == null) {
+      return other.fallback == null;
+    }
+    return fallback.equals(other.fallback);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int hashCode() {
+    int result = datacenter.hashCode();
+    result = 31 * result + rack.hashCode();
+    result = 31 * result + (fallback != null ? fallback.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/com/scylladb/alternator/routing/RoutingScope.java
+++ b/src/main/java/com/scylladb/alternator/routing/RoutingScope.java
@@ -1,0 +1,93 @@
+package com.scylladb.alternator.routing;
+
+/**
+ * Defines a composable routing scope for targeting specific Alternator nodes. Routing scopes allow
+ * users to specify which nodes should be used for load balancing, with optional fallback chains for
+ * hierarchical targeting.
+ *
+ * <p>The scope system follows a hierarchical model where requests can be targeted at specific
+ * levels:
+ *
+ * <ul>
+ *   <li>{@link RackScope} - Target nodes in a specific rack within a datacenter
+ *   <li>{@link DatacenterScope} - Target nodes in a specific datacenter
+ *   <li>{@link ClusterScope} - Target all nodes in the cluster (no filtering)
+ * </ul>
+ *
+ * <p>Scopes can be chained with fallbacks, allowing automatic degradation when the preferred scope
+ * has no available nodes:
+ *
+ * <pre>{@code
+ * // Target rack1 in dc1, fall back to dc1, then to entire cluster
+ * RoutingScope scope = RackScope.of("dc1", "rack1",
+ *     DatacenterScope.of("dc1",
+ *         ClusterScope.create()));
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @see ClusterScope
+ * @see DatacenterScope
+ * @see RackScope
+ * @since 1.0.5
+ */
+public interface RoutingScope {
+
+  /**
+   * Returns the short name of this scope type.
+   *
+   * <p>Examples: "Cluster", "Datacenter", "Rack"
+   *
+   * @return the scope type name
+   */
+  String getName();
+
+  /**
+   * Returns a human-readable description of this scope.
+   *
+   * <p>This description includes the scope type and any configuration details, such as the
+   * datacenter or rack name. Used primarily for logging fallback transitions.
+   *
+   * <p>Examples:
+   *
+   * <ul>
+   *   <li>"Cluster (all nodes)"
+   *   <li>"Datacenter dc1"
+   *   <li>"Rack rack1 in Datacenter dc1"
+   * </ul>
+   *
+   * @return the scope description
+   */
+  String getDescription();
+
+  /**
+   * Returns the fallback scope to use when this scope has no available nodes.
+   *
+   * <p>The fallback chain allows automatic degradation from more specific to less specific scopes.
+   * For example, a rack scope might fall back to its datacenter scope, which might then fall back
+   * to the cluster scope.
+   *
+   * <p>Returning {@code null} indicates this is a terminal scope with no fallback. If no nodes are
+   * available in a terminal scope, the client will fail rather than degrade further.
+   *
+   * @return the fallback scope, or {@code null} if this is a terminal scope
+   */
+  RoutingScope getFallback();
+
+  /**
+   * Returns the query string to append to the {@code /localnodes} endpoint URL.
+   *
+   * <p>This query string filters the nodes returned by the Alternator node discovery endpoint. The
+   * query string should not include the leading "?" character.
+   *
+   * <p>Examples:
+   *
+   * <ul>
+   *   <li>"" (empty string) for cluster-wide scope
+   *   <li>"dc=dc1" for datacenter scope
+   *   <li>"dc=dc1&amp;rack=rack1" for rack scope
+   * </ul>
+   *
+   * @return the query string for filtering nodes, or empty string for no filtering
+   */
+  String getLocalNodesQuery();
+}

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
@@ -2,6 +2,9 @@ package com.scylladb.alternator;
 
 import static org.junit.Assert.*;
 
+import com.scylladb.alternator.routing.ClusterScope;
+import com.scylladb.alternator.routing.DatacenterScope;
+import com.scylladb.alternator.routing.RackScope;
 import org.junit.Test;
 
 /**
@@ -69,29 +72,31 @@ public class AlternatorConfigCompressionTest {
   }
 
   @Test
-  public void testCompressionWithDatacenterAndRack() {
+  public void testCompressionWithRoutingScope() {
     AlternatorConfig config =
         AlternatorConfig.builder()
-            .withDatacenter("us-east")
-            .withRack("rack1")
+            .withRoutingScope(
+                RackScope.of(
+                    "us-east", "rack1", DatacenterScope.of("us-east", ClusterScope.create())))
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
             .withMinCompressionSizeBytes(512)
             .build();
 
-    assertEquals("us-east", config.getDatacenter());
-    assertEquals("rack1", config.getRack());
+    assertEquals("Rack", config.getRoutingScope().getName());
     assertEquals(RequestCompressionAlgorithm.GZIP, config.getCompressionAlgorithm());
     assertEquals(512, config.getMinCompressionSizeBytes());
   }
 
   @Test
-  public void testBackwardCompatibilityWithoutCompression() {
+  public void testDefaultWithoutCompression() {
     // Existing code without compression settings should still work
     AlternatorConfig config =
-        AlternatorConfig.builder().withDatacenter("dc1").withRack("rack1").build();
+        AlternatorConfig.builder()
+            .withRoutingScope(
+                RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create())))
+            .build();
 
-    assertEquals("dc1", config.getDatacenter());
-    assertEquals("rack1", config.getRack());
+    assertEquals("Rack", config.getRoutingScope().getName());
     // Compression defaults to disabled
     assertEquals(RequestCompressionAlgorithm.NONE, config.getCompressionAlgorithm());
     assertEquals(

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
@@ -3,6 +3,10 @@ package com.scylladb.alternator;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
+import com.scylladb.alternator.routing.ClusterScope;
+import com.scylladb.alternator.routing.DatacenterScope;
+import com.scylladb.alternator.routing.RackScope;
+import com.scylladb.alternator.routing.RoutingScope;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
@@ -72,12 +76,22 @@ public class AlternatorDynamoDbAsyncClientIT {
   }
 
   private AlternatorDynamoDbAsyncClientWrapper buildClient(String dc, String rackName) {
+    RoutingScope scope = deriveRoutingScope(dc, rackName);
     return AlternatorDynamoDbAsyncClient.builder()
         .endpointOverride(seedUri)
         .credentialsProvider(credentialsProvider)
-        .withDatacenter(dc)
-        .withRack(rackName)
+        .withRoutingScope(scope)
         .buildWithAlternatorAPI();
+  }
+
+  private static RoutingScope deriveRoutingScope(String dc, String rackName) {
+    if (dc == null || dc.isEmpty()) {
+      return ClusterScope.create();
+    }
+    if (rackName == null || rackName.isEmpty()) {
+      return DatacenterScope.of(dc, ClusterScope.create());
+    }
+    return RackScope.of(dc, rackName, DatacenterScope.of(dc, ClusterScope.create()));
   }
 
   private AlternatorDynamoDbAsyncClientWrapper buildClient() {
@@ -289,7 +303,7 @@ public class AlternatorDynamoDbAsyncClientIT {
         AlternatorDynamoDbAsyncClient.builder()
             .endpointOverride(seedUri)
             .credentialsProvider(credentialsProvider)
-            .withDatacenter(datacenter)
+            .withRoutingScope(DatacenterScope.of(datacenter, ClusterScope.create()))
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
             .withMinCompressionSizeBytes(512)
             .buildWithAlternatorAPI();

--- a/src/test/java/com/scylladb/alternator/RoutingScopeTest.java
+++ b/src/test/java/com/scylladb/alternator/RoutingScopeTest.java
@@ -1,0 +1,341 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import com.scylladb.alternator.routing.ClusterScope;
+import com.scylladb.alternator.routing.DatacenterScope;
+import com.scylladb.alternator.routing.RackScope;
+import com.scylladb.alternator.routing.RoutingScope;
+import org.junit.Test;
+
+/**
+ * Unit tests for RoutingScope implementations.
+ *
+ * @author dmitry.kropachev
+ */
+public class RoutingScopeTest {
+
+  // ============== ClusterScope Tests ==============
+
+  @Test
+  public void testClusterScopeCreate() {
+    ClusterScope scope = ClusterScope.create();
+    assertNotNull(scope);
+  }
+
+  @Test
+  public void testClusterScopeSingleton() {
+    ClusterScope scope1 = ClusterScope.create();
+    ClusterScope scope2 = ClusterScope.create();
+    assertSame("ClusterScope should return singleton instance", scope1, scope2);
+  }
+
+  @Test
+  public void testClusterScopeGetName() {
+    ClusterScope scope = ClusterScope.create();
+    assertEquals("Cluster", scope.getName());
+  }
+
+  @Test
+  public void testClusterScopeGetDescription() {
+    ClusterScope scope = ClusterScope.create();
+    assertEquals("Cluster (all nodes)", scope.getDescription());
+  }
+
+  @Test
+  public void testClusterScopeGetFallback() {
+    ClusterScope scope = ClusterScope.create();
+    assertNull("ClusterScope should have no fallback", scope.getFallback());
+  }
+
+  @Test
+  public void testClusterScopeGetLocalNodesQuery() {
+    ClusterScope scope = ClusterScope.create();
+    assertEquals("", scope.getLocalNodesQuery());
+  }
+
+  @Test
+  public void testClusterScopeToString() {
+    ClusterScope scope = ClusterScope.create();
+    assertEquals("ClusterScope{}", scope.toString());
+  }
+
+  @Test
+  public void testClusterScopeEquals() {
+    ClusterScope scope1 = ClusterScope.create();
+    ClusterScope scope2 = ClusterScope.create();
+    assertEquals(scope1, scope2);
+    assertEquals(scope1.hashCode(), scope2.hashCode());
+  }
+
+  // ============== DatacenterScope Tests ==============
+
+  @Test
+  public void testDatacenterScopeCreate() {
+    DatacenterScope scope = DatacenterScope.of("dc1", null);
+    assertNotNull(scope);
+    assertEquals("dc1", scope.getDatacenter());
+  }
+
+  @Test
+  public void testDatacenterScopeWithFallback() {
+    ClusterScope fallback = ClusterScope.create();
+    DatacenterScope scope = DatacenterScope.of("dc1", fallback);
+    assertEquals(fallback, scope.getFallback());
+  }
+
+  @Test
+  public void testDatacenterScopeWithoutFallback() {
+    DatacenterScope scope = DatacenterScope.of("dc1", null);
+    assertNull(scope.getFallback());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDatacenterScopeWithNullDatacenter() {
+    DatacenterScope.of(null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDatacenterScopeWithEmptyDatacenter() {
+    DatacenterScope.of("", null);
+  }
+
+  @Test
+  public void testDatacenterScopeGetName() {
+    DatacenterScope scope = DatacenterScope.of("dc1", null);
+    assertEquals("Datacenter", scope.getName());
+  }
+
+  @Test
+  public void testDatacenterScopeGetDescription() {
+    DatacenterScope scope = DatacenterScope.of("dc1", null);
+    assertEquals("Datacenter dc1", scope.getDescription());
+  }
+
+  @Test
+  public void testDatacenterScopeGetLocalNodesQuery() {
+    DatacenterScope scope = DatacenterScope.of("dc1", null);
+    assertEquals("dc=dc1", scope.getLocalNodesQuery());
+  }
+
+  @Test
+  public void testDatacenterScopeToString() {
+    DatacenterScope scope = DatacenterScope.of("dc1", ClusterScope.create());
+    assertTrue(scope.toString().contains("dc1"));
+    assertTrue(scope.toString().contains("ClusterScope"));
+  }
+
+  @Test
+  public void testDatacenterScopeEquals() {
+    DatacenterScope scope1 = DatacenterScope.of("dc1", ClusterScope.create());
+    DatacenterScope scope2 = DatacenterScope.of("dc1", ClusterScope.create());
+    DatacenterScope scope3 = DatacenterScope.of("dc2", ClusterScope.create());
+    DatacenterScope scope4 = DatacenterScope.of("dc1", null);
+
+    assertEquals(scope1, scope2);
+    assertEquals(scope1.hashCode(), scope2.hashCode());
+    assertNotEquals(scope1, scope3);
+    assertNotEquals(scope1, scope4);
+  }
+
+  // ============== RackScope Tests ==============
+
+  @Test
+  public void testRackScopeCreate() {
+    RackScope scope = RackScope.of("dc1", "rack1", null);
+    assertNotNull(scope);
+    assertEquals("dc1", scope.getDatacenter());
+    assertEquals("rack1", scope.getRack());
+  }
+
+  @Test
+  public void testRackScopeWithFallback() {
+    DatacenterScope fallback = DatacenterScope.of("dc1", ClusterScope.create());
+    RackScope scope = RackScope.of("dc1", "rack1", fallback);
+    assertEquals(fallback, scope.getFallback());
+  }
+
+  @Test
+  public void testRackScopeWithoutFallback() {
+    RackScope scope = RackScope.of("dc1", "rack1", null);
+    assertNull(scope.getFallback());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRackScopeWithNullDatacenter() {
+    RackScope.of(null, "rack1", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRackScopeWithEmptyDatacenter() {
+    RackScope.of("", "rack1", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRackScopeWithNullRack() {
+    RackScope.of("dc1", null, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRackScopeWithEmptyRack() {
+    RackScope.of("dc1", "", null);
+  }
+
+  @Test
+  public void testRackScopeGetName() {
+    RackScope scope = RackScope.of("dc1", "rack1", null);
+    assertEquals("Rack", scope.getName());
+  }
+
+  @Test
+  public void testRackScopeGetDescription() {
+    RackScope scope = RackScope.of("dc1", "rack1", null);
+    assertEquals("Rack rack1 in Datacenter dc1", scope.getDescription());
+  }
+
+  @Test
+  public void testRackScopeGetLocalNodesQuery() {
+    RackScope scope = RackScope.of("dc1", "rack1", null);
+    assertEquals("dc=dc1&rack=rack1", scope.getLocalNodesQuery());
+  }
+
+  @Test
+  public void testRackScopeToString() {
+    RackScope scope = RackScope.of("dc1", "rack1", null);
+    assertTrue(scope.toString().contains("dc1"));
+    assertTrue(scope.toString().contains("rack1"));
+  }
+
+  @Test
+  public void testRackScopeEquals() {
+    RackScope scope1 = RackScope.of("dc1", "rack1", null);
+    RackScope scope2 = RackScope.of("dc1", "rack1", null);
+    RackScope scope3 = RackScope.of("dc1", "rack2", null);
+    RackScope scope4 = RackScope.of("dc2", "rack1", null);
+
+    assertEquals(scope1, scope2);
+    assertEquals(scope1.hashCode(), scope2.hashCode());
+    assertNotEquals(scope1, scope3);
+    assertNotEquals(scope1, scope4);
+  }
+
+  // ============== Fallback Chain Tests ==============
+
+  @Test
+  public void testFallbackChainRackToDatacenterToCluster() {
+    RoutingScope scope =
+        RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create()));
+
+    // First level: Rack
+    assertEquals("Rack", scope.getName());
+    assertEquals("dc=dc1&rack=rack1", scope.getLocalNodesQuery());
+
+    // Second level: Datacenter
+    RoutingScope fallback1 = scope.getFallback();
+    assertNotNull(fallback1);
+    assertEquals("Datacenter", fallback1.getName());
+    assertEquals("dc=dc1", fallback1.getLocalNodesQuery());
+
+    // Third level: Cluster
+    RoutingScope fallback2 = fallback1.getFallback();
+    assertNotNull(fallback2);
+    assertEquals("Cluster", fallback2.getName());
+    assertEquals("", fallback2.getLocalNodesQuery());
+
+    // No more fallbacks
+    assertNull(fallback2.getFallback());
+  }
+
+  @Test
+  public void testFallbackChainRackToRackToDatacenterToCluster() {
+    RoutingScope scope =
+        RackScope.of(
+            "dc1",
+            "rack1",
+            RackScope.of("dc1", "rack2", DatacenterScope.of("dc1", ClusterScope.create())));
+
+    // First level: Rack1
+    assertEquals("Rack rack1 in Datacenter dc1", scope.getDescription());
+
+    // Second level: Rack2
+    RoutingScope fallback1 = scope.getFallback();
+    assertNotNull(fallback1);
+    assertEquals("Rack rack2 in Datacenter dc1", fallback1.getDescription());
+
+    // Third level: Datacenter
+    RoutingScope fallback2 = fallback1.getFallback();
+    assertNotNull(fallback2);
+    assertEquals("Datacenter dc1", fallback2.getDescription());
+
+    // Fourth level: Cluster
+    RoutingScope fallback3 = fallback2.getFallback();
+    assertNotNull(fallback3);
+    assertEquals("Cluster (all nodes)", fallback3.getDescription());
+
+    // No more fallbacks
+    assertNull(fallback3.getFallback());
+  }
+
+  @Test
+  public void testStrictTargetingNoFallback() {
+    DatacenterScope scope = DatacenterScope.of("dc1", null);
+    assertNull("Strict targeting should have no fallback", scope.getFallback());
+  }
+
+  @Test
+  public void testFallbackChainTraversal() {
+    RoutingScope scope =
+        RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create()));
+
+    // Count the number of scopes in the chain
+    int count = 0;
+    RoutingScope current = scope;
+    while (current != null) {
+      count++;
+      current = current.getFallback();
+    }
+    assertEquals("Chain should have 3 scopes (rack -> dc -> cluster)", 3, count);
+  }
+
+  // ============== Cross-type Equality Tests ==============
+
+  @Test
+  public void testDifferentScopeTypesNotEqual() {
+    ClusterScope clusterScope = ClusterScope.create();
+    DatacenterScope datacenterScope = DatacenterScope.of("dc1", null);
+    RackScope rackScope = RackScope.of("dc1", "rack1", null);
+
+    assertNotEquals(clusterScope, datacenterScope);
+    assertNotEquals(datacenterScope, rackScope);
+    assertNotEquals(clusterScope, rackScope);
+  }
+
+  // ============== AlternatorConfig Integration Tests ==============
+
+  @Test
+  public void testAlternatorConfigWithRoutingScope() {
+    RoutingScope scope =
+        RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create()));
+
+    AlternatorConfig config = AlternatorConfig.builder().withRoutingScope(scope).build();
+
+    assertEquals(scope, config.getRoutingScope());
+  }
+
+  @Test
+  public void testAlternatorConfigWithoutRoutingScopeDefaultsToCluster() {
+    AlternatorConfig config = AlternatorConfig.builder().build();
+    RoutingScope scope = config.getRoutingScope();
+    assertNotNull("RoutingScope should never be null", scope);
+    assertTrue("Default scope should be ClusterScope", scope instanceof ClusterScope);
+    assertEquals("", scope.getLocalNodesQuery());
+  }
+
+  @Test
+  public void testAlternatorConfigWithNullRoutingScopeDefaultsToCluster() {
+    AlternatorConfig config = AlternatorConfig.builder().withRoutingScope(null).build();
+    RoutingScope scope = config.getRoutingScope();
+    assertNotNull("RoutingScope should never be null even when explicitly set to null", scope);
+    assertTrue("Null routing scope should default to ClusterScope", scope instanceof ClusterScope);
+  }
+}


### PR DESCRIPTION
## Summary

Implements composable routing scope system for targeting specific racks/datacenters with hierarchical fallback chains.

- Add `RoutingScope` interface with `ClusterScope`, `DatacenterScope`, and `RackScope` implementations
- Support fallback chains (e.g., Rack -> Datacenter -> Cluster)
- Refactor `AlternatorConfig` to store seed hosts, scheme, and port separately
- Update `AlternatorLiveNodes` to handle fallback automatically at runtime
- Deprecate legacy `withDatacenter()`/`withRack()` methods in favor of `withRoutingScope()`


Closes: https://github.com/scylladb/alternator-client-java/issues/16

## Usage

```java
// Target rack with fallback to datacenter and cluster
RoutingScope scope = RackScope.of("dc1", "rack1",
    DatacenterScope.of("dc1",
        ClusterScope.create()));

DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(URI.create("https://localhost:8043"))
    .withRoutingScope(scope)
    .build();

// Or using explicit hosts, scheme, port
AlternatorConfig config = AlternatorConfig.builder()
    .withSeedHosts(Arrays.asList("192.168.1.100", "192.168.1.101"))
    .withScheme("https")
    .withPort(8043)
    .withRoutingScope(scope)
    .build();
```

## Test plan

- [x] Unit tests for all RoutingScope implementations
- [x] Unit tests for AlternatorConfig integration
- [x] All existing tests pass (152 tests)
- [x] `make verify` passes

Closes [DRIVER-282](https://scylladb.atlassian.net/browse/DRIVER-282)


[DRIVER-282]: https://scylladb.atlassian.net/browse/DRIVER-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ