### PR TITLE
Add TLS session tickets support for quick TLS renegotiation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -180,6 +180,47 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
+     * Sets the TLS session cache configuration for quick TLS renegotiation.
+     *
+     * <p>TLS session tickets (RFC 5077) allow clients to resume TLS sessions without performing a
+     * full handshake. This significantly reduces latency when reconnecting to Alternator nodes.
+     *
+     * <p>Default: {@link TlsSessionCacheConfig#getDefault()} (enabled with 1024 sessions, 24h
+     * timeout)
+     *
+     * @param tlsSessionCacheConfig the TLS session cache configuration, or null to use default
+     * @return this builder instance
+     * @since 1.0.5
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withTlsSessionCacheConfig(
+        TlsSessionCacheConfig tlsSessionCacheConfig) {
+      configBuilder.withTlsSessionCacheConfig(tlsSessionCacheConfig);
+      return this;
+    }
+
+    /**
+     * Sets the complete Alternator configuration.
+     *
+     * <p>This method allows setting all Alternator-specific configuration options at once using a
+     * pre-built {@link AlternatorConfig} instance.
+     *
+     * @param config the Alternator configuration
+     * @return this builder instance
+     * @since 1.0.5
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withAlternatorConfig(AlternatorConfig config) {
+      if (config != null) {
+        configBuilder.withRoutingScope(config.getRoutingScope());
+        configBuilder.withCompressionAlgorithm(config.getCompressionAlgorithm());
+        configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
+        configBuilder.withOptimizeHeaders(config.isOptimizeHeaders());
+        configBuilder.withHeadersWhitelist(config.getHeadersWhitelist());
+        configBuilder.withTlsSessionCacheConfig(config.getTlsSessionCacheConfig());
+      }
+      return this;
+    }
+
+    /**
      * Disables SSL certificate validation for testing purposes.
      *
      * <p><strong>WARNING:</strong> This should only be used for testing with self-signed
@@ -613,7 +654,7 @@ public class AlternatorDynamoDbAsyncClient {
       // Build the underlying client and wrap it with Alternator metadata
       DynamoDbAsyncClient client = delegate.build();
       return new AlternatorDynamoDbAsyncClientWrapper(
-          client, liveNodes, alternatorEndpointProvider);
+          client, liveNodes, alternatorEndpointProvider, alternatorConfig);
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
@@ -37,6 +37,7 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
   private final DynamoDbAsyncClient client;
   private final AlternatorLiveNodes liveNodes;
   private final AlternatorEndpointProvider endpointProvider;
+  private final AlternatorConfig config;
 
   /**
    * Creates a new wrapper with the given client, live nodes, and endpoint provider.
@@ -49,9 +50,26 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
       DynamoDbAsyncClient client,
       AlternatorLiveNodes liveNodes,
       AlternatorEndpointProvider endpointProvider) {
+    this(client, liveNodes, endpointProvider, null);
+  }
+
+  /**
+   * Creates a new wrapper with the given client, live nodes, endpoint provider, and config.
+   *
+   * @param client the underlying DynamoDbAsyncClient
+   * @param liveNodes the AlternatorLiveNodes instance managing node discovery
+   * @param endpointProvider the AlternatorEndpointProvider used for this client
+   * @param config the AlternatorConfig used for this client
+   */
+  public AlternatorDynamoDbAsyncClientWrapper(
+      DynamoDbAsyncClient client,
+      AlternatorLiveNodes liveNodes,
+      AlternatorEndpointProvider endpointProvider,
+      AlternatorConfig config) {
     this.client = client;
     this.liveNodes = liveNodes;
     this.endpointProvider = endpointProvider;
+    this.config = config;
   }
 
   /**
@@ -110,6 +128,18 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
    */
   public AlternatorEndpointProvider getAlternatorEndpointProvider() {
     return endpointProvider;
+  }
+
+  /**
+   * Returns the AlternatorConfig used to create this client.
+   *
+   * <p>The config contains all settings including TLS session cache configuration, compression
+   * settings, header optimization, and routing scope.
+   *
+   * @return the {@link AlternatorConfig} instance, or null if not available
+   */
+  public AlternatorConfig getAlternatorConfig() {
+    return config;
   }
 
   /** Closes the underlying DynamoDbAsyncClient. */

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapper.java
@@ -37,6 +37,7 @@ public class AlternatorDynamoDbClientWrapper implements AutoCloseable {
   private final DynamoDbClient client;
   private final AlternatorLiveNodes liveNodes;
   private final AlternatorEndpointProvider endpointProvider;
+  private final AlternatorConfig config;
 
   /**
    * Creates a new wrapper with the given client, live nodes, and endpoint provider.
@@ -49,9 +50,26 @@ public class AlternatorDynamoDbClientWrapper implements AutoCloseable {
       DynamoDbClient client,
       AlternatorLiveNodes liveNodes,
       AlternatorEndpointProvider endpointProvider) {
+    this(client, liveNodes, endpointProvider, null);
+  }
+
+  /**
+   * Creates a new wrapper with the given client, live nodes, endpoint provider, and config.
+   *
+   * @param client the underlying DynamoDbClient
+   * @param liveNodes the AlternatorLiveNodes instance managing node discovery
+   * @param endpointProvider the AlternatorEndpointProvider used for this client
+   * @param config the AlternatorConfig used for this client
+   */
+  public AlternatorDynamoDbClientWrapper(
+      DynamoDbClient client,
+      AlternatorLiveNodes liveNodes,
+      AlternatorEndpointProvider endpointProvider,
+      AlternatorConfig config) {
     this.client = client;
     this.liveNodes = liveNodes;
     this.endpointProvider = endpointProvider;
+    this.config = config;
   }
 
   /**
@@ -110,6 +128,18 @@ public class AlternatorDynamoDbClientWrapper implements AutoCloseable {
    */
   public AlternatorEndpointProvider getAlternatorEndpointProvider() {
     return endpointProvider;
+  }
+
+  /**
+   * Returns the AlternatorConfig used to create this client.
+   *
+   * <p>The config contains all settings including TLS session cache configuration, compression
+   * settings, header optimization, and routing scope.
+   *
+   * @return the {@link AlternatorConfig} instance, or null if not available
+   */
+  public AlternatorConfig getAlternatorConfig() {
+    return config;
   }
 
   /** Closes the underlying DynamoDbClient. */

--- a/src/main/java/com/scylladb/alternator/TlsSessionCacheConfig.java
+++ b/src/main/java/com/scylladb/alternator/TlsSessionCacheConfig.java
@@ -1,0 +1,221 @@
+package com.scylladb.alternator;
+
+import java.util.Objects;
+
+/**
+ * Configuration for TLS session caching to enable quick TLS renegotiation.
+ *
+ * <p>TLS session tickets (RFC 5077) allow clients to resume TLS sessions without performing a full
+ * handshake. This significantly reduces latency when reconnecting to Alternator nodes, which is
+ * especially beneficial in load-balanced scenarios where connections may be distributed across
+ * different nodes.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Use default settings (enabled, 1024 sessions, 24h timeout)
+ * TlsSessionCacheConfig config = TlsSessionCacheConfig.getDefault();
+ *
+ * // Custom configuration
+ * TlsSessionCacheConfig config = TlsSessionCacheConfig.builder()
+ *     .withEnabled(true)
+ *     .withSessionCacheSize(200)
+ *     .withSessionTimeoutSeconds(3600)  // 1 hour
+ *     .build();
+ *
+ * // Disable session caching
+ * TlsSessionCacheConfig config = TlsSessionCacheConfig.disabled();
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.5
+ */
+public final class TlsSessionCacheConfig {
+  /** Default session cache size (number of sessions to cache). */
+  public static final int DEFAULT_SESSION_CACHE_SIZE = 1024;
+
+  /** Default session timeout in seconds (24 hours). */
+  public static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 86400;
+
+  private static final TlsSessionCacheConfig DEFAULT_INSTANCE =
+      new TlsSessionCacheConfig(true, DEFAULT_SESSION_CACHE_SIZE, DEFAULT_SESSION_TIMEOUT_SECONDS);
+
+  private static final TlsSessionCacheConfig DISABLED_INSTANCE =
+      new TlsSessionCacheConfig(false, 0, 0);
+
+  private final boolean enabled;
+  private final int sessionCacheSize;
+  private final int sessionTimeoutSeconds;
+
+  private TlsSessionCacheConfig(boolean enabled, int sessionCacheSize, int sessionTimeoutSeconds) {
+    this.enabled = enabled;
+    this.sessionCacheSize = sessionCacheSize;
+    this.sessionTimeoutSeconds = sessionTimeoutSeconds;
+  }
+
+  /**
+   * Returns the default TLS session cache configuration.
+   *
+   * <p>The default configuration has:
+   *
+   * <ul>
+   *   <li>Session caching enabled
+   *   <li>Cache size of 1024 sessions
+   *   <li>Session timeout of 24 hours (86400 seconds)
+   * </ul>
+   *
+   * @return the default configuration instance
+   */
+  public static TlsSessionCacheConfig getDefault() {
+    return DEFAULT_INSTANCE;
+  }
+
+  /**
+   * Returns a disabled TLS session cache configuration.
+   *
+   * <p>Use this when TLS session caching should be turned off entirely.
+   *
+   * @return a configuration with session caching disabled
+   */
+  public static TlsSessionCacheConfig disabled() {
+    return DISABLED_INSTANCE;
+  }
+
+  /**
+   * Creates a new builder for TlsSessionCacheConfig.
+   *
+   * @return a new {@link Builder}
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns whether TLS session caching is enabled.
+   *
+   * @return true if session caching is enabled, false otherwise
+   */
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Returns the maximum number of TLS sessions to cache.
+   *
+   * <p>This controls how many session tickets can be stored for resumption. A larger value allows
+   * more connections to benefit from session resumption but uses more memory.
+   *
+   * @return the session cache size
+   */
+  public int getSessionCacheSize() {
+    return sessionCacheSize;
+  }
+
+  /**
+   * Returns the session timeout in seconds.
+   *
+   * <p>Cached sessions older than this value will be invalidated. The timeout should be set based
+   * on security requirements and expected connection patterns.
+   *
+   * @return the session timeout in seconds
+   */
+  public int getSessionTimeoutSeconds() {
+    return sessionTimeoutSeconds;
+  }
+
+  @Override
+  public String toString() {
+    return "TlsSessionCacheConfig{"
+        + "enabled="
+        + enabled
+        + ", sessionCacheSize="
+        + sessionCacheSize
+        + ", sessionTimeoutSeconds="
+        + sessionTimeoutSeconds
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TlsSessionCacheConfig that = (TlsSessionCacheConfig) o;
+    return enabled == that.enabled
+        && sessionCacheSize == that.sessionCacheSize
+        && sessionTimeoutSeconds == that.sessionTimeoutSeconds;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, sessionCacheSize, sessionTimeoutSeconds);
+  }
+
+  /** Builder for creating {@link TlsSessionCacheConfig} instances. */
+  public static class Builder {
+    private boolean enabled = true;
+    private int sessionCacheSize = DEFAULT_SESSION_CACHE_SIZE;
+    private int sessionTimeoutSeconds = DEFAULT_SESSION_TIMEOUT_SECONDS;
+
+    Builder() {}
+
+    /**
+     * Enables or disables TLS session caching.
+     *
+     * @param enabled true to enable session caching, false to disable
+     * @return this builder instance
+     */
+    public Builder withEnabled(boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
+
+    /**
+     * Sets the maximum number of TLS sessions to cache.
+     *
+     * @param sessionCacheSize the cache size (must be positive)
+     * @return this builder instance
+     */
+    public Builder withSessionCacheSize(int sessionCacheSize) {
+      this.sessionCacheSize = sessionCacheSize;
+      return this;
+    }
+
+    /**
+     * Sets the session timeout in seconds.
+     *
+     * @param sessionTimeoutSeconds the timeout in seconds (must be positive)
+     * @return this builder instance
+     */
+    public Builder withSessionTimeoutSeconds(int sessionTimeoutSeconds) {
+      this.sessionTimeoutSeconds = sessionTimeoutSeconds;
+      return this;
+    }
+
+    /**
+     * Builds and returns a {@link TlsSessionCacheConfig} instance.
+     *
+     * @return a new TlsSessionCacheConfig
+     * @throws IllegalArgumentException if sessionCacheSize or sessionTimeoutSeconds is not positive
+     *     when enabled
+     */
+    public TlsSessionCacheConfig build() {
+      if (enabled) {
+        if (sessionCacheSize <= 0) {
+          throw new IllegalArgumentException(
+              "sessionCacheSize must be positive when TLS session cache is enabled, but was: "
+                  + sessionCacheSize);
+        }
+        if (sessionTimeoutSeconds <= 0) {
+          throw new IllegalArgumentException(
+              "sessionTimeoutSeconds must be positive when TLS session cache is enabled, but was: "
+                  + sessionTimeoutSeconds);
+        }
+      }
+      return new TlsSessionCacheConfig(enabled, sessionCacheSize, sessionTimeoutSeconds);
+    }
+  }
+}

--- a/src/main/java/com/scylladb/alternator/internal/TlsContextFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/TlsContextFactory.java
@@ -1,0 +1,126 @@
+package com.scylladb.alternator.internal;
+
+import com.scylladb.alternator.TlsSessionCacheConfig;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * Factory for creating SSLContext instances with TLS session ticket support.
+ *
+ * <p>This factory creates SSL contexts configured for:
+ *
+ * <ul>
+ *   <li>Modern TLS protocols (TLS 1.2+) that support session tickets
+ *   <li>Configurable session caching for TLS session resumption
+ *   <li>Trust-all certificate validation (for development/testing with self-signed certs)
+ * </ul>
+ *
+ * <p><strong>Security Note:</strong> The created SSL contexts accept all certificates including
+ * self-signed ones. This is intentional for development and testing scenarios but should be
+ * carefully considered for production deployments.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.5
+ */
+public final class TlsContextFactory {
+
+  private TlsContextFactory() {
+    // Utility class
+  }
+
+  /**
+   * Creates an SSLContext configured according to the provided TLS session cache configuration.
+   *
+   * <p>The returned context:
+   *
+   * <ul>
+   *   <li>Uses TLSv1.3 protocol (preferred) or TLS (fallback) for session ticket support
+   *   <li>Has session caching configured per the provided config
+   *   <li>Trusts all certificates (including self-signed)
+   * </ul>
+   *
+   * <p><b>Note:</b> TLS 1.3 session tickets require server-side support. In ScyllaDB, enable
+   * session tickets via {@code alternator_encryption_options.enable_session_tickets: true} in
+   * scylla.yaml.
+   *
+   * @param config the TLS session cache configuration
+   * @return a configured SSLContext
+   * @throws RuntimeException if the SSL context cannot be created
+   */
+  public static SSLContext createSslContext(TlsSessionCacheConfig config) {
+    TrustManager[] trustAllCertificates = createTrustAllManagers();
+
+    try {
+      // Prefer TLSv1.3 for session ticket support, fall back to TLS if not available
+      SSLContext sslContext;
+      try {
+        sslContext = SSLContext.getInstance("TLSv1.3");
+      } catch (NoSuchAlgorithmException e) {
+        // Fall back to generic TLS (will use highest available version)
+        sslContext = SSLContext.getInstance("TLS");
+      }
+      sslContext.init(null, trustAllCertificates, new java.security.SecureRandom());
+
+      // Configure session caching
+      configureSessionCache(sslContext, config);
+
+      return sslContext;
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      throw new RuntimeException("Failed to create SSL context", e);
+    }
+  }
+
+  /**
+   * Creates trust managers that accept all certificates.
+   *
+   * <p><strong>Security Note:</strong> This is intended for development and testing with
+   * self-signed certificates. For production, consider using proper certificate validation.
+   *
+   * @return an array containing a trust-all X509TrustManager
+   */
+  private static TrustManager[] createTrustAllManagers() {
+    return new TrustManager[] {
+      new X509TrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+          // Accept all client certificates
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+          // Accept all server certificates
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+          return new X509Certificate[0];
+        }
+      }
+    };
+  }
+
+  /**
+   * Configures the SSL session cache based on the provided configuration.
+   *
+   * @param sslContext the SSL context to configure
+   * @param config the TLS session cache configuration
+   */
+  private static void configureSessionCache(SSLContext sslContext, TlsSessionCacheConfig config) {
+    SSLSessionContext clientSessionContext = sslContext.getClientSessionContext();
+    if (clientSessionContext != null) {
+      if (config.isEnabled()) {
+        // Enable session caching with configured size and timeout
+        clientSessionContext.setSessionCacheSize(config.getSessionCacheSize());
+        clientSessionContext.setSessionTimeout(config.getSessionTimeoutSeconds());
+      } else {
+        // Disable session caching by setting cache size to 0
+        clientSessionContext.setSessionCacheSize(0);
+      }
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigTlsTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigTlsTest.java
@@ -1,0 +1,95 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import java.net.URI;
+import org.junit.Test;
+
+/**
+ * Unit tests for TLS session cache configuration in AlternatorConfig.
+ *
+ * @author dmitry.kropachev
+ */
+public class AlternatorConfigTlsTest {
+
+  @Test
+  public void testDefaultTlsSessionCacheConfig() {
+    AlternatorConfig config =
+        AlternatorConfig.builder().withSeedNode(URI.create("https://localhost:8043")).build();
+
+    TlsSessionCacheConfig tlsConfig = config.getTlsSessionCacheConfig();
+    assertNotNull("TLS session cache config should not be null", tlsConfig);
+    assertTrue("TLS session cache should be enabled by default", tlsConfig.isEnabled());
+  }
+
+  @Test
+  public void testCustomTlsSessionCacheConfig() {
+    TlsSessionCacheConfig customTlsConfig =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(500)
+            .withSessionTimeoutSeconds(7200)
+            .build();
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsSessionCacheConfig(customTlsConfig)
+            .build();
+
+    TlsSessionCacheConfig tlsConfig = config.getTlsSessionCacheConfig();
+    assertEquals(customTlsConfig, tlsConfig);
+    assertEquals(500, tlsConfig.getSessionCacheSize());
+    assertEquals(7200, tlsConfig.getSessionTimeoutSeconds());
+  }
+
+  @Test
+  public void testDisabledTlsSessionCache() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsSessionCacheConfig(TlsSessionCacheConfig.disabled())
+            .build();
+
+    TlsSessionCacheConfig tlsConfig = config.getTlsSessionCacheConfig();
+    assertFalse("TLS session cache should be disabled", tlsConfig.isEnabled());
+  }
+
+  @Test
+  public void testHttpSchemeShouldStillHaveTlsConfig() {
+    // Even for HTTP, the TLS config should be present (though not used)
+    AlternatorConfig config =
+        AlternatorConfig.builder().withSeedNode(URI.create("http://localhost:8000")).build();
+
+    TlsSessionCacheConfig tlsConfig = config.getTlsSessionCacheConfig();
+    assertNotNull("TLS config should be present even for HTTP", tlsConfig);
+  }
+
+  @Test
+  public void testTlsSessionCacheWithCompression() {
+    // TLS session cache should work alongside compression
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withTlsSessionCacheConfig(TlsSessionCacheConfig.getDefault())
+            .build();
+
+    assertTrue(config.getTlsSessionCacheConfig().isEnabled());
+    assertEquals(RequestCompressionAlgorithm.GZIP, config.getCompressionAlgorithm());
+  }
+
+  @Test
+  public void testNullTlsConfigUsesDefault() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsSessionCacheConfig(null)
+            .build();
+
+    // Should use default when null is passed
+    TlsSessionCacheConfig tlsConfig = config.getTlsSessionCacheConfig();
+    assertNotNull(tlsConfig);
+    assertTrue(tlsConfig.isEnabled());
+  }
+}

--- a/src/test/java/com/scylladb/alternator/TlsSessionCacheConfigTest.java
+++ b/src/test/java/com/scylladb/alternator/TlsSessionCacheConfigTest.java
@@ -1,0 +1,134 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for TlsSessionCacheConfig.
+ *
+ * @author dmitry.kropachev
+ */
+public class TlsSessionCacheConfigTest {
+
+  @Test
+  public void testDefaultValues() {
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.getDefault();
+
+    assertTrue("TLS session cache should be enabled by default", config.isEnabled());
+    assertEquals("Default session cache size should be 1024", 1024, config.getSessionCacheSize());
+    assertEquals(
+        "Default session timeout should be 86400 seconds (24 hours)",
+        86400,
+        config.getSessionTimeoutSeconds());
+  }
+
+  @Test
+  public void testDisabled() {
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.disabled();
+
+    assertFalse("TLS session cache should be disabled", config.isEnabled());
+  }
+
+  @Test
+  public void testBuilderWithCustomValues() {
+    TlsSessionCacheConfig config =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(200)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    assertTrue(config.isEnabled());
+    assertEquals(200, config.getSessionCacheSize());
+    assertEquals(3600, config.getSessionTimeoutSeconds());
+  }
+
+  @Test
+  public void testBuilderWithDisabled() {
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.builder().withEnabled(false).build();
+
+    assertFalse(config.isEnabled());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderRejectsNegativeCacheSize() {
+    TlsSessionCacheConfig.builder().withSessionCacheSize(-1).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderRejectsZeroCacheSize() {
+    TlsSessionCacheConfig.builder().withSessionCacheSize(0).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderRejectsNegativeTimeout() {
+    TlsSessionCacheConfig.builder().withSessionTimeoutSeconds(-1).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderRejectsZeroTimeout() {
+    TlsSessionCacheConfig.builder().withSessionTimeoutSeconds(0).build();
+  }
+
+  @Test
+  public void testDefaultConfigIsImmutable() {
+    TlsSessionCacheConfig config1 = TlsSessionCacheConfig.getDefault();
+    TlsSessionCacheConfig config2 = TlsSessionCacheConfig.getDefault();
+
+    // Should return the same instance
+    assertSame(config1, config2);
+  }
+
+  @Test
+  public void testDisabledConfigIsImmutable() {
+    TlsSessionCacheConfig config1 = TlsSessionCacheConfig.disabled();
+    TlsSessionCacheConfig config2 = TlsSessionCacheConfig.disabled();
+
+    // Should return the same instance
+    assertSame(config1, config2);
+  }
+
+  @Test
+  public void testToString() {
+    TlsSessionCacheConfig config =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(50)
+            .withSessionTimeoutSeconds(1800)
+            .build();
+
+    String str = config.toString();
+    assertTrue(str.contains("enabled=true"));
+    assertTrue(str.contains("sessionCacheSize=50"));
+    assertTrue(str.contains("sessionTimeoutSeconds=1800"));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    TlsSessionCacheConfig config1 =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(100)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    TlsSessionCacheConfig config2 =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(100)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    TlsSessionCacheConfig config3 =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(200)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    assertEquals(config1, config2);
+    assertEquals(config1.hashCode(), config2.hashCode());
+    assertNotEquals(config1, config3);
+  }
+}

--- a/src/test/java/com/scylladb/alternator/TlsSessionResumptionIT.java
+++ b/src/test/java/com/scylladb/alternator/TlsSessionResumptionIT.java
@@ -1,0 +1,411 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+import com.scylladb.alternator.internal.TlsContextFactory;
+import com.scylladb.alternator.routing.ClusterScope;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesRequest;
+
+/**
+ * Integration tests for TLS session ticket support.
+ *
+ * <p>These tests require a running ScyllaDB cluster with Alternator enabled over HTTPS. The tests
+ * verify that TLS session caching is properly configured and improves connection performance.
+ *
+ * <p>Set environment variables to configure:
+ *
+ * <ul>
+ *   <li>ALTERNATOR_HOST: Host address (default: 172.39.0.2)
+ *   <li>ALTERNATOR_PORT: Port number for HTTPS (default: 9999)
+ *   <li>INTEGRATION_TESTS: Set to "true" to enable tests
+ * </ul>
+ */
+public class TlsSessionResumptionIT {
+
+  private static String host;
+  private static int httpsPort;
+  private static URI seedUri;
+  private static boolean integrationTestsEnabled;
+  private static boolean httpsEnabled;
+  private static StaticCredentialsProvider credentialsProvider;
+
+  @BeforeClass
+  public static void setUpClass() {
+    host = System.getenv().getOrDefault("ALTERNATOR_HOST", "172.39.0.2");
+    httpsPort = Integer.parseInt(System.getenv().getOrDefault("ALTERNATOR_HTTPS_PORT", "9999"));
+    httpsEnabled = Boolean.parseBoolean(System.getenv().getOrDefault("ALTERNATOR_HTTPS", "false"));
+
+    try {
+      seedUri = new URI("https://" + host + ":" + httpsPort);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    credentialsProvider =
+        StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test"));
+
+    integrationTestsEnabled =
+        Boolean.parseBoolean(System.getenv().getOrDefault("INTEGRATION_TESTS", "false"));
+  }
+
+  @Before
+  public void setUp() {
+    assumeTrue(
+        "Integration tests disabled. Set INTEGRATION_TESTS=true to enable.",
+        integrationTestsEnabled);
+    assumeTrue("HTTPS tests require ALTERNATOR_HTTPS=true", httpsEnabled);
+  }
+
+  @Test
+  public void testDefaultTlsSessionCacheEnabled() throws Exception {
+    // Create client with default TLS session cache (enabled)
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional over HTTPS
+    List<URI> nodes = wrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify the TLS config is as expected
+    AlternatorConfig config = wrapper.getAlternatorConfig();
+    assertTrue(
+        "TLS session cache should be enabled by default",
+        config.getTlsSessionCacheConfig().isEnabled());
+
+    wrapper.close();
+  }
+
+  @Test
+  public void testTlsSessionCacheWithCustomSettings() throws Exception {
+    // Create client with custom TLS session cache settings
+    TlsSessionCacheConfig tlsConfig =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(200)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsSessionCacheConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional
+    List<URI> nodes = wrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify config was applied
+    AlternatorConfig config = wrapper.getAlternatorConfig();
+    assertEquals(200, config.getTlsSessionCacheConfig().getSessionCacheSize());
+    assertEquals(3600, config.getTlsSessionCacheConfig().getSessionTimeoutSeconds());
+
+    wrapper.close();
+  }
+
+  @Test
+  public void testTlsSessionCacheDisabled() throws Exception {
+    // Create client with TLS session cache disabled
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsSessionCacheConfig(TlsSessionCacheConfig.disabled())
+            .buildWithAlternatorAPI();
+
+    // Verify client is still functional without session caching
+    List<URI> nodes = wrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify config was applied
+    AlternatorConfig config = wrapper.getAlternatorConfig();
+    assertFalse(
+        "TLS session cache should be disabled", config.getTlsSessionCacheConfig().isEnabled());
+
+    wrapper.close();
+  }
+
+  @Test
+  public void testMultipleRequestsBenefitFromSessionCache() throws Exception {
+    // Create client with TLS session cache enabled
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsSessionCacheConfig(TlsSessionCacheConfig.getDefault())
+            .buildWithAlternatorAPI();
+
+    DynamoDbClient client = wrapper.getClient();
+
+    // Perform multiple requests - subsequent requests should benefit from session resumption
+    // Note: We can't directly measure TLS handshake time in this test, but we verify
+    // that multiple requests work correctly with session caching enabled
+    for (int i = 0; i < 10; i++) {
+      try {
+        client.listTables(ListTablesRequest.builder().limit(1).build());
+      } catch (Exception e) {
+        // Ignore errors - we're testing TLS, not DynamoDB operations
+      }
+    }
+
+    // The fact that multiple requests succeeded indicates TLS connections are working
+    List<URI> nodes = wrapper.getLiveNodes();
+    assertFalse("Should still have nodes after multiple requests", nodes.isEmpty());
+
+    wrapper.close();
+  }
+
+  @Test
+  public void testTlsSessionCacheWithCompression() throws Exception {
+    // Test TLS session cache combined with compression
+    TlsSessionCacheConfig tlsConfig =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(100)
+            .withSessionTimeoutSeconds(7200)
+            .build();
+
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsSessionCacheConfig(tlsConfig)
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withMinCompressionSizeBytes(512)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional with both features enabled
+    List<URI> nodes = wrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify both configs are applied
+    AlternatorConfig config = wrapper.getAlternatorConfig();
+    assertTrue(config.getTlsSessionCacheConfig().isEnabled());
+    assertEquals(RequestCompressionAlgorithm.GZIP, config.getCompressionAlgorithm());
+
+    wrapper.close();
+  }
+
+  @Test
+  public void testTlsSessionCacheWithHeadersOptimization() throws Exception {
+    // Test TLS session cache combined with headers optimization
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsSessionCacheConfig(TlsSessionCacheConfig.getDefault())
+            .withOptimizeHeaders(true)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional with both features enabled
+    List<URI> nodes = wrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify both configs are applied
+    AlternatorConfig config = wrapper.getAlternatorConfig();
+    assertTrue(config.getTlsSessionCacheConfig().isEnabled());
+    assertTrue(config.isOptimizeHeaders());
+
+    wrapper.close();
+  }
+
+  @Test
+  public void testTlsSessionCacheWithRoutingScope() throws Exception {
+    // Test TLS session cache combined with routing scope
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsSessionCacheConfig(TlsSessionCacheConfig.getDefault())
+            .withRoutingScope(ClusterScope.create())
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional
+    List<URI> nodes = wrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    wrapper.close();
+  }
+
+  @Test
+  public void testTlsSessionCacheViaAlternatorConfig() throws Exception {
+    // Test setting TLS config via AlternatorConfig
+    TlsSessionCacheConfig tlsConfig =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(150)
+            .withSessionTimeoutSeconds(1800)
+            .build();
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(seedUri)
+            .withRoutingScope(ClusterScope.create())
+            .withTlsSessionCacheConfig(tlsConfig)
+            .build();
+
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withAlternatorConfig(config)
+            .buildWithAlternatorAPI();
+
+    // Verify config was applied
+    AlternatorConfig appliedConfig = wrapper.getAlternatorConfig();
+    assertEquals(150, appliedConfig.getTlsSessionCacheConfig().getSessionCacheSize());
+    assertEquals(1800, appliedConfig.getTlsSessionCacheConfig().getSessionTimeoutSeconds());
+
+    wrapper.close();
+  }
+
+  /**
+   * Tests TLS session caching configuration with actual connections.
+   *
+   * <p>This test verifies that:
+   *
+   * <ol>
+   *   <li>The SSLContext is properly configured with session caching enabled
+   *   <li>Multiple TLS connections can be established successfully
+   *   <li>The client-side session cache is configured correctly
+   * </ol>
+   *
+   * <p><b>Note:</b> Actual session resumption depends on server support for TLS session tickets
+   * (RFC 5077). If the server doesn't support session tickets, each connection will have a unique
+   * session ID even with client-side caching enabled. This test verifies our client configuration
+   * is correct; session reuse is a server-dependent optimization.
+   */
+  @Test
+  public void testTlsSessionCachingWithMultipleConnections() throws Exception {
+    TlsSessionCacheConfig config =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(100)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+    SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+
+    // Verify client-side session cache is configured correctly
+    assertEquals(
+        "Client session cache size should be configured",
+        100,
+        sslContext.getClientSessionContext().getSessionCacheSize());
+    assertEquals(
+        "Client session timeout should be configured",
+        3600,
+        sslContext.getClientSessionContext().getSessionTimeout());
+
+    Set<String> sessionIds = new HashSet<>();
+    int successfulConnections = 0;
+
+    // Make multiple connections to the same server
+    for (int i = 0; i < 5; i++) {
+      SSLSocket socket = null;
+      try {
+        socket = (SSLSocket) socketFactory.createSocket(host, httpsPort);
+        socket.startHandshake();
+
+        SSLSession session = socket.getSession();
+        assertTrue("SSL session should be valid", session.isValid());
+
+        byte[] currentSessionId = session.getId();
+        if (currentSessionId != null && currentSessionId.length > 0) {
+          sessionIds.add(bytesToHex(currentSessionId));
+        }
+        successfulConnections++;
+      } finally {
+        if (socket != null) {
+          socket.close();
+        }
+      }
+    }
+
+    assertEquals("All connections should succeed", 5, successfulConnections);
+
+    // Log session reuse information (informational, not assertive)
+    // Session reuse depends on server support for TLS session tickets
+    System.out.println(
+        "TLS Session caching test: "
+            + sessionIds.size()
+            + " unique sessions out of "
+            + successfulConnections
+            + " connections. "
+            + (sessionIds.size() < successfulConnections
+                ? "Session reuse detected!"
+                : "Server may not support TLS session tickets."));
+  }
+
+  /**
+   * Tests that TLS sessions are NOT reused when session caching is disabled.
+   *
+   * <p>With session caching disabled (cache size 0), each connection should perform a full TLS
+   * handshake and get a new session.
+   */
+  @Test
+  public void testTlsSessionNotReusedWhenDisabled() throws Exception {
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.disabled();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+    SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+
+    Set<String> sessionIds = new HashSet<>();
+
+    // Make multiple connections to the same server
+    for (int i = 0; i < 3; i++) {
+      SSLSocket socket = null;
+      try {
+        socket = (SSLSocket) socketFactory.createSocket(host, httpsPort);
+        socket.startHandshake();
+
+        SSLSession session = socket.getSession();
+        byte[] sessionId = session.getId();
+
+        if (sessionId != null && sessionId.length > 0) {
+          sessionIds.add(bytesToHex(sessionId));
+        }
+      } finally {
+        if (socket != null) {
+          socket.close();
+        }
+      }
+    }
+
+    // With session caching disabled, we expect each connection to have a different session
+    // Note: Some servers might not support session tickets, so we allow for some reuse
+    // The main point is that with cache size 0, the client won't cache sessions
+    System.out.println(
+        "Session caching disabled - unique session IDs: "
+            + sessionIds.size()
+            + " out of 3 connections");
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder();
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+}

--- a/src/test/java/com/scylladb/alternator/TlsSessionResumptionTest.java
+++ b/src/test/java/com/scylladb/alternator/TlsSessionResumptionTest.java
@@ -1,0 +1,159 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import com.scylladb.alternator.internal.TlsContextFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSessionContext;
+import org.junit.Test;
+
+/**
+ * Unit tests for TLS session resumption support.
+ *
+ * <p>These tests verify that the SSLContext is properly configured to support TLS session tickets
+ * and session resumption, which enables faster TLS renegotiation when reconnecting to nodes.
+ *
+ * @author dmitry.kropachev
+ */
+public class TlsSessionResumptionTest {
+
+  @Test
+  public void testSslContextWithDefaultConfig() {
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.getDefault();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    assertNotNull("SSLContext should not be null", sslContext);
+    // Should use TLSv1.3 (preferred) or TLS as fallback
+    assertTrue(
+        "Should use TLS protocol (TLSv1.3 or TLS)", sslContext.getProtocol().startsWith("TLS"));
+  }
+
+  @Test
+  public void testSslContextSessionCacheEnabled() {
+    TlsSessionCacheConfig config =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(200)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+    SSLSessionContext clientSessionContext = sslContext.getClientSessionContext();
+
+    assertNotNull("Client session context should not be null", clientSessionContext);
+    assertEquals(
+        "Session cache size should match config", 200, clientSessionContext.getSessionCacheSize());
+    assertEquals(
+        "Session timeout should match config", 3600, clientSessionContext.getSessionTimeout());
+  }
+
+  @Test
+  public void testSslContextSessionCacheDisabled() {
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.disabled();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    SSLSessionContext clientSessionContext = sslContext.getClientSessionContext();
+    assertNotNull("Client session context should not be null", clientSessionContext);
+    // When disabled, cache size should be 0
+    assertEquals(
+        "Session cache size should be 0 when disabled",
+        0,
+        clientSessionContext.getSessionCacheSize());
+  }
+
+  @Test
+  public void testSslContextWithCustomCacheSize() {
+    TlsSessionCacheConfig config =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(500)
+            .withSessionTimeoutSeconds(7200)
+            .build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+    SSLSessionContext clientSessionContext = sslContext.getClientSessionContext();
+
+    assertEquals(500, clientSessionContext.getSessionCacheSize());
+    assertEquals(7200, clientSessionContext.getSessionTimeout());
+  }
+
+  @Test
+  public void testSslContextTrustAllCertificates() {
+    // This test verifies that the SSL context accepts all certificates
+    // (trust-all behavior for development/testing)
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.getDefault();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    // The SSL context should be properly initialized
+    assertNotNull(sslContext.getSocketFactory());
+  }
+
+  @Test
+  public void testModernTlsProtocol() {
+    // Verify we're using modern TLS, not the deprecated "SSL" protocol
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.getDefault();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    String protocol = sslContext.getProtocol();
+    // Should be TLS (which allows TLS 1.2 and 1.3), not the legacy "SSL"
+    assertTrue(
+        "Should use modern TLS protocol, not legacy SSL",
+        protocol.startsWith("TLS") || protocol.equals("Default"));
+  }
+
+  @Test
+  public void testMultipleSslContextsShareConfig() {
+    // Creating multiple SSL contexts with the same config should work
+    TlsSessionCacheConfig config =
+        TlsSessionCacheConfig.builder()
+            .withEnabled(true)
+            .withSessionCacheSize(100)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    SSLContext context1 = TlsContextFactory.createSslContext(config);
+    SSLContext context2 = TlsContextFactory.createSslContext(config);
+
+    assertNotNull(context1);
+    assertNotNull(context2);
+    // They should be different instances
+    assertNotSame(context1, context2);
+    // But have the same configuration
+    assertEquals(
+        context1.getClientSessionContext().getSessionCacheSize(),
+        context2.getClientSessionContext().getSessionCacheSize());
+  }
+
+  @Test
+  public void testSessionContextConfiguredForReuse() {
+    // This test verifies that the SSLSessionContext is properly configured
+    // to allow session reuse (non-zero cache size and timeout)
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.getDefault();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    SSLSessionContext clientContext = sslContext.getClientSessionContext();
+
+    // For session reuse to work, cache size must be > 0
+    assertTrue(
+        "Session cache size must be positive for session reuse",
+        clientContext.getSessionCacheSize() > 0);
+
+    // Session timeout must be > 0 for sessions to be valid
+    assertTrue(
+        "Session timeout must be positive for session reuse",
+        clientContext.getSessionTimeout() > 0);
+  }
+
+  @Test
+  public void testDisabledConfigPreventsSessionReuse() {
+    // When disabled, cache size should be 0, preventing session reuse
+    TlsSessionCacheConfig config = TlsSessionCacheConfig.disabled();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    SSLSessionContext clientContext = sslContext.getClientSessionContext();
+
+    // Cache size of 0 means no sessions will be cached
+    assertEquals(
+        "Session cache size should be 0 when disabled", 0, clientContext.getSessionCacheSize());
+  }
+}


### PR DESCRIPTION
## Summary

- Add `TlsSessionCacheConfig` class for configuring TLS session caching (RFC 5077)
- Add `TlsContextFactory` for creating SSLContext with TLS 1.3 session ticket support
- Update `AlternatorLiveNodes` to use modern TLS protocol instead of legacy "SSL"
- Add `withTlsSessionCacheConfig()` and `withAlternatorConfig()` methods to client builders
- Add `getAlternatorConfig()` to client wrappers for runtime config inspection
- Upgrade minimum Java version from 8 to 11 for TLS 1.3 support
- Default session cache: 1024 sessions, 24h timeout

## Server Configuration

TLS session tickets require server-side support. In ScyllaDB, add to `scylla.yaml`:

```yaml
alternator_encryption_options:
    certificate: /path/to/scylla.crt
    keyfile: /path/to/scylla.key
    enable_session_tickets: true
```

## Usage

```java
// Default (enabled)
DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(URI.create("https://localhost:8043"))
    .credentialsProvider(credentials)
    .build();

// Custom configuration
DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(URI.create("https://localhost:8043"))
    .credentialsProvider(credentials)
    .withTlsSessionCacheConfig(TlsSessionCacheConfig.builder()
        .withSessionCacheSize(2048)
        .withSessionTimeoutSeconds(3600)
        .build())
    .build();

// Disabled
DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(URI.create("https://localhost:8043"))
    .credentialsProvider(credentials)
    .withTlsSessionCacheConfig(TlsSessionCacheConfig.disabled())
    .build();
```

## Test plan

- [x] Unit tests for `TlsSessionCacheConfig` (12 tests)
- [x] Unit tests for `TlsSessionResumptionTest` (9 tests)
- [x] Unit tests for `AlternatorConfigTlsTest` (6 tests)
- [x] Integration tests for HTTPS connections (`TlsSessionResumptionIT`)
- [x] All existing tests pass (176 total)

Closes #9