### PR TITLE
Add KeyRouteAffinity for LWT performance optimization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb-enhanced</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
@@ -142,7 +142,14 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
     return config;
   }
 
-  /** Closes the underlying DynamoDbAsyncClient. */
+  /**
+   * Closes the underlying DynamoDbAsyncClient.
+   *
+   * <p>Note: Unlike {@link AlternatorDynamoDbClientWrapper#close()}, this method does not need to
+   * shut down a PartitionKeyResolver because key route affinity is not supported for async clients.
+   * The async client builder rejects key affinity configuration at build time since it relies on
+   * ThreadLocal context passing which doesn't work with async/reactive patterns.
+   */
   @Override
   public void close() {
     client.close();

--- a/src/main/java/com/scylladb/alternator/AlternatorEndpointProvider.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorEndpointProvider.java
@@ -1,6 +1,7 @@
 package com.scylladb.alternator;
 
 import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.keyrouting.KeyRouteAffinityContext;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +39,12 @@ public class AlternatorEndpointProvider implements DynamoDbEndpointProvider {
   /** {@inheritDoc} */
   @Override
   public CompletableFuture<Endpoint> resolveEndpoint(DynamoDbEndpointParams endpointParams) {
-    URI uri = liveNodes.nextAsURI();
+    // Check if key route affinity has set a target node
+    URI uri = KeyRouteAffinityContext.getTargetNode();
+    if (uri == null) {
+      // Fall back to round-robin selection
+      uri = liveNodes.nextAsURI();
+    }
     CompletableFuture<Endpoint> endpoint = futureCache.getOrDefault(uri, null);
     if (endpoint != null) {
       return endpoint;

--- a/src/main/java/com/scylladb/alternator/keyrouting/AttributeValueHasher.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/AttributeValueHasher.java
@@ -1,0 +1,219 @@
+package com.scylladb.alternator.keyrouting;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Hashes DynamoDB AttributeValue objects using MurmurHash3.
+ *
+ * <p>Supports all DynamoDB attribute types:
+ *
+ * <ul>
+ *   <li>S (String) - UTF-8 bytes hashed directly
+ *   <li>N (Number) - String representation hashed
+ *   <li>B (Binary) - Raw bytes hashed
+ *   <li>BOOL (Boolean) - 1 or 0 byte
+ *   <li>NULL - 1 or 0 byte
+ *   <li>SS (String Set) - Strings sorted lexicographically, then concatenated and hashed
+ *   <li>NS (Number Set) - Number strings sorted lexicographically, then concatenated and hashed
+ *   <li>BS (Binary Set) - Binary values sorted by unsigned byte comparison, then concatenated and
+ *       hashed
+ *   <li>L (List) - Each element hashed recursively in order
+ *   <li>M (Map) - Keys sorted lexicographically, then key-value pairs hashed recursively
+ * </ul>
+ *
+ * <p>Sets are sorted before hashing to ensure deterministic results, since DynamoDB sets are
+ * unordered collections and iteration order is not guaranteed.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public final class AttributeValueHasher {
+
+  private AttributeValueHasher() {}
+
+  /**
+   * Computes a hash for a DynamoDB AttributeValue.
+   *
+   * @param value the attribute value to hash
+   * @return the hash value
+   * @throws IllegalArgumentException if the attribute value type is not supported
+   */
+  public static long hash(AttributeValue value) {
+    if (value == null) {
+      return 0L;
+    }
+
+    byte[] data = toBytes(value);
+    return MurmurHash3.hash(data);
+  }
+
+  /**
+   * Converts an AttributeValue to bytes for hashing.
+   *
+   * @param value the attribute value
+   * @return the byte representation
+   */
+  private static byte[] toBytes(AttributeValue value) {
+    // String
+    if (value.s() != null) {
+      return value.s().getBytes(StandardCharsets.UTF_8);
+    }
+
+    // Number (stored as string)
+    if (value.n() != null) {
+      return value.n().getBytes(StandardCharsets.UTF_8);
+    }
+
+    // Binary
+    if (value.b() != null) {
+      return value.b().asByteArray();
+    }
+
+    // Boolean
+    if (value.bool() != null) {
+      return new byte[] {(byte) (value.bool() ? 1 : 0)};
+    }
+
+    // Null
+    if (value.nul() != null) {
+      return new byte[] {(byte) (value.nul() ? 1 : 0)};
+    }
+
+    // String Set
+    if (value.hasSs() && value.ss() != null) {
+      return hashStringCollection(value.ss());
+    }
+
+    // Number Set
+    if (value.hasNs() && value.ns() != null) {
+      return hashStringCollection(value.ns());
+    }
+
+    // Binary Set
+    if (value.hasBs() && value.bs() != null) {
+      return hashBinaryCollection(value.bs());
+    }
+
+    // List
+    if (value.hasL() && value.l() != null) {
+      return hashList(value.l());
+    }
+
+    // Map
+    if (value.hasM() && value.m() != null) {
+      return hashMap(value.m());
+    }
+
+    throw new IllegalArgumentException("Unsupported AttributeValue type");
+  }
+
+  private static byte[] hashStringCollection(List<String> values) {
+    // Sort strings lexicographically for deterministic hashing
+    // (DynamoDB sets are unordered, so iteration order is not guaranteed)
+    List<String> sorted = new ArrayList<>(values);
+    Collections.sort(sorted);
+
+    // Concatenate all string bytes
+    int totalLength = 0;
+    List<byte[]> bytesList = new ArrayList<>();
+    for (String s : sorted) {
+      byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+      bytesList.add(bytes);
+      totalLength += bytes.length;
+    }
+
+    byte[] result = new byte[totalLength];
+    int offset = 0;
+    for (byte[] bytes : bytesList) {
+      System.arraycopy(bytes, 0, result, offset, bytes.length);
+      offset += bytes.length;
+    }
+    return result;
+  }
+
+  private static byte[] hashBinaryCollection(List<SdkBytes> values) {
+    // Sort binary values for deterministic hashing
+    // (DynamoDB sets are unordered, so iteration order is not guaranteed)
+    List<byte[]> byteArrays = new ArrayList<>();
+    for (SdkBytes b : values) {
+      byteArrays.add(b.asByteArray());
+    }
+    Collections.sort(byteArrays, BYTE_ARRAY_COMPARATOR);
+
+    int totalLength = 0;
+    for (byte[] bytes : byteArrays) {
+      totalLength += bytes.length;
+    }
+
+    byte[] result = new byte[totalLength];
+    int offset = 0;
+    for (byte[] bytes : byteArrays) {
+      System.arraycopy(bytes, 0, result, offset, bytes.length);
+      offset += bytes.length;
+    }
+    return result;
+  }
+
+  /** Comparator for sorting byte arrays lexicographically (unsigned byte comparison). */
+  private static final Comparator<byte[]> BYTE_ARRAY_COMPARATOR =
+      (a, b) -> {
+        int minLength = Math.min(a.length, b.length);
+        for (int i = 0; i < minLength; i++) {
+          int cmp = (a[i] & 0xff) - (b[i] & 0xff);
+          if (cmp != 0) {
+            return cmp;
+          }
+        }
+        return a.length - b.length;
+      };
+
+  private static byte[] hashList(List<AttributeValue> values) {
+    // Recursively hash each element and concatenate
+    int totalLength = 0;
+    List<byte[]> bytesList = new ArrayList<>();
+    for (AttributeValue v : values) {
+      byte[] bytes = toBytes(v);
+      bytesList.add(bytes);
+      totalLength += bytes.length;
+    }
+
+    byte[] result = new byte[totalLength];
+    int offset = 0;
+    for (byte[] bytes : bytesList) {
+      System.arraycopy(bytes, 0, result, offset, bytes.length);
+      offset += bytes.length;
+    }
+    return result;
+  }
+
+  private static byte[] hashMap(Map<String, AttributeValue> map) {
+    // Sort keys lexicographically, then hash key-value pairs
+    List<String> keys = new ArrayList<>(map.keySet());
+    Collections.sort(keys);
+
+    int totalLength = 0;
+    List<byte[]> bytesList = new ArrayList<>();
+    for (String key : keys) {
+      byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+      byte[] valueBytes = toBytes(map.get(key));
+      bytesList.add(keyBytes);
+      bytesList.add(valueBytes);
+      totalLength += keyBytes.length + valueBytes.length;
+    }
+
+    byte[] result = new byte[totalLength];
+    int offset = 0;
+    for (byte[] bytes : bytesList) {
+      System.arraycopy(bytes, 0, result, offset, bytes.length);
+      offset += bytes.length;
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
@@ -1,0 +1,196 @@
+package com.scylladb.alternator.keyrouting;
+
+import java.util.Map;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * Determines if a DynamoDB request qualifies for key route affinity.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public final class KeyAffinityRequestClassifier {
+
+  private KeyAffinityRequestClassifier() {}
+
+  /**
+   * Returns true if the request should use route affinity based on mode.
+   *
+   * @param mode the route affinity mode
+   * @param request the DynamoDB request
+   * @return true if route affinity should be applied
+   */
+  public static boolean shouldApply(KeyRouteAffinity mode, SdkRequest request) {
+    if (mode == KeyRouteAffinity.NONE) {
+      return false;
+    }
+
+    if (request instanceof UpdateItemRequest) {
+      return shouldApplyUpdateItem(mode, (UpdateItemRequest) request);
+    }
+    if (request instanceof PutItemRequest) {
+      return shouldApplyPutItem(mode, (PutItemRequest) request);
+    }
+    if (request instanceof DeleteItemRequest) {
+      return shouldApplyDeleteItem(mode, (DeleteItemRequest) request);
+    }
+    // Note: BatchWriteItemRequest is intentionally not supported for key route affinity.
+    // It can contain items for multiple tables with different partition keys, making it
+    // impossible to route deterministically to a single node. These requests will use
+    // the default round-robin routing.
+
+    // Read operations and unsupported operations don't qualify
+    return false;
+  }
+
+  private static boolean shouldApplyUpdateItem(KeyRouteAffinity mode, UpdateItemRequest request) {
+    if (mode == KeyRouteAffinity.ANY_WRITE) {
+      return true;
+    }
+    // RMW mode: trigger for conditional operations or read-before-write
+
+    // UpdateExpression operations are LWT-based in Alternator
+    if (request.updateExpression() != null && !request.updateExpression().isEmpty()) {
+      return true;
+    }
+    if (request.conditionExpression() != null && !request.conditionExpression().isEmpty()) {
+      return true;
+    }
+    if (request.hasExpected() && !request.expected().isEmpty()) {
+      return true;
+    }
+    // Check return values that require reading the item's current state:
+    // - ALL_OLD: returns entire item before update (requires read)
+    // - UPDATED_OLD: returns only updated attributes before update (requires read)
+    // - ALL_NEW: returns entire item after update, including non-updated attributes (requires read)
+    // - UPDATED_NEW: returns only the updated attributes after update, which can be computed
+    //   directly from the update expression without reading the current item state
+    ReturnValue rv = request.returnValues();
+    if (rv == ReturnValue.ALL_OLD || rv == ReturnValue.UPDATED_OLD || rv == ReturnValue.ALL_NEW) {
+      return true;
+    }
+    // Check for ADD action or DELETE action with value in legacy AttributeUpdates
+    if (request.hasAttributeUpdates()) {
+      for (AttributeValueUpdate update : request.attributeUpdates().values()) {
+        if (update.action() == AttributeAction.ADD) {
+          return true;
+        }
+        if (update.action() == AttributeAction.DELETE && update.value() != null) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean shouldApplyPutItem(KeyRouteAffinity mode, PutItemRequest request) {
+    if (mode == KeyRouteAffinity.ANY_WRITE) {
+      return true;
+    }
+    // RMW mode: check for conditions
+    if (request.conditionExpression() != null && !request.conditionExpression().isEmpty()) {
+      return true;
+    }
+    if (request.hasExpected() && !request.expected().isEmpty()) {
+      return true;
+    }
+    if (request.returnValues() != null && request.returnValues() != ReturnValue.NONE) {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean shouldApplyDeleteItem(KeyRouteAffinity mode, DeleteItemRequest request) {
+    if (mode == KeyRouteAffinity.ANY_WRITE) {
+      return true;
+    }
+    // RMW mode: check for conditions
+    if (request.conditionExpression() != null && !request.conditionExpression().isEmpty()) {
+      return true;
+    }
+    if (request.hasExpected() && !request.expected().isEmpty()) {
+      return true;
+    }
+    if (request.returnValues() != null && request.returnValues() != ReturnValue.NONE) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Extracts the table name from a DynamoDB request.
+   *
+   * <p>Note: This method handles more request types than {@link #shouldApply} for completeness and
+   * potential future use. For example, QueryRequest is handled here even though shouldApply returns
+   * false for Query operations, because:
+   *
+   * <ul>
+   *   <li>Query operations don't benefit from key affinity (they read from replicas)
+   *   <li>Query may return results from multiple partition keys, making single-node routing
+   *       meaningless
+   *   <li>Having extractTableName support Query enables future extensions or diagnostic use
+   * </ul>
+   *
+   * @param request the DynamoDB request
+   * @return the table name, or null if not applicable
+   */
+  public static String extractTableName(SdkRequest request) {
+    if (request instanceof UpdateItemRequest) {
+      return ((UpdateItemRequest) request).tableName();
+    }
+    if (request instanceof PutItemRequest) {
+      return ((PutItemRequest) request).tableName();
+    }
+    if (request instanceof DeleteItemRequest) {
+      return ((DeleteItemRequest) request).tableName();
+    }
+    if (request instanceof GetItemRequest) {
+      return ((GetItemRequest) request).tableName();
+    }
+    // Note: QueryRequest is included for completeness, though shouldApply returns false for Query.
+    // See method Javadoc for rationale.
+    if (request instanceof QueryRequest) {
+      return ((QueryRequest) request).tableName();
+    }
+    // BatchWriteItem can contain items for multiple tables.
+    // Key route affinity for BatchWriteItem is not implemented - would require either:
+    // 1. Single-table batches only (limiting functionality)
+    // 2. Splitting batches by partition key (complex, changes semantics)
+    return null;
+  }
+
+  /**
+   * Extracts the partition key value from a DynamoDB request.
+   *
+   * @param request the DynamoDB request
+   * @param pkAttributeName the partition key attribute name
+   * @return the partition key value, or null if not found
+   */
+  public static AttributeValue extractPartitionKey(SdkRequest request, String pkAttributeName) {
+    Map<String, AttributeValue> key = null;
+
+    if (request instanceof UpdateItemRequest) {
+      key = ((UpdateItemRequest) request).key();
+    } else if (request instanceof PutItemRequest) {
+      key = ((PutItemRequest) request).item();
+    } else if (request instanceof DeleteItemRequest) {
+      key = ((DeleteItemRequest) request).key();
+    } else if (request instanceof GetItemRequest) {
+      key = ((GetItemRequest) request).key();
+    }
+
+    if (key != null && pkAttributeName != null) {
+      return key.get(pkAttributeName);
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinity.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinity.java
@@ -1,0 +1,42 @@
+package com.scylladb.alternator.keyrouting;
+
+/**
+ * Specifies the type of operations that should use key-based route affinity.
+ *
+ * <p>Key route affinity ensures that all requests for the same partition key are routed to the same
+ * Alternator node, which improves performance for Lightweight Transactions (LWT) that use Paxos
+ * consensus.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public enum KeyRouteAffinity {
+  /**
+   * No route affinity optimization - use random load balancing for all requests. This is the
+   * default behavior.
+   */
+  NONE,
+
+  /**
+   * Optimize only read-before-write (RMW) operations.
+   *
+   * <p>This includes:
+   *
+   * <ul>
+   *   <li>UpdateItem with ConditionExpression, Expected, or non-NONE ReturnValues
+   *   <li>PutItem with ConditionExpression, Expected, or non-NONE ReturnValues
+   *   <li>DeleteItem with ConditionExpression, Expected, or non-NONE ReturnValues
+   * </ul>
+   *
+   * <p>Note: BatchWriteItem is intentionally excluded because it does not support conditional
+   * expressions and would require single-table batch handling for proper affinity routing.
+   */
+  RMW,
+
+  /**
+   * Optimize all write operations regardless of conditions.
+   *
+   * <p>This includes all PutItem, UpdateItem, DeleteItem, and BatchWriteItem requests.
+   */
+  ANY_WRITE
+}

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityConfig.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityConfig.java
@@ -1,0 +1,141 @@
+package com.scylladb.alternator.keyrouting;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration for key-based route affinity.
+ *
+ * <p>This class holds the affinity type and optional pre-configured partition key information per
+ * table. If partition key info is not provided for a table, it will be discovered automatically via
+ * DescribeTable.
+ *
+ * <p><strong>Important:</strong> Key route affinity only works reliably with synchronous DynamoDB
+ * clients ({@link software.amazon.awssdk.services.dynamodb.DynamoDbClient}). With async clients,
+ * the ThreadLocal-based context passing mechanism may fail due to cross-thread execution. Do not
+ * use key route affinity with {@link software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * KeyRouteAffinityConfig config = KeyRouteAffinityConfig.builder()
+ *     .withType(KeyRouteAffinity.RMW)
+ *     .withPkInfo("users", "user_id")
+ *     .withPkInfo("orders", "order_id")
+ *     .build();
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public class KeyRouteAffinityConfig {
+  private final KeyRouteAffinity type;
+  private final Map<String, String> pkInfoPerTable;
+
+  private KeyRouteAffinityConfig(KeyRouteAffinity type, Map<String, String> pkInfoPerTable) {
+    this.type = type != null ? type : KeyRouteAffinity.NONE;
+    this.pkInfoPerTable = Collections.unmodifiableMap(new HashMap<>(pkInfoPerTable));
+  }
+
+  /**
+   * Returns the route affinity type.
+   *
+   * @return the affinity type, never null
+   */
+  public KeyRouteAffinity getType() {
+    return type;
+  }
+
+  /**
+   * Returns the pre-configured partition key info per table.
+   *
+   * @return unmodifiable map of table name to partition key attribute name
+   */
+  public Map<String, String> getPkInfoPerTable() {
+    return pkInfoPerTable;
+  }
+
+  /**
+   * Checks if route affinity is enabled (type is not NONE).
+   *
+   * @return true if route affinity is enabled
+   */
+  public boolean isEnabled() {
+    return type != KeyRouteAffinity.NONE;
+  }
+
+  /**
+   * Creates a new builder for KeyRouteAffinityConfig.
+   *
+   * @return a new builder instance
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Creates a config with the specified type and no pre-configured PK info.
+   *
+   * @param type the route affinity type
+   * @return a new config instance
+   */
+  public static KeyRouteAffinityConfig of(KeyRouteAffinity type) {
+    return new KeyRouteAffinityConfig(type, Collections.<String, String>emptyMap());
+  }
+
+  /** Builder for {@link KeyRouteAffinityConfig}. */
+  public static class Builder {
+    private KeyRouteAffinity type = KeyRouteAffinity.NONE;
+    private final Map<String, String> pkInfoPerTable = new HashMap<>();
+
+    Builder() {}
+
+    /**
+     * Sets the route affinity type.
+     *
+     * @param type the affinity type
+     * @return this builder
+     */
+    public Builder withType(KeyRouteAffinity type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
+     * Adds partition key info for a table.
+     *
+     * @param tableName the table name
+     * @param pkAttributeName the partition key attribute name
+     * @return this builder
+     */
+    public Builder withPkInfo(String tableName, String pkAttributeName) {
+      if (tableName != null && pkAttributeName != null) {
+        pkInfoPerTable.put(tableName, pkAttributeName);
+      }
+      return this;
+    }
+
+    /**
+     * Adds partition key info for multiple tables.
+     *
+     * @param pkInfo map of table name to partition key attribute name
+     * @return this builder
+     */
+    public Builder withPkInfoMap(Map<String, String> pkInfo) {
+      if (pkInfo != null) {
+        pkInfoPerTable.putAll(pkInfo);
+      }
+      return this;
+    }
+
+    /**
+     * Builds the configuration.
+     *
+     * @return a new KeyRouteAffinityConfig instance
+     */
+    public KeyRouteAffinityConfig build() {
+      return new KeyRouteAffinityConfig(type, pkInfoPerTable);
+    }
+  }
+}

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityContext.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityContext.java
@@ -1,0 +1,66 @@
+package com.scylladb.alternator.keyrouting;
+
+import java.net.URI;
+
+/**
+ * Thread-local context for passing key route affinity decisions to the endpoint provider.
+ *
+ * <p>This class provides a mechanism for the {@link KeyRouteAffinityInterceptor} to communicate the
+ * target node URI to the {@link com.scylladb.alternator.AlternatorEndpointProvider} during request
+ * execution.
+ *
+ * <p>The context uses a ThreadLocal to store the target URI, which is set by the interceptor before
+ * endpoint resolution and cleared after the request completes.
+ *
+ * <p><strong>Important:</strong> This ThreadLocal-based approach only works reliably with
+ * synchronous clients ({@link software.amazon.awssdk.services.dynamodb.DynamoDbClient}). With async
+ * clients ({@link software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient}), the interceptor's
+ * {@code beforeExecution} may run on a different thread than the endpoint provider's {@code
+ * resolveEndpoint}, causing the ThreadLocal value to be null. Key route affinity should only be
+ * used with synchronous DynamoDB clients.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public final class KeyRouteAffinityContext {
+
+  private static final ThreadLocal<URI> targetNode = new ThreadLocal<>();
+
+  private KeyRouteAffinityContext() {}
+
+  /**
+   * Sets the target node URI for the current request.
+   *
+   * @param uri the target node URI, or null to clear
+   */
+  public static void setTargetNode(URI uri) {
+    if (uri == null) {
+      targetNode.remove();
+    } else {
+      targetNode.set(uri);
+    }
+  }
+
+  /**
+   * Gets the target node URI for the current request.
+   *
+   * @return the target node URI, or null if not set
+   */
+  public static URI getTargetNode() {
+    return targetNode.get();
+  }
+
+  /** Clears the target node URI for the current thread. */
+  public static void clear() {
+    targetNode.remove();
+  }
+
+  /**
+   * Checks if a target node has been set for the current request.
+   *
+   * @return true if a target node is set
+   */
+  public static boolean hasTargetNode() {
+    return targetNode.get() != null;
+  }
+}

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityInterceptor.java
@@ -1,0 +1,150 @@
+package com.scylladb.alternator.keyrouting;
+
+import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.internal.LazyQueryPlan;
+import java.net.URI;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Execution interceptor that implements key-based route affinity.
+ *
+ * <p>This interceptor examines DynamoDB requests before execution, extracts the partition key when
+ * applicable, hashes it, and selects a target node deterministically. The target node is stored in
+ * {@link KeyRouteAffinityContext} for the endpoint provider to use.
+ *
+ * <p>The interceptor is automatically configured when key route affinity is enabled via {@link
+ * com.scylladb.alternator.AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder#withKeyRouteAffinity}.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public class KeyRouteAffinityInterceptor implements ExecutionInterceptor {
+
+  private final KeyRouteAffinityConfig config;
+  private final AlternatorLiveNodes liveNodes;
+  private final PartitionKeyResolver pkResolver;
+  private volatile DynamoDbClient clientForDiscovery;
+
+  /**
+   * Creates a new interceptor with the given configuration and live nodes.
+   *
+   * @param config the key route affinity configuration
+   * @param liveNodes the live nodes manager
+   * @param clientForDiscovery the DynamoDB client to use for PK discovery (may be null)
+   */
+  public KeyRouteAffinityInterceptor(
+      KeyRouteAffinityConfig config,
+      AlternatorLiveNodes liveNodes,
+      DynamoDbClient clientForDiscovery) {
+    this.config = config;
+    this.liveNodes = liveNodes;
+    this.pkResolver = new PartitionKeyResolver(config.getPkInfoPerTable());
+    this.clientForDiscovery = clientForDiscovery;
+  }
+
+  /**
+   * Creates a new interceptor without auto-discovery support.
+   *
+   * <p>Note: To enable auto-discovery, call {@link #setClientForDiscovery(DynamoDbClient)} after
+   * the client is built.
+   *
+   * @param config the key route affinity configuration
+   * @param liveNodes the live nodes manager
+   */
+  public KeyRouteAffinityInterceptor(KeyRouteAffinityConfig config, AlternatorLiveNodes liveNodes) {
+    this(config, liveNodes, null);
+  }
+
+  /**
+   * Sets the DynamoDB client used for partition key auto-discovery.
+   *
+   * <p>This method should be called after the client is built to enable auto-discovery of partition
+   * key names for tables not pre-configured via {@link
+   * KeyRouteAffinityConfig.Builder#withPkInfo(String, String)}.
+   *
+   * <p>Thread-safe: This method can be called from any thread after construction.
+   *
+   * @param client the DynamoDB client to use for DescribeTable calls
+   */
+  public void setClientForDiscovery(DynamoDbClient client) {
+    this.clientForDiscovery = client;
+  }
+
+  @Override
+  public void beforeExecution(
+      Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
+    // Clear any previous context
+    KeyRouteAffinityContext.clear();
+
+    if (!config.isEnabled()) {
+      return;
+    }
+
+    SdkRequest request = context.request();
+
+    // Check if this request qualifies for key affinity
+    if (!KeyAffinityRequestClassifier.shouldApply(config.getType(), request)) {
+      return;
+    }
+
+    // Extract table name
+    String tableName = KeyAffinityRequestClassifier.extractTableName(request);
+    if (tableName == null) {
+      return;
+    }
+
+    // Get partition key name
+    String pkName = pkResolver.getPartitionKeyName(tableName);
+    if (pkName == null) {
+      // Trigger async discovery if we have a client
+      if (clientForDiscovery != null) {
+        pkResolver.triggerDiscovery(tableName, clientForDiscovery);
+      }
+      // Fall back to random routing for this request
+      return;
+    }
+
+    // Extract partition key value
+    AttributeValue pkValue = KeyAffinityRequestClassifier.extractPartitionKey(request, pkName);
+    if (pkValue == null) {
+      return;
+    }
+
+    // Hash the partition key and select a node
+    long hash = AttributeValueHasher.hash(pkValue);
+    LazyQueryPlan plan = liveNodes.newQueryPlan(hash);
+
+    if (plan.hasNext()) {
+      URI targetUri = plan.next();
+      KeyRouteAffinityContext.setTargetNode(targetUri);
+    }
+  }
+
+  @Override
+  public void afterExecution(
+      Context.AfterExecution context, ExecutionAttributes executionAttributes) {
+    // Clean up the context
+    KeyRouteAffinityContext.clear();
+  }
+
+  @Override
+  public void onExecutionFailure(
+      Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+    // Clean up the context on failure as well
+    KeyRouteAffinityContext.clear();
+  }
+
+  /**
+   * Returns the partition key resolver used by this interceptor.
+   *
+   * @return the partition key resolver
+   */
+  public PartitionKeyResolver getPartitionKeyResolver() {
+    return pkResolver;
+  }
+}

--- a/src/main/java/com/scylladb/alternator/keyrouting/MurmurHash3.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/MurmurHash3.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Content before git sha 34fdeebefcbf183ed7f916f931aa0586fdaa1b40
+ * Copyright (c) 2016, The Gocql authors,
+ * provided under the BSD-3-Clause License.
+ * See the NOTICE file distributed with this work for additional information.
+ */
+
+package com.scylladb.alternator.keyrouting;
+
+/**
+ * MurmurHash3 x64 128-bit implementation returning the first 64 bits.
+ *
+ * <p>This implementation is used to hash partition keys for deterministic node routing. It produces
+ * the same hash values as the Go implementation for compatibility with other Alternator clients.
+ *
+ * <p>Based on the original MurmurHash3 algorithm by Austin Appleby and the gocql implementation
+ * (Apache 2.0 / BSD-3-Clause licensed).
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public final class MurmurHash3 {
+
+  private static final long C1 = 0x87c37b91114253d5L;
+  private static final long C2 = 0x4cf5ad432745937fL;
+  private static final long FMIX1 = 0xff51afd7ed558ccdL;
+  private static final long FMIX2 = 0xc4ceb9fe1a85ec53L;
+
+  private MurmurHash3() {}
+
+  /**
+   * Computes MurmurHash3 x64 128-bit hash and returns the first 64 bits (h1).
+   *
+   * @param data the data to hash
+   * @return the hash value (first 64 bits of 128-bit hash)
+   */
+  public static long hash(byte[] data) {
+    return hash(data, 0, data.length);
+  }
+
+  /**
+   * Computes MurmurHash3 x64 128-bit hash and returns the first 64 bits (h1).
+   *
+   * @param data the data to hash
+   * @param offset the starting offset in data
+   * @param length the number of bytes to hash
+   * @return the hash value (first 64 bits of 128-bit hash)
+   */
+  public static long hash(byte[] data, int offset, int length) {
+    long h1 = 0;
+    long h2 = 0;
+
+    // body - process 16-byte blocks
+    int nBlocks = length / 16;
+    for (int i = 0; i < nBlocks; i++) {
+      long k1 = getBlock(data, offset + i * 16);
+      long k2 = getBlock(data, offset + i * 16 + 8);
+
+      k1 *= C1;
+      k1 = rotl64(k1, 31);
+      k1 *= C2;
+      h1 ^= k1;
+
+      h1 = rotl64(h1, 27);
+      h1 += h2;
+      // 0x52dce729 is a mixing constant from the original MurmurHash3 specification by Austin
+      // Appleby
+      h1 = h1 * 5 + 0x52dce729;
+
+      k2 *= C2;
+      k2 = rotl64(k2, 33);
+      k2 *= C1;
+      h2 ^= k2;
+
+      h2 = rotl64(h2, 31);
+      h2 += h1;
+      // 0x38495ab5 is a mixing constant from the original MurmurHash3 specification by Austin
+      // Appleby
+      h2 = h2 * 5 + 0x38495ab5;
+    }
+
+    // tail - handle remaining bytes
+    int tailOffset = offset + nBlocks * 16;
+    long k1 = 0;
+    long k2 = 0;
+
+    switch (length & 15) {
+      case 15:
+        k2 ^= ((long) data[tailOffset + 14] & 0xff) << 48;
+      // fall through
+      case 14:
+        k2 ^= ((long) data[tailOffset + 13] & 0xff) << 40;
+      // fall through
+      case 13:
+        k2 ^= ((long) data[tailOffset + 12] & 0xff) << 32;
+      // fall through
+      case 12:
+        k2 ^= ((long) data[tailOffset + 11] & 0xff) << 24;
+      // fall through
+      case 11:
+        k2 ^= ((long) data[tailOffset + 10] & 0xff) << 16;
+      // fall through
+      case 10:
+        k2 ^= ((long) data[tailOffset + 9] & 0xff) << 8;
+      // fall through
+      case 9:
+        k2 ^= ((long) data[tailOffset + 8] & 0xff);
+
+        k2 *= C2;
+        k2 = rotl64(k2, 33);
+        k2 *= C1;
+        h2 ^= k2;
+      // fall through
+      case 8:
+        k1 ^= ((long) data[tailOffset + 7] & 0xff) << 56;
+      // fall through
+      case 7:
+        k1 ^= ((long) data[tailOffset + 6] & 0xff) << 48;
+      // fall through
+      case 6:
+        k1 ^= ((long) data[tailOffset + 5] & 0xff) << 40;
+      // fall through
+      case 5:
+        k1 ^= ((long) data[tailOffset + 4] & 0xff) << 32;
+      // fall through
+      case 4:
+        k1 ^= ((long) data[tailOffset + 3] & 0xff) << 24;
+      // fall through
+      case 3:
+        k1 ^= ((long) data[tailOffset + 2] & 0xff) << 16;
+      // fall through
+      case 2:
+        k1 ^= ((long) data[tailOffset + 1] & 0xff) << 8;
+      // fall through
+      case 1:
+        k1 ^= ((long) data[tailOffset] & 0xff);
+
+        k1 *= C1;
+        k1 = rotl64(k1, 31);
+        k1 *= C2;
+        h1 ^= k1;
+    }
+
+    // finalization
+    h1 ^= length;
+    h2 ^= length;
+
+    h1 += h2;
+    h2 += h1;
+
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+
+    h1 += h2;
+    // h2 += h1 is omitted since h2 is discarded
+
+    return h1;
+  }
+
+  /**
+   * Reads 8 bytes from the data array in little-endian order and returns as a long. Uses unsigned
+   * byte masking (& 0xff) to match the Go implementation where bytes are unsigned.
+   */
+  private static long getBlock(byte[] data, int offset) {
+    return ((long) data[offset] & 0xff)
+        | (((long) data[offset + 1] & 0xff) << 8)
+        | (((long) data[offset + 2] & 0xff) << 16)
+        | (((long) data[offset + 3] & 0xff) << 24)
+        | (((long) data[offset + 4] & 0xff) << 32)
+        | (((long) data[offset + 5] & 0xff) << 40)
+        | (((long) data[offset + 6] & 0xff) << 48)
+        | (((long) data[offset + 7] & 0xff) << 56);
+  }
+
+  private static long rotl64(long x, int r) {
+    return (x << r) | (x >>> (64 - r));
+  }
+
+  private static long fmix64(long k) {
+    k ^= k >>> 33;
+    k *= FMIX1;
+    k ^= k >>> 33;
+    k *= FMIX2;
+    k ^= k >>> 33;
+    return k;
+  }
+}

--- a/src/main/java/com/scylladb/alternator/keyrouting/PartitionKeyResolver.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/PartitionKeyResolver.java
@@ -1,0 +1,384 @@
+package com.scylladb.alternator.keyrouting;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+
+/**
+ * Resolves partition key attribute names for DynamoDB tables.
+ *
+ * <p>Caches results to avoid repeated DescribeTable calls. Supports both pre-configured partition
+ * key info and automatic discovery.
+ *
+ * <p><strong>Retry Behavior:</strong> Transient failures (network errors, throttling, server
+ * errors) are retried with exponential backoff up to {@link #MAX_RETRIES} times. Permanent failures
+ * (table not found, access denied) are not retried but allow future discovery attempts after a
+ * cooldown period.
+ *
+ * <p><strong>Limitation:</strong> Auto-discovery via {@link #triggerDiscovery(String,
+ * DynamoDbClient)} only works with synchronous clients ({@link DynamoDbClient}). For async clients,
+ * pre-configure partition key names using {@link KeyRouteAffinityConfig.Builder#withPkInfo(String,
+ * String)} to avoid discovery calls.
+ *
+ * <p><strong>Resource Management:</strong> This class manages an internal executor for async
+ * discovery. Call {@link #close()} or {@link #shutdown()} when done to release resources.
+ * Implements {@link AutoCloseable} for use with try-with-resources.
+ *
+ * <p>Thread-safe for concurrent access.
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.7
+ */
+public class PartitionKeyResolver implements AutoCloseable {
+
+  private static final Logger logger = Logger.getLogger(PartitionKeyResolver.class.getName());
+
+  /** Maximum number of retry attempts for transient failures. */
+  static final int MAX_RETRIES = 3;
+
+  /** Initial delay between retries in milliseconds. */
+  static final long INITIAL_RETRY_DELAY_MS = 100;
+
+  /** Maximum delay between retries in milliseconds. */
+  static final long MAX_RETRY_DELAY_MS = 2000;
+
+  /** Cooldown period after permanent failure before allowing another discovery attempt (5 min). */
+  static final long PERMANENT_FAILURE_COOLDOWN_MS = 5 * 60 * 1000;
+
+  private final ConcurrentHashMap<String, String> cache;
+  private final Set<String> discoveryInProgress;
+  private final ConcurrentHashMap<String, FailureRecord> failedTables;
+  private final ExecutorService discoveryExecutor;
+
+  /** Records information about a failed discovery attempt. */
+  private static class FailureRecord {
+    final long timestamp;
+    final boolean permanent;
+
+    FailureRecord(boolean permanent) {
+      this.timestamp = System.currentTimeMillis();
+      this.permanent = permanent;
+    }
+
+    boolean canRetry() {
+      if (!permanent) {
+        return true; // Transient failures can always be retried via triggerDiscovery
+      }
+      // Permanent failures have a cooldown period
+      return System.currentTimeMillis() - timestamp > PERMANENT_FAILURE_COOLDOWN_MS;
+    }
+  }
+
+  /**
+   * Creates a new resolver with pre-configured partition key info.
+   *
+   * @param preConfigured map of table name to partition key attribute name
+   */
+  public PartitionKeyResolver(Map<String, String> preConfigured) {
+    this.cache = new ConcurrentHashMap<>();
+    if (preConfigured != null) {
+      this.cache.putAll(preConfigured);
+    }
+    this.discoveryInProgress = ConcurrentHashMap.newKeySet();
+    this.failedTables = new ConcurrentHashMap<>();
+    this.discoveryExecutor =
+        Executors.newSingleThreadExecutor(
+            r -> {
+              Thread t = new Thread(r, "pk-discovery");
+              t.setDaemon(true);
+              return t;
+            });
+  }
+
+  /**
+   * Gets the cached partition key name for a table.
+   *
+   * @param tableName the table name
+   * @return the partition key attribute name, or null if not yet known
+   */
+  public String getPartitionKeyName(String tableName) {
+    return cache.get(tableName);
+  }
+
+  /**
+   * Triggers async discovery of partition key for a table.
+   *
+   * <p>If discovery is already in progress for this table, this call is a no-op. Discovery happens
+   * asynchronously and updates the cache when complete.
+   *
+   * <p>Transient failures (network errors, throttling) are retried with exponential backoff.
+   * Permanent failures (table not found, access denied) are recorded and will block further
+   * discovery attempts until a cooldown period expires.
+   *
+   * @param tableName the table name
+   * @param client the DynamoDB client to use for DescribeTable
+   */
+  public void triggerDiscovery(String tableName, DynamoDbClient client) {
+    if (cache.containsKey(tableName)) {
+      return; // Already cached
+    }
+
+    // Check if this table previously failed and is still in cooldown
+    FailureRecord failureRecord = failedTables.get(tableName);
+    if (failureRecord != null && !failureRecord.canRetry()) {
+      return; // Still in cooldown period after permanent failure
+    }
+
+    if (!discoveryInProgress.add(tableName)) {
+      return; // Discovery already in progress
+    }
+    // Double-check after acquiring the discovery lock to avoid race condition
+    // where another thread may have populated the cache between our first check
+    // and acquiring the lock
+    if (cache.containsKey(tableName)) {
+      discoveryInProgress.remove(tableName);
+      return; // Another thread cached it while we were waiting
+    }
+
+    // Clear any previous failure record since we're retrying
+    failedTables.remove(tableName);
+
+    discoveryExecutor.submit(() -> discoverWithRetry(tableName, client));
+  }
+
+  /**
+   * Performs discovery with exponential backoff retry for transient failures.
+   *
+   * @param tableName the table name
+   * @param client the DynamoDB client
+   */
+  private void discoverWithRetry(String tableName, DynamoDbClient client) {
+    int attempt = 0;
+    long delay = INITIAL_RETRY_DELAY_MS;
+
+    try {
+      while (attempt <= MAX_RETRIES) {
+        try {
+          DescribeTableResponse response =
+              client.describeTable(DescribeTableRequest.builder().tableName(tableName).build());
+
+          for (KeySchemaElement element : response.table().keySchema()) {
+            if (element.keyType() == KeyType.HASH) {
+              String pkName = element.attributeName();
+              cache.put(tableName, pkName);
+              logger.log(
+                  Level.FINE,
+                  "Discovered partition key for table {0}: {1}",
+                  new Object[] {tableName, pkName});
+              return; // Success
+            }
+          }
+          // No HASH key found - this shouldn't happen for valid tables
+          logger.log(
+              Level.WARNING, "Table {0} has no HASH key in schema", new Object[] {tableName});
+          failedTables.put(tableName, new FailureRecord(true));
+          return;
+
+        } catch (ResourceNotFoundException e) {
+          // Table doesn't exist - permanent failure, don't retry
+          logger.log(
+              Level.FINE,
+              "Table {0} not found during partition key discovery: {1}",
+              new Object[] {tableName, e.getMessage()});
+          failedTables.put(tableName, new FailureRecord(true));
+          return;
+
+        } catch (DynamoDbException e) {
+          if (isPermanentFailure(e)) {
+            // Access denied or other permanent error - don't retry
+            logger.log(
+                Level.WARNING,
+                "Access denied when discovering partition key for table {0}. "
+                    + "Ensure the client has DescribeTable permission: {1}",
+                new Object[] {tableName, e.getMessage()});
+            failedTables.put(tableName, new FailureRecord(true));
+            return;
+          }
+
+          // Transient error - retry with backoff
+          attempt++;
+          if (attempt > MAX_RETRIES) {
+            logger.log(
+                Level.WARNING,
+                "Failed to discover partition key for table {0} after {1} attempts: {2}",
+                new Object[] {tableName, MAX_RETRIES + 1, e.getMessage()});
+            failedTables.put(tableName, new FailureRecord(false));
+            return;
+          }
+
+          logger.log(
+              Level.FINE,
+              "Transient error discovering partition key for table {0}, retry {1}/{2} after {3}ms: {4}",
+              new Object[] {tableName, attempt, MAX_RETRIES, delay, e.getMessage()});
+
+          sleep(delay);
+          delay = Math.min(delay * 2, MAX_RETRY_DELAY_MS);
+
+        } catch (Exception e) {
+          // Network errors or other transient issues - retry with backoff
+          attempt++;
+          if (attempt > MAX_RETRIES) {
+            logger.log(
+                Level.WARNING,
+                "Failed to discover partition key for table "
+                    + tableName
+                    + " after "
+                    + (MAX_RETRIES + 1)
+                    + " attempts",
+                e);
+            failedTables.put(tableName, new FailureRecord(false));
+            return;
+          }
+
+          if (logger.isLoggable(Level.FINE)) {
+            logger.log(
+                Level.FINE,
+                "Transient error discovering partition key for table "
+                    + tableName
+                    + ", retry "
+                    + attempt
+                    + "/"
+                    + MAX_RETRIES
+                    + " after "
+                    + delay
+                    + "ms",
+                e);
+          }
+
+          sleep(delay);
+          delay = Math.min(delay * 2, MAX_RETRY_DELAY_MS);
+        }
+      }
+    } finally {
+      discoveryInProgress.remove(tableName);
+    }
+  }
+
+  /**
+   * Checks if a DynamoDB exception represents a permanent failure that should not be retried.
+   *
+   * @param e the exception to check
+   * @return true if this is a permanent failure
+   */
+  private boolean isPermanentFailure(DynamoDbException e) {
+    // Access denied is permanent
+    if (e.statusCode() == 403) {
+      return true;
+    }
+    if (e.awsErrorDetails() != null) {
+      String errorCode = e.awsErrorDetails().errorCode();
+      // AccessDeniedException and ValidationException are permanent
+      return "AccessDeniedException".equals(errorCode) || "ValidationException".equals(errorCode);
+    }
+    // 4xx errors (except 429 throttling) are generally permanent
+    return e.statusCode() >= 400 && e.statusCode() < 500 && e.statusCode() != 429;
+  }
+
+  /**
+   * Sleeps for the specified duration, handling interruption.
+   *
+   * @param millis the sleep duration in milliseconds
+   */
+  private void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Manually registers a table's partition key name.
+   *
+   * @param tableName the table name
+   * @param pkAttributeName the partition key attribute name
+   */
+  public void register(String tableName, String pkAttributeName) {
+    cache.put(tableName, pkAttributeName);
+  }
+
+  /**
+   * Checks if partition key info is available for a table.
+   *
+   * @param tableName the table name
+   * @return true if PK info is cached
+   */
+  public boolean hasPartitionKeyInfo(String tableName) {
+    return cache.containsKey(tableName);
+  }
+
+  /**
+   * Checks if discovery for a table has failed and is in cooldown.
+   *
+   * @param tableName the table name
+   * @return true if discovery failed and cannot be retried yet
+   */
+  public boolean isInFailureCooldown(String tableName) {
+    FailureRecord record = failedTables.get(tableName);
+    return record != null && !record.canRetry();
+  }
+
+  /**
+   * Clears the failure record for a table, allowing immediate retry.
+   *
+   * <p>This is useful when the underlying issue has been resolved (e.g., table created, permissions
+   * granted).
+   *
+   * @param tableName the table name
+   */
+  public void clearFailure(String tableName) {
+    failedTables.remove(tableName);
+  }
+
+  /**
+   * Returns the number of tables currently in failure cooldown.
+   *
+   * @return the count of failed tables
+   */
+  public int getFailedTableCount() {
+    return failedTables.size();
+  }
+
+  /**
+   * Closes this resolver and releases its resources.
+   *
+   * <p>This is an alias for {@link #shutdown()} to support {@link AutoCloseable}.
+   */
+  @Override
+  public void close() {
+    shutdown();
+  }
+
+  /**
+   * Shuts down the discovery executor and waits for any in-flight tasks to complete.
+   *
+   * <p>Waits up to 5 seconds for graceful shutdown. If tasks don't complete in time, forces
+   * immediate shutdown.
+   */
+  public void shutdown() {
+    discoveryExecutor.shutdown();
+    try {
+      if (!discoveryExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+        discoveryExecutor.shutdownNow();
+        logger.log(
+            Level.FINE,
+            "Partition key discovery executor did not terminate gracefully, forced shutdown");
+      }
+    } catch (InterruptedException e) {
+      discoveryExecutor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/KeyRouteAffinityClientTest.java
+++ b/src/test/java/com/scylladb/alternator/KeyRouteAffinityClientTest.java
@@ -1,0 +1,1112 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.internal.LazyQueryPlan;
+import com.scylladb.alternator.keyrouting.KeyRouteAffinity;
+import com.scylladb.alternator.keyrouting.KeyRouteAffinityConfig;
+import com.scylladb.alternator.keyrouting.KeyRouteAffinityInterceptor;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * Integration tests for KeyRouteAffinity with full client.
+ *
+ * <p>These tests verify key route affinity at the HTTP request level by:
+ *
+ * <ul>
+ *   <li>Building a full DynamoDbClient with AlternatorEndpointProvider
+ *   <li>Mocking HTTP at the SdkHttpClient layer to capture actual requests
+ *   <li>Using a mock AlternatorLiveNodes to provide a controlled node list
+ *   <li>Verifying requests are routed to correct nodes based on partition key
+ * </ul>
+ *
+ * @author dmitry.kropachev
+ */
+public class KeyRouteAffinityClientTest {
+
+  private List<URI> testNodeUris;
+  private MockSdkHttpClient mockHttpClient;
+
+  @Before
+  public void setUp() throws Exception {
+    // Create 5 test node URIs
+    testNodeUris = new ArrayList<>();
+    for (int i = 1; i <= 5; i++) {
+      testNodeUris.add(new URI("http://127.0.0." + i + ":8000"));
+    }
+    mockHttpClient = new MockSdkHttpClient();
+  }
+
+  @After
+  public void tearDown() {
+    mockHttpClient.close();
+  }
+
+  /**
+   * Creates a DynamoDbClient with key route affinity using controlled mock components.
+   *
+   * <p>This method builds the client manually to inject:
+   *
+   * <ul>
+   *   <li>A mock AlternatorLiveNodes that provides a fixed node list without network calls
+   *   <li>A mock SdkHttpClient that captures all HTTP requests for verification
+   *   <li>The KeyRouteAffinityInterceptor for request routing
+   * </ul>
+   */
+  private DynamoDbClient createClientWithKeyAffinity(KeyRouteAffinityConfig keyAffinity) {
+    // Create mock AlternatorLiveNodes that provides our test nodes
+    AlternatorLiveNodes liveNodes = new MockAlternatorLiveNodes(testNodeUris);
+
+    // Create the endpoint provider with mock live nodes
+    AlternatorEndpointProvider endpointProvider = new AlternatorEndpointProvider(liveNodes);
+
+    // Build override configuration with key affinity interceptor
+    ClientOverrideConfiguration.Builder overrideBuilder = ClientOverrideConfiguration.builder();
+    if (keyAffinity != null && keyAffinity.isEnabled()) {
+      overrideBuilder.addExecutionInterceptor(
+          new KeyRouteAffinityInterceptor(keyAffinity, liveNodes));
+    }
+
+    // Build the DynamoDB client with our mock components
+    return DynamoDbClient.builder()
+        .region(Region.of("test-region"))
+        .credentialsProvider(AnonymousCredentialsProvider.create())
+        .endpointProvider(endpointProvider)
+        .httpClient(mockHttpClient)
+        .overrideConfiguration(overrideBuilder.build())
+        .build();
+  }
+
+  // ========== Tests for same key routing to same node ==========
+
+  @Test
+  public void testSamePartitionKeyRoutesToSameNode() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String partitionKeyValue = "user-123";
+
+      // Execute first request
+      Map<String, AttributeValue> item1 = new HashMap<>();
+      item1.put("user_id", AttributeValue.builder().s(partitionKeyValue).build());
+      item1.put("data", AttributeValue.builder().s("data1").build());
+
+      PutItemRequest request1 = PutItemRequest.builder().tableName("users").item(item1).build();
+
+      mockHttpClient.clearCapturedRequests();
+      client.putItem(request1);
+      URI host1 = mockHttpClient.getLastRequestUri();
+      assertNotNull("First request should have been made", host1);
+
+      // Execute second request with same key
+      Map<String, AttributeValue> item2 = new HashMap<>();
+      item2.put("user_id", AttributeValue.builder().s(partitionKeyValue).build());
+      item2.put("data", AttributeValue.builder().s("data2").build());
+
+      PutItemRequest request2 = PutItemRequest.builder().tableName("users").item(item2).build();
+
+      mockHttpClient.clearCapturedRequests();
+      client.putItem(request2);
+      URI host2 = mockHttpClient.getLastRequestUri();
+      assertNotNull("Second request should have been made", host2);
+
+      assertEquals("Same partition key should route to same node", host1, host2);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testSamePartitionKeyConsistentAcrossMultipleRequests() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("orders", "order_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String partitionKey = "order-abc-123";
+      URI expectedUri = null;
+
+      // Make 10 requests with the same key and verify they all go to the same node
+      for (int i = 0; i < 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("order_id", AttributeValue.builder().s(partitionKey).build());
+        item.put("iteration", AttributeValue.builder().n(String.valueOf(i)).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("orders").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        assertNotNull("Request " + i + " should have been made", targetUri);
+
+        if (expectedUri == null) {
+          expectedUri = targetUri;
+        } else {
+          assertEquals(
+              "Request " + i + " should route to same node as previous requests",
+              expectedUri,
+              targetUri);
+        }
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for different keys routing to different nodes ==========
+
+  @Test
+  public void testDifferentPartitionKeysCanRouteToDifferentNodes() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      Set<URI> nodesUsed = new HashSet<>();
+      String[] partitionKeys = {
+        "user-1",
+        "user-2",
+        "user-3",
+        "user-4",
+        "user-5",
+        "user-100",
+        "user-200",
+        "user-300",
+        "user-400",
+        "user-500"
+      };
+
+      for (String pk : partitionKeys) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().s(pk).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("users").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        assertNotNull("Request for key " + pk + " should have been made", targetUri);
+        nodesUsed.add(targetUri);
+      }
+
+      // With 10 different keys and 5 nodes, we should use more than 1 node
+      assertTrue(
+          "Different partition keys should route to multiple nodes (got " + nodesUsed.size() + ")",
+          nodesUsed.size() > 1);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testDifferentPartitionKeysAreDeterministic() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("sessions", "session_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String[] partitionKeys = {"session-aaa", "session-bbb", "session-ccc"};
+      Map<String, URI> firstPassRouting = new HashMap<>();
+      Map<String, URI> secondPassRouting = new HashMap<>();
+
+      // First pass - record where each key routes
+      for (String pk : partitionKeys) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("session_id", AttributeValue.builder().s(pk).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("sessions").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+        firstPassRouting.put(pk, mockHttpClient.getLastRequestUri());
+      }
+
+      // Second pass - verify routing is the same
+      for (String pk : partitionKeys) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("session_id", AttributeValue.builder().s(pk).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("sessions").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+        secondPassRouting.put(pk, mockHttpClient.getLastRequestUri());
+      }
+
+      // Verify deterministic routing
+      for (String pk : partitionKeys) {
+        assertEquals(
+            "Key " + pk + " should route to same node on both passes",
+            firstPassRouting.get(pk),
+            secondPassRouting.get(pk));
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for RMW mode vs ANY_WRITE mode ==========
+
+  @Test
+  public void testRmwModeOnlyAppliesToConditionalWrites() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String partitionKeyValue = "user-123";
+
+      // Simple PutItem without conditions - uses round-robin, may hit different nodes
+      Set<URI> nodesForSimplePut = new HashSet<>();
+      for (int i = 0; i < 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().s(partitionKeyValue).build());
+        item.put("data", AttributeValue.builder().s("data" + i).build());
+
+        PutItemRequest simplePut = PutItemRequest.builder().tableName("users").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(simplePut);
+        nodesForSimplePut.add(mockHttpClient.getLastRequestUri());
+      }
+
+      // PutItem with condition - should always route to same node for same key
+      URI expectedNodeForConditional = null;
+      for (int i = 0; i < 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().s(partitionKeyValue).build());
+        item.put("data", AttributeValue.builder().s("conditional" + i).build());
+
+        PutItemRequest conditionalPut =
+            PutItemRequest.builder()
+                .tableName("users")
+                .item(item)
+                .conditionExpression("attribute_not_exists(user_id)")
+                .build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(conditionalPut);
+
+        URI targetNode = mockHttpClient.getLastRequestUri();
+        if (expectedNodeForConditional == null) {
+          expectedNodeForConditional = targetNode;
+        } else {
+          assertEquals(
+              "Conditional writes should always route to same node",
+              expectedNodeForConditional,
+              targetNode);
+        }
+      }
+
+      // Verify conditional writes go to one consistent node
+      assertNotNull("Conditional writes should have a target node", expectedNodeForConditional);
+
+      // Simple puts should use round-robin (multiple nodes) since RMW doesn't apply
+      assertTrue(
+          "Simple puts in RMW mode should use round-robin (got "
+              + nodesForSimplePut.size()
+              + " nodes)",
+          nodesForSimplePut.size() > 1);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testAnyWriteModeAppliesToAllWrites() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String partitionKeyValue = "user-456";
+
+      // ALL writes (even without conditions) should route to same node in ANY_WRITE mode
+      URI expectedNode = null;
+      for (int i = 0; i < 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().s(partitionKeyValue).build());
+        item.put("data", AttributeValue.builder().s("data" + i).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("users").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetNode = mockHttpClient.getLastRequestUri();
+        if (expectedNode == null) {
+          expectedNode = targetNode;
+        } else {
+          assertEquals(
+              "All writes in ANY_WRITE mode should route to same node for same key",
+              expectedNode,
+              targetNode);
+        }
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for UpdateItem ==========
+
+  @Test
+  public void testUpdateItemSameKeyRoutesToSameNode() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      Map<String, AttributeValue> key = new HashMap<>();
+      key.put("user_id", AttributeValue.builder().s("user-999").build());
+
+      // First update
+      UpdateItemRequest request1 =
+          UpdateItemRequest.builder()
+              .tableName("users")
+              .key(key)
+              .updateExpression("SET counter = counter + :val")
+              .expressionAttributeValues(
+                  Collections.singletonMap(":val", AttributeValue.builder().n("1").build()))
+              .build();
+
+      mockHttpClient.clearCapturedRequests();
+      client.updateItem(request1);
+      URI host1 = mockHttpClient.getLastRequestUri();
+
+      // Second update with same key
+      UpdateItemRequest request2 =
+          UpdateItemRequest.builder()
+              .tableName("users")
+              .key(key)
+              .updateExpression("SET counter = counter + :val2")
+              .expressionAttributeValues(
+                  Collections.singletonMap(":val2", AttributeValue.builder().n("2").build()))
+              .build();
+
+      mockHttpClient.clearCapturedRequests();
+      client.updateItem(request2);
+      URI host2 = mockHttpClient.getLastRequestUri();
+
+      assertEquals("UpdateItem requests with same key should route to same node", host1, host2);
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for numeric partition keys ==========
+
+  @Test
+  public void testNumericPartitionKeyRoutesConsistently() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("products", "product_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      URI expectedUri = null;
+      for (int i = 0; i < 5; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("product_id", AttributeValue.builder().n("12345").build());
+        item.put("iteration", AttributeValue.builder().n(String.valueOf(i)).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("products").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        if (expectedUri == null) {
+          expectedUri = targetUri;
+        } else {
+          assertEquals("Numeric partition key should route consistently", expectedUri, targetUri);
+        }
+      }
+
+      assertNotNull("Requests should have been routed", expectedUri);
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for hash distribution ==========
+
+  @Test
+  public void testHashDistributionAcrossNodes() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("data", "id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      // Use host:port string as key to avoid URI path/equality issues
+      Map<String, Integer> nodeHits = new HashMap<>();
+      for (URI uri : testNodeUris) {
+        nodeHits.put(uri.getHost() + ":" + uri.getPort(), 0);
+      }
+
+      // Generate many requests with different keys
+      int numRequests = 1000;
+      for (int i = 0; i < numRequests; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("id", AttributeValue.builder().s("key-" + i).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("data").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        String hostPort = targetUri.getHost() + ":" + targetUri.getPort();
+        nodeHits.put(hostPort, nodeHits.getOrDefault(hostPort, 0) + 1);
+      }
+
+      // Verify distribution - each node should get some requests
+      for (Map.Entry<String, Integer> entry : nodeHits.entrySet()) {
+        assertTrue(
+            "Node "
+                + entry.getKey()
+                + " should receive some requests (got "
+                + entry.getValue()
+                + ")",
+            entry.getValue() > 0);
+      }
+
+      // Verify reasonable distribution (no node gets more than 50% of requests)
+      for (Map.Entry<String, Integer> entry : nodeHits.entrySet()) {
+        assertTrue(
+            "Node "
+                + entry.getKey()
+                + " should not receive more than 50% of requests (got "
+                + entry.getValue()
+                + ")",
+            entry.getValue() < numRequests / 2);
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for NONE mode ==========
+
+  @Test
+  public void testNoneModeUsesRoundRobin() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.NONE)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      // In NONE mode, same key should use round-robin across nodes
+      Set<URI> nodesUsed = new HashSet<>();
+      String partitionKey = "user-same-key";
+
+      for (int i = 0; i < 20; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().s(partitionKey).build());
+        item.put("data", AttributeValue.builder().s("data" + i).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("users").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+        nodesUsed.add(mockHttpClient.getLastRequestUri());
+      }
+
+      // With 20 requests in round-robin mode across 5 nodes, we should see multiple nodes
+      assertTrue(
+          "NONE mode should use round-robin across multiple nodes (got " + nodesUsed.size() + ")",
+          nodesUsed.size() > 1);
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for binary partition keys ==========
+
+  @Test
+  public void testBinaryPartitionKeyRoutesConsistently() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("bindata", "bin_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      byte[] binaryKey = new byte[] {0x01, 0x02, 0x03, (byte) 0xff, (byte) 0xfe};
+      URI expectedUri = null;
+
+      for (int i = 0; i < 10; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("bin_id", AttributeValue.builder().b(SdkBytes.fromByteArray(binaryKey)).build());
+        item.put("iteration", AttributeValue.builder().n(String.valueOf(i)).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("bindata").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        if (expectedUri == null) {
+          expectedUri = targetUri;
+        } else {
+          assertEquals(
+              "Binary partition key should route consistently to same node",
+              expectedUri,
+              targetUri);
+        }
+      }
+
+      assertNotNull("Requests should have been routed", expectedUri);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testDifferentBinaryPartitionKeysCanRouteToDifferentNodes() {
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("bindata", "bin_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      Set<URI> nodesUsed = new HashSet<>();
+
+      // Generate different binary keys
+      for (int i = 0; i < 20; i++) {
+        byte[] binaryKey = new byte[] {(byte) i, (byte) (i + 1), (byte) (i * 2)};
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("bin_id", AttributeValue.builder().b(SdkBytes.fromByteArray(binaryKey)).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("bindata").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+        nodesUsed.add(mockHttpClient.getLastRequestUri());
+      }
+
+      // With different binary keys, we should use multiple nodes
+      assertTrue(
+          "Different binary partition keys should route to multiple nodes (got "
+              + nodesUsed.size()
+              + ")",
+          nodesUsed.size() > 1);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testBinaryKeyWithHighBytesRoutesConsistently() {
+    // Test binary keys with bytes >= 0x80 to verify unsigned byte handling
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo("bindata", "bin_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      byte[] binaryKey = new byte[] {(byte) 0xff, (byte) 0x80, (byte) 0x7f, (byte) 0x00};
+      URI expectedUri = null;
+
+      for (int i = 0; i < 5; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("bin_id", AttributeValue.builder().b(SdkBytes.fromByteArray(binaryKey)).build());
+
+        PutItemRequest request = PutItemRequest.builder().tableName("bindata").item(item).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        if (expectedUri == null) {
+          expectedUri = targetUri;
+        } else {
+          assertEquals(
+              "Binary key with high bytes should route consistently", expectedUri, targetUri);
+        }
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for RMW mode with specific triggers ==========
+
+  @Test
+  public void testRmwModeWithUpdateExpressionRoutesToSameNode() {
+    // UpdateExpression triggers LWT in Alternator, so RMW mode should apply
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("counters", "counter_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String partitionKey = "counter-abc";
+      URI expectedUri = null;
+
+      for (int i = 0; i < 10; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("counter_id", AttributeValue.builder().s(partitionKey).build());
+
+        // UpdateItem with UpdateExpression (LWT in Alternator)
+        UpdateItemRequest request =
+            UpdateItemRequest.builder()
+                .tableName("counters")
+                .key(key)
+                .updateExpression("SET #cnt = if_not_exists(#cnt, :zero) + :inc")
+                .expressionAttributeNames(Collections.singletonMap("#cnt", "count"))
+                .expressionAttributeValues(
+                    new HashMap<String, AttributeValue>() {
+                      {
+                        put(":zero", AttributeValue.builder().n("0").build());
+                        put(":inc", AttributeValue.builder().n("1").build());
+                      }
+                    })
+                .build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.updateItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        if (expectedUri == null) {
+          expectedUri = targetUri;
+        } else {
+          assertEquals(
+              "RMW mode with UpdateExpression should route to same node for same key",
+              expectedUri,
+              targetUri);
+        }
+      }
+
+      assertNotNull("Requests should have been routed", expectedUri);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testRmwModeWithReturnValuesAllOld() {
+    // ReturnValues=ALL_OLD requires reading the item, triggering RMW
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String partitionKey = "user-return-old";
+      URI expectedUri = null;
+
+      for (int i = 0; i < 5; i++) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().s(partitionKey).build());
+        item.put("data", AttributeValue.builder().s("data" + i).build());
+
+        // PutItem with ReturnValues=ALL_OLD
+        PutItemRequest request =
+            PutItemRequest.builder()
+                .tableName("users")
+                .item(item)
+                .returnValues(ReturnValue.ALL_OLD)
+                .build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.putItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        if (expectedUri == null) {
+          expectedUri = targetUri;
+        } else {
+          assertEquals(
+              "RMW mode with ReturnValues=ALL_OLD should route to same node",
+              expectedUri,
+              targetUri);
+        }
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testRmwModeWithConditionExpressionOnDelete() {
+    // DeleteItem with condition expression triggers RMW
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("sessions", "session_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      String partitionKey = "session-conditional-delete";
+      URI expectedUri = null;
+
+      for (int i = 0; i < 5; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("session_id", AttributeValue.builder().s(partitionKey).build());
+
+        // DeleteItem with condition expression
+        DeleteItemRequest request =
+            DeleteItemRequest.builder()
+                .tableName("sessions")
+                .key(key)
+                .conditionExpression("attribute_exists(session_id)")
+                .build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.deleteItem(request);
+
+        URI targetUri = mockHttpClient.getLastRequestUri();
+        if (expectedUri == null) {
+          expectedUri = targetUri;
+        } else {
+          assertEquals(
+              "RMW mode with conditional delete should route to same node", expectedUri, targetUri);
+        }
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testRmwModeSimpleDeleteUsesRoundRobin() {
+    // Simple DeleteItem without conditions should use round-robin in RMW mode
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("sessions", "session_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      Set<URI> nodesUsed = new HashSet<>();
+      String partitionKey = "session-simple-delete";
+
+      for (int i = 0; i < 20; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("session_id", AttributeValue.builder().s(partitionKey).build());
+
+        // Simple DeleteItem without conditions
+        DeleteItemRequest request =
+            DeleteItemRequest.builder().tableName("sessions").key(key).build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.deleteItem(request);
+        nodesUsed.add(mockHttpClient.getLastRequestUri());
+      }
+
+      // Simple deletes in RMW mode should use round-robin
+      assertTrue(
+          "Simple delete in RMW mode should use round-robin (got " + nodesUsed.size() + " nodes)",
+          nodesUsed.size() > 1);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testRmwModeWithReturnValuesUpdatedNew_DoesNotTrigger() {
+    // UPDATED_NEW does NOT trigger RMW - can be computed from update alone
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    DynamoDbClient client = createClientWithKeyAffinity(keyAffinity);
+
+    try {
+      Set<URI> nodesUsed = new HashSet<>();
+      String partitionKey = "user-updated-new";
+
+      for (int i = 0; i < 20; i++) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("user_id", AttributeValue.builder().s(partitionKey).build());
+
+        // UpdateItem with only ReturnValues=UPDATED_NEW (no condition, no expression)
+        UpdateItemRequest request =
+            UpdateItemRequest.builder()
+                .tableName("users")
+                .key(key)
+                .returnValues(ReturnValue.UPDATED_NEW)
+                .build();
+
+        mockHttpClient.clearCapturedRequests();
+        client.updateItem(request);
+        nodesUsed.add(mockHttpClient.getLastRequestUri());
+      }
+
+      // UPDATED_NEW alone doesn't trigger RMW, should use round-robin
+      assertTrue(
+          "UPDATED_NEW alone in RMW mode should use round-robin (got " + nodesUsed.size() + ")",
+          nodesUsed.size() > 1);
+    } finally {
+      client.close();
+    }
+  }
+
+  // ========== Tests for async client rejection ==========
+
+  @Test(expected = IllegalStateException.class)
+  public void testAsyncClientRejectsKeyAffinity() {
+    // Key route affinity uses ThreadLocal to pass routing information from the interceptor
+    // to the endpoint provider. Async clients execute requests on different threads than
+    // where the interceptor runs, so the ThreadLocal-based approach doesn't work.
+    // The async client builder should fail fast with a clear error message.
+
+    AlternatorDynamoDbAsyncClient.builder()
+        .endpointOverride(URI.create("http://localhost:8000"))
+        .withKeyRouteAffinity(KeyRouteAffinity.ANY_WRITE)
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAsyncClientRejectsKeyAffinityConfig() {
+    // Also test with full KeyRouteAffinityConfig object
+    KeyRouteAffinityConfig keyAffinity =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    AlternatorDynamoDbAsyncClient.builder()
+        .endpointOverride(URI.create("http://localhost:8000"))
+        .withKeyRouteAffinity(keyAffinity)
+        .build();
+  }
+
+  @Test
+  public void testAsyncClientAcceptsNoneMode() {
+    // NONE mode should be accepted since it doesn't actually use key affinity
+    // This verifies the check is specific to enabled key affinity, not just any config
+    try {
+      DynamoDbAsyncClient client =
+          AlternatorDynamoDbAsyncClient.builder()
+              .endpointOverride(URI.create("http://localhost:8000"))
+              .withKeyRouteAffinity(KeyRouteAffinity.NONE)
+              .build();
+      client.close();
+    } catch (IllegalStateException e) {
+      fail("NONE mode should not throw IllegalStateException: " + e.getMessage());
+    }
+  }
+
+  // ========== Mock implementations ==========
+
+  /**
+   * Mock AlternatorLiveNodes that provides a fixed list of nodes without network calls.
+   *
+   * <p>This mock:
+   *
+   * <ul>
+   *   <li>Does not start any background threads
+   *   <li>Provides a fixed list of test nodes
+   *   <li>Supports LazyQueryPlan creation for key affinity
+   *   <li>Implements round-robin across all test nodes
+   * </ul>
+   */
+  private static class MockAlternatorLiveNodes extends AlternatorLiveNodes {
+    private final List<URI> nodes;
+    private final java.util.concurrent.atomic.AtomicInteger counter =
+        new java.util.concurrent.atomic.AtomicInteger(0);
+
+    MockAlternatorLiveNodes(List<URI> nodes) {
+      super(
+          AlternatorConfig.builder()
+              .withSeedHosts(Collections.singletonList(nodes.get(0).getHost()))
+              .withScheme(nodes.get(0).getScheme())
+              .withPort(nodes.get(0).getPort())
+              .build());
+      this.nodes = new ArrayList<>(nodes);
+    }
+
+    @Override
+    public LazyQueryPlan newQueryPlan(long seed) {
+      return new LazyQueryPlan(nodes, Collections.<URI>emptyList(), seed);
+    }
+
+    @Override
+    public LazyQueryPlan newQueryPlan() {
+      return new LazyQueryPlan(nodes, Collections.<URI>emptyList());
+    }
+
+    @Override
+    public URI nextAsURI() {
+      // Round-robin through all test nodes (not just seed node)
+      return nodes.get(Math.abs(counter.getAndIncrement() % nodes.size()));
+    }
+
+    @Override
+    public void start() {
+      // Don't start background thread in tests
+    }
+
+    @Override
+    public List<URI> getLiveNodes() {
+      return Collections.unmodifiableList(new ArrayList<>(nodes));
+    }
+  }
+
+  /**
+   * Mock SdkHttpClient that captures HTTP requests and returns mock DynamoDB responses.
+   *
+   * <p>This allows verification of which node (URI) each request was sent to without requiring an
+   * actual server.
+   */
+  private static class MockSdkHttpClient implements SdkHttpClient {
+    private final List<CapturedRequest> capturedRequests = new CopyOnWriteArrayList<>();
+    private volatile boolean closed = false;
+
+    void clearCapturedRequests() {
+      capturedRequests.clear();
+    }
+
+    URI getLastRequestUri() {
+      if (capturedRequests.isEmpty()) {
+        return null;
+      }
+      return capturedRequests.get(capturedRequests.size() - 1).uri;
+    }
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      SdkHttpRequest httpRequest = request.httpRequest();
+      URI uri = httpRequest.getUri();
+
+      capturedRequests.add(new CapturedRequest(uri));
+
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() throws IOException {
+          return createDynamoDbResponse();
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    private HttpExecuteResponse createDynamoDbResponse() {
+      // Return a minimal DynamoDB success response
+      String responseBody = "{}";
+      byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+
+      SdkHttpFullResponse response =
+          SdkHttpFullResponse.builder()
+              .statusCode(200)
+              .putHeader("Content-Type", "application/x-amz-json-1.0")
+              .putHeader("Content-Length", String.valueOf(body.length))
+              .build();
+
+      return HttpExecuteResponse.builder()
+          .response(response)
+          .responseBody(AbortableInputStream.create(new ByteArrayInputStream(body)))
+          .build();
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    @Override
+    public String clientName() {
+      return "MockSdkHttpClient";
+    }
+
+    private static class CapturedRequest {
+      final URI uri;
+
+      CapturedRequest(URI uri) {
+        this.uri = uri;
+      }
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/keyrouting/AttributeValueHasherTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/AttributeValueHasherTest.java
@@ -1,0 +1,468 @@
+package com.scylladb.alternator.keyrouting;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Unit tests for AttributeValueHasher.
+ *
+ * @author dmitry.kropachev
+ */
+public class AttributeValueHasherTest {
+
+  @Test
+  public void testNullValue() {
+    long hash = AttributeValueHasher.hash(null);
+    assertEquals(0L, hash);
+  }
+
+  @Test
+  public void testStringValue() {
+    AttributeValue value = AttributeValue.builder().s("hello").build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testStringConsistency() {
+    AttributeValue value1 = AttributeValue.builder().s("user_123").build();
+    AttributeValue value2 = AttributeValue.builder().s("user_123").build();
+    assertEquals(AttributeValueHasher.hash(value1), AttributeValueHasher.hash(value2));
+  }
+
+  @Test
+  public void testDifferentStrings() {
+    AttributeValue value1 = AttributeValue.builder().s("user_123").build();
+    AttributeValue value2 = AttributeValue.builder().s("user_456").build();
+    assertNotEquals(AttributeValueHasher.hash(value1), AttributeValueHasher.hash(value2));
+  }
+
+  @Test
+  public void testNumberValue() {
+    AttributeValue value = AttributeValue.builder().n("12345").build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testNumberConsistency() {
+    AttributeValue value1 = AttributeValue.builder().n("42").build();
+    AttributeValue value2 = AttributeValue.builder().n("42").build();
+    assertEquals(AttributeValueHasher.hash(value1), AttributeValueHasher.hash(value2));
+  }
+
+  @Test
+  public void testBinaryValue() {
+    byte[] data = new byte[] {0x01, 0x02, 0x03, 0x04};
+    AttributeValue value = AttributeValue.builder().b(SdkBytes.fromByteArray(data)).build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testBooleanTrue() {
+    AttributeValue value = AttributeValue.builder().bool(true).build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testBooleanFalse() {
+    AttributeValue value = AttributeValue.builder().bool(false).build();
+    long hashFalse = AttributeValueHasher.hash(value);
+    // Note: false becomes byte 0, which hashes differently than empty
+    assertNotNull(hashFalse);
+  }
+
+  @Test
+  public void testBooleanTrueAndFalseDiffer() {
+    AttributeValue trueVal = AttributeValue.builder().bool(true).build();
+    AttributeValue falseVal = AttributeValue.builder().bool(false).build();
+    assertNotEquals(AttributeValueHasher.hash(trueVal), AttributeValueHasher.hash(falseVal));
+  }
+
+  @Test
+  public void testNullAttribute() {
+    AttributeValue value = AttributeValue.builder().nul(true).build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotNull(hash);
+  }
+
+  @Test
+  public void testStringSet() {
+    AttributeValue value =
+        AttributeValue.builder().ss(Arrays.asList("apple", "banana", "cherry")).build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testNumberSet() {
+    AttributeValue value = AttributeValue.builder().ns(Arrays.asList("1", "2", "3")).build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testBinarySet() {
+    AttributeValue value =
+        AttributeValue.builder()
+            .bs(
+                Arrays.asList(
+                    SdkBytes.fromByteArray(new byte[] {1, 2}),
+                    SdkBytes.fromByteArray(new byte[] {3, 4})))
+            .build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testList() {
+    AttributeValue value =
+        AttributeValue.builder()
+            .l(
+                Arrays.asList(
+                    AttributeValue.builder().s("item1").build(),
+                    AttributeValue.builder().n("42").build()))
+            .build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testMap() {
+    Map<String, AttributeValue> map = new HashMap<>();
+    map.put("name", AttributeValue.builder().s("John").build());
+    map.put("age", AttributeValue.builder().n("30").build());
+    AttributeValue value = AttributeValue.builder().m(map).build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testMapKeyOrderIndependence() {
+    // Maps should hash the same regardless of insertion order
+    // because we sort keys before hashing
+    Map<String, AttributeValue> map1 = new HashMap<>();
+    map1.put("b", AttributeValue.builder().s("second").build());
+    map1.put("a", AttributeValue.builder().s("first").build());
+
+    Map<String, AttributeValue> map2 = new HashMap<>();
+    map2.put("a", AttributeValue.builder().s("first").build());
+    map2.put("b", AttributeValue.builder().s("second").build());
+
+    AttributeValue value1 = AttributeValue.builder().m(map1).build();
+    AttributeValue value2 = AttributeValue.builder().m(map2).build();
+
+    assertEquals(AttributeValueHasher.hash(value1), AttributeValueHasher.hash(value2));
+  }
+
+  @Test
+  public void testNestedStructure() {
+    Map<String, AttributeValue> innerMap = new HashMap<>();
+    innerMap.put("inner", AttributeValue.builder().s("value").build());
+
+    AttributeValue value =
+        AttributeValue.builder()
+            .l(
+                Arrays.asList(
+                    AttributeValue.builder().m(innerMap).build(),
+                    AttributeValue.builder().s("item").build()))
+            .build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testTypicalPartitionKeys() {
+    // Test common partition key patterns
+    String[] keys = {"user_12345", "ORDER#2024-01-15", "pk_abc123", "session-uuid-here"};
+
+    for (String key : keys) {
+      AttributeValue value = AttributeValue.builder().s(key).build();
+      long hash = AttributeValueHasher.hash(value);
+      // Verify consistency
+      assertEquals(hash, AttributeValueHasher.hash(value));
+    }
+  }
+
+  @Test
+  public void testNumericPartitionKeys() {
+    // Some tables use numeric partition keys
+    String[] keys = {"12345", "98765432", "0", "-1"};
+
+    for (String key : keys) {
+      AttributeValue value = AttributeValue.builder().n(key).build();
+      long hash = AttributeValueHasher.hash(value);
+      assertEquals(hash, AttributeValueHasher.hash(value));
+    }
+  }
+
+  // ========== Collision Detection Tests ==========
+  // These tests document known collision scenarios in the current implementation.
+  // See GitHub issue #32 for the fix proposal.
+
+  /**
+   * Documents that String and Number types with the same value currently produce the same hash.
+   *
+   * <p>This is a known limitation - see issue #32.
+   *
+   * <p>IMPORTANT: When issue #32 is fixed, this test should be updated to use assertNotEquals.
+   */
+  @Test
+  public void testStringNumberCollision_KnownIssue() {
+    // String "12345" and Number "12345" currently hash to the same value
+    // because both are encoded as UTF-8 bytes without type prefix
+    AttributeValue stringVal = AttributeValue.builder().s("12345").build();
+    AttributeValue numberVal = AttributeValue.builder().n("12345").build();
+
+    long stringHash = AttributeValueHasher.hash(stringVal);
+    long numberHash = AttributeValueHasher.hash(numberVal);
+
+    // KNOWN ISSUE: These currently collide. After fix, change to assertNotEquals.
+    assertEquals(
+        "KNOWN ISSUE #32: String and Number with same value collide", stringHash, numberHash);
+  }
+
+  /**
+   * Documents that different String Set element boundaries can produce the same hash.
+   *
+   * <p>This is a known limitation - see issue #32.
+   */
+  @Test
+  public void testStringSetConcatenationCollision_KnownIssue() {
+    // SS ["a", "bc"] and SS ["ab", "c"] both concatenate to "abc"
+    AttributeValue set1 = AttributeValue.builder().ss(Arrays.asList("a", "bc")).build();
+    AttributeValue set2 = AttributeValue.builder().ss(Arrays.asList("ab", "c")).build();
+
+    long hash1 = AttributeValueHasher.hash(set1);
+    long hash2 = AttributeValueHasher.hash(set2);
+
+    // KNOWN ISSUE: These currently collide. After fix, change to assertNotEquals.
+    assertEquals("KNOWN ISSUE #32: Different SS element boundaries collide", hash1, hash2);
+  }
+
+  /**
+   * Documents that different List element boundaries can produce the same hash.
+   *
+   * <p>This is a known limitation - see issue #32.
+   */
+  @Test
+  public void testListConcatenationCollision_KnownIssue() {
+    // L [S("a"), S("bc")] and L [S("ab"), S("c")] both concatenate to "abc"
+    AttributeValue list1 =
+        AttributeValue.builder()
+            .l(
+                Arrays.asList(
+                    AttributeValue.builder().s("a").build(),
+                    AttributeValue.builder().s("bc").build()))
+            .build();
+    AttributeValue list2 =
+        AttributeValue.builder()
+            .l(
+                Arrays.asList(
+                    AttributeValue.builder().s("ab").build(),
+                    AttributeValue.builder().s("c").build()))
+            .build();
+
+    long hash1 = AttributeValueHasher.hash(list1);
+    long hash2 = AttributeValueHasher.hash(list2);
+
+    // KNOWN ISSUE: These currently collide. After fix, change to assertNotEquals.
+    assertEquals("KNOWN ISSUE #32: Different List element boundaries collide", hash1, hash2);
+  }
+
+  /**
+   * Documents that empty collections of different types currently produce the same hash.
+   *
+   * <p>This is a known limitation - see issue #32.
+   */
+  @Test
+  public void testEmptyCollectionCollision_KnownIssue() {
+    // Empty SS, NS, and BS all produce empty byte array → hash 0
+    AttributeValue emptySS = AttributeValue.builder().ss(Arrays.<String>asList()).build();
+    AttributeValue emptyNS = AttributeValue.builder().ns(Arrays.<String>asList()).build();
+    AttributeValue emptyBS = AttributeValue.builder().bs(Arrays.<SdkBytes>asList()).build();
+
+    long hashSS = AttributeValueHasher.hash(emptySS);
+    long hashNS = AttributeValueHasher.hash(emptyNS);
+    long hashBS = AttributeValueHasher.hash(emptyBS);
+
+    // KNOWN ISSUE: Empty collections all hash to 0
+    assertEquals("Empty SS hashes to 0", 0L, hashSS);
+    assertEquals("Empty NS hashes to 0", 0L, hashNS);
+    assertEquals("Empty BS hashes to 0", 0L, hashBS);
+
+    // All three collide (after fix, these should differ)
+    assertEquals("KNOWN ISSUE #32: Empty SS and NS collide", hashSS, hashNS);
+    assertEquals("KNOWN ISSUE #32: Empty NS and BS collide", hashNS, hashBS);
+  }
+
+  // ========== Binary Partition Key Tests ==========
+
+  @Test
+  public void testBinaryPartitionKeyConsistency() {
+    byte[] data = new byte[] {0x01, 0x02, 0x03, (byte) 0xff, (byte) 0xfe};
+    AttributeValue value1 = AttributeValue.builder().b(SdkBytes.fromByteArray(data)).build();
+    AttributeValue value2 =
+        AttributeValue.builder().b(SdkBytes.fromByteArray(data.clone())).build();
+
+    assertEquals(
+        "Binary partition keys with same data should hash consistently",
+        AttributeValueHasher.hash(value1),
+        AttributeValueHasher.hash(value2));
+  }
+
+  @Test
+  public void testDifferentBinaryValues() {
+    AttributeValue value1 =
+        AttributeValue.builder().b(SdkBytes.fromByteArray(new byte[] {1, 2, 3})).build();
+    AttributeValue value2 =
+        AttributeValue.builder().b(SdkBytes.fromByteArray(new byte[] {1, 2, 4})).build();
+
+    assertNotEquals(
+        "Different binary values should produce different hashes",
+        AttributeValueHasher.hash(value1),
+        AttributeValueHasher.hash(value2));
+  }
+
+  @Test
+  public void testBinaryWithHighBytes() {
+    // Test binary data with bytes >= 0x80 to verify unsigned handling
+    byte[] data = new byte[] {(byte) 0xff, (byte) 0x80, (byte) 0x7f, (byte) 0x00};
+    AttributeValue value = AttributeValue.builder().b(SdkBytes.fromByteArray(data)).build();
+    long hash = AttributeValueHasher.hash(value);
+
+    // Verify consistency
+    assertEquals(hash, AttributeValueHasher.hash(value));
+    assertNotEquals("Binary with high bytes should produce non-zero hash", 0L, hash);
+  }
+
+  // ========== String Set Order Independence Tests ==========
+
+  @Test
+  public void testStringSetOrderIndependence() {
+    // String sets should hash the same regardless of input order
+    // because we sort before hashing
+    AttributeValue set1 =
+        AttributeValue.builder().ss(Arrays.asList("cherry", "apple", "banana")).build();
+    AttributeValue set2 =
+        AttributeValue.builder().ss(Arrays.asList("apple", "banana", "cherry")).build();
+    AttributeValue set3 =
+        AttributeValue.builder().ss(Arrays.asList("banana", "cherry", "apple")).build();
+
+    long hash1 = AttributeValueHasher.hash(set1);
+    long hash2 = AttributeValueHasher.hash(set2);
+    long hash3 = AttributeValueHasher.hash(set3);
+
+    assertEquals("SS order should not affect hash (1 vs 2)", hash1, hash2);
+    assertEquals("SS order should not affect hash (2 vs 3)", hash2, hash3);
+  }
+
+  @Test
+  public void testNumberSetOrderIndependence() {
+    AttributeValue set1 = AttributeValue.builder().ns(Arrays.asList("3", "1", "2")).build();
+    AttributeValue set2 = AttributeValue.builder().ns(Arrays.asList("1", "2", "3")).build();
+
+    assertEquals(
+        "NS order should not affect hash",
+        AttributeValueHasher.hash(set1),
+        AttributeValueHasher.hash(set2));
+  }
+
+  @Test
+  public void testBinarySetOrderIndependence() {
+    AttributeValue set1 =
+        AttributeValue.builder()
+            .bs(
+                Arrays.asList(
+                    SdkBytes.fromByteArray(new byte[] {3, 4}),
+                    SdkBytes.fromByteArray(new byte[] {1, 2})))
+            .build();
+    AttributeValue set2 =
+        AttributeValue.builder()
+            .bs(
+                Arrays.asList(
+                    SdkBytes.fromByteArray(new byte[] {1, 2}),
+                    SdkBytes.fromByteArray(new byte[] {3, 4})))
+            .build();
+
+    assertEquals(
+        "BS order should not affect hash",
+        AttributeValueHasher.hash(set1),
+        AttributeValueHasher.hash(set2));
+  }
+
+  // ========== Edge Case Tests ==========
+
+  @Test
+  public void testEmptyString() {
+    AttributeValue value = AttributeValue.builder().s("").build();
+    long hash = AttributeValueHasher.hash(value);
+    // Empty string hashes to 0 (same as empty byte array)
+    assertEquals("Empty string hashes to 0", 0L, hash);
+  }
+
+  @Test
+  public void testUnicodeString() {
+    AttributeValue value = AttributeValue.builder().s("こんにちは世界").build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+    // Verify consistency
+    assertEquals(hash, AttributeValueHasher.hash(value));
+  }
+
+  @Test
+  public void testVeryLongString() {
+    // Test with a string longer than 16 bytes (MurmurHash3 block size)
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      sb.append("partition_key_segment_").append(i).append("_");
+    }
+    AttributeValue value = AttributeValue.builder().s(sb.toString()).build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+    assertEquals(hash, AttributeValueHasher.hash(value));
+  }
+
+  @Test
+  public void testNegativeNumber() {
+    AttributeValue value = AttributeValue.builder().n("-12345.6789").build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+    assertEquals(hash, AttributeValueHasher.hash(value));
+  }
+
+  @Test
+  public void testScientificNotationNumber() {
+    AttributeValue value = AttributeValue.builder().n("1.23E10").build();
+    long hash = AttributeValueHasher.hash(value);
+    assertNotEquals(0L, hash);
+    assertEquals(hash, AttributeValueHasher.hash(value));
+  }
+
+  @Test
+  public void testDeeplyNestedStructure() {
+    // Create a deeply nested map
+    Map<String, AttributeValue> level3 = new HashMap<>();
+    level3.put("deep", AttributeValue.builder().s("value").build());
+
+    Map<String, AttributeValue> level2 = new HashMap<>();
+    level2.put("nested", AttributeValue.builder().m(level3).build());
+
+    Map<String, AttributeValue> level1 = new HashMap<>();
+    level1.put("outer", AttributeValue.builder().m(level2).build());
+
+    AttributeValue value = AttributeValue.builder().m(level1).build();
+    long hash = AttributeValueHasher.hash(value);
+
+    assertNotEquals(0L, hash);
+    assertEquals(hash, AttributeValueHasher.hash(value));
+  }
+}

--- a/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
@@ -1,0 +1,501 @@
+package com.scylladb.alternator.keyrouting;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+/**
+ * Unit tests for KeyAffinityRequestClassifier.
+ *
+ * @author dmitry.kropachev
+ */
+public class KeyAffinityRequestClassifierTest {
+
+  // ========== shouldApply tests for NONE mode ==========
+
+  @Test
+  public void testNoneModeNeverApplies() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .updateExpression("SET x = :v")
+            .build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.NONE, request));
+  }
+
+  // ========== shouldApply tests for RMW mode - UpdateItem ==========
+
+  @Test
+  public void testRmwModeUpdateItemWithUpdateExpression() {
+    // UpdateItem with updateExpression SHOULD trigger RMW because UpdateExpression operations
+    // are LWT-based in Alternator
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .updateExpression("SET x = :v")
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithConditionExpression() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .conditionExpression("attribute_exists(x)")
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithExpected() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .expected(
+                Collections.singletonMap(
+                    "x", ExpectedAttributeValue.builder().exists(true).build()))
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithReturnValues() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .returnValues(ReturnValue.ALL_OLD)
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithReturnValuesNone() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .returnValues(ReturnValue.NONE)
+            .build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithReturnValuesUpdatedOld() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .returnValues(ReturnValue.UPDATED_OLD)
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithReturnValuesAllNew() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .returnValues(ReturnValue.ALL_NEW)
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithReturnValuesUpdatedNew() {
+    // UPDATED_NEW does NOT trigger RMW - can be computed from update alone without full read
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .returnValues(ReturnValue.UPDATED_NEW)
+            .build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithAddAction() {
+    // ADD action requires reading current value for atomic increment
+    Map<String, AttributeValueUpdate> updates = new HashMap<>();
+    updates.put(
+        "counter",
+        AttributeValueUpdate.builder()
+            .action(AttributeAction.ADD)
+            .value(AttributeValue.builder().n("1").build())
+            .build());
+
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .attributeUpdates(updates)
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithDeleteActionWithValue() {
+    // DELETE action with value requires checking set membership
+    Map<String, AttributeValueUpdate> updates = new HashMap<>();
+    updates.put(
+        "tags",
+        AttributeValueUpdate.builder()
+            .action(AttributeAction.DELETE)
+            .value(AttributeValue.builder().ss("tag1").build())
+            .build());
+
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .attributeUpdates(updates)
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithDeleteActionWithoutValue() {
+    // DELETE action without value (deleting entire attribute) does NOT need to read current value
+    Map<String, AttributeValueUpdate> updates = new HashMap<>();
+    updates.put("tags", AttributeValueUpdate.builder().action(AttributeAction.DELETE).build());
+
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .attributeUpdates(updates)
+            .build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemWithPutAction() {
+    // PUT action (simple attribute set) does NOT trigger RMW
+    Map<String, AttributeValueUpdate> updates = new HashMap<>();
+    updates.put(
+        "name",
+        AttributeValueUpdate.builder()
+            .action(AttributeAction.PUT)
+            .value(AttributeValue.builder().s("new name").build())
+            .build());
+
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .attributeUpdates(updates)
+            .build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeUpdateItemSimple() {
+    // UpdateItem without any conditions or return values
+    UpdateItemRequest request =
+        UpdateItemRequest.builder().tableName("test").key(createKey("pk", "value")).build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  // ========== shouldApply tests for RMW mode - PutItem ==========
+
+  @Test
+  public void testRmwModePutItemWithConditionExpression() {
+    PutItemRequest request =
+        PutItemRequest.builder()
+            .tableName("test")
+            .item(createItem("pk", "value"))
+            .conditionExpression("attribute_not_exists(pk)")
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModePutItemWithExpected() {
+    PutItemRequest request =
+        PutItemRequest.builder()
+            .tableName("test")
+            .item(createItem("pk", "value"))
+            .expected(
+                Collections.singletonMap(
+                    "pk", ExpectedAttributeValue.builder().exists(false).build()))
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModePutItemWithReturnValues() {
+    PutItemRequest request =
+        PutItemRequest.builder()
+            .tableName("test")
+            .item(createItem("pk", "value"))
+            .returnValues(ReturnValue.ALL_OLD)
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModePutItemSimple() {
+    PutItemRequest request =
+        PutItemRequest.builder().tableName("test").item(createItem("pk", "value")).build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  // ========== shouldApply tests for RMW mode - DeleteItem ==========
+
+  @Test
+  public void testRmwModeDeleteItemWithConditionExpression() {
+    DeleteItemRequest request =
+        DeleteItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .conditionExpression("attribute_exists(pk)")
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeDeleteItemWithExpected() {
+    DeleteItemRequest request =
+        DeleteItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .expected(
+                Collections.singletonMap(
+                    "pk", ExpectedAttributeValue.builder().exists(true).build()))
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeDeleteItemWithReturnValues() {
+    DeleteItemRequest request =
+        DeleteItemRequest.builder()
+            .tableName("test")
+            .key(createKey("pk", "value"))
+            .returnValues(ReturnValue.ALL_OLD)
+            .build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testRmwModeDeleteItemSimple() {
+    DeleteItemRequest request =
+        DeleteItemRequest.builder().tableName("test").key(createKey("pk", "value")).build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  // ========== shouldApply tests for RMW mode - BatchWriteItem ==========
+
+  @Test
+  public void testRmwModeBatchWriteItem() {
+    // BatchWriteItem is not supported for key route affinity because it can contain
+    // items for multiple tables with different partition keys
+    BatchWriteItemRequest request = BatchWriteItemRequest.builder().build();
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  // ========== shouldApply tests for ANY_WRITE mode ==========
+
+  @Test
+  public void testAnyWriteModeUpdateItem() {
+    UpdateItemRequest request =
+        UpdateItemRequest.builder().tableName("test").key(createKey("pk", "value")).build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
+  }
+
+  @Test
+  public void testAnyWriteModePutItem() {
+    PutItemRequest request =
+        PutItemRequest.builder().tableName("test").item(createItem("pk", "value")).build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
+  }
+
+  @Test
+  public void testAnyWriteModeDeleteItem() {
+    DeleteItemRequest request =
+        DeleteItemRequest.builder().tableName("test").key(createKey("pk", "value")).build();
+
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
+  }
+
+  @Test
+  public void testAnyWriteModeBatchWriteItem() {
+    // BatchWriteItem is not supported for key route affinity because it can contain
+    // items for multiple tables with different partition keys
+    BatchWriteItemRequest request = BatchWriteItemRequest.builder().build();
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
+  }
+
+  // ========== shouldApply tests for read operations ==========
+
+  @Test
+  public void testRmwModeDoesNotApplyToGetItem() {
+    GetItemRequest request =
+        GetItemRequest.builder().tableName("test").key(createKey("pk", "value")).build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+  }
+
+  @Test
+  public void testAnyWriteModeDoesNotApplyToGetItem() {
+    GetItemRequest request =
+        GetItemRequest.builder().tableName("test").key(createKey("pk", "value")).build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
+  }
+
+  @Test
+  public void testDoesNotApplyToQuery() {
+    QueryRequest request = QueryRequest.builder().tableName("test").build();
+
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
+    assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
+  }
+
+  // ========== extractTableName tests ==========
+
+  @Test
+  public void testExtractTableNameFromUpdateItem() {
+    UpdateItemRequest request = UpdateItemRequest.builder().tableName("users").build();
+    assertEquals("users", KeyAffinityRequestClassifier.extractTableName(request));
+  }
+
+  @Test
+  public void testExtractTableNameFromPutItem() {
+    PutItemRequest request = PutItemRequest.builder().tableName("orders").build();
+    assertEquals("orders", KeyAffinityRequestClassifier.extractTableName(request));
+  }
+
+  @Test
+  public void testExtractTableNameFromDeleteItem() {
+    DeleteItemRequest request = DeleteItemRequest.builder().tableName("sessions").build();
+    assertEquals("sessions", KeyAffinityRequestClassifier.extractTableName(request));
+  }
+
+  @Test
+  public void testExtractTableNameFromGetItem() {
+    GetItemRequest request = GetItemRequest.builder().tableName("products").build();
+    assertEquals("products", KeyAffinityRequestClassifier.extractTableName(request));
+  }
+
+  @Test
+  public void testExtractTableNameFromQuery() {
+    QueryRequest request = QueryRequest.builder().tableName("events").build();
+    assertEquals("events", KeyAffinityRequestClassifier.extractTableName(request));
+  }
+
+  @Test
+  public void testExtractTableNameFromBatchWriteItem() {
+    BatchWriteItemRequest request = BatchWriteItemRequest.builder().build();
+    assertNull(KeyAffinityRequestClassifier.extractTableName(request));
+  }
+
+  // ========== extractPartitionKey tests ==========
+
+  @Test
+  public void testExtractPartitionKeyFromUpdateItem() {
+    Map<String, AttributeValue> key = createKey("user_id", "u123");
+    UpdateItemRequest request = UpdateItemRequest.builder().tableName("users").key(key).build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "user_id");
+    assertNotNull(pk);
+    assertEquals("u123", pk.s());
+  }
+
+  @Test
+  public void testExtractPartitionKeyFromPutItem() {
+    Map<String, AttributeValue> item = createItem("order_id", "o456");
+    PutItemRequest request = PutItemRequest.builder().tableName("orders").item(item).build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "order_id");
+    assertNotNull(pk);
+    assertEquals("o456", pk.s());
+  }
+
+  @Test
+  public void testExtractPartitionKeyFromDeleteItem() {
+    Map<String, AttributeValue> key = createKey("session_id", "s789");
+    DeleteItemRequest request = DeleteItemRequest.builder().tableName("sessions").key(key).build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "session_id");
+    assertNotNull(pk);
+    assertEquals("s789", pk.s());
+  }
+
+  @Test
+  public void testExtractPartitionKeyFromGetItem() {
+    Map<String, AttributeValue> key = createKey("product_id", "p012");
+    GetItemRequest request = GetItemRequest.builder().tableName("products").key(key).build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "product_id");
+    assertNotNull(pk);
+    assertEquals("p012", pk.s());
+  }
+
+  @Test
+  public void testExtractPartitionKeyWithWrongKeyName() {
+    Map<String, AttributeValue> key = createKey("user_id", "u123");
+    UpdateItemRequest request = UpdateItemRequest.builder().tableName("users").key(key).build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "wrong_key");
+    assertNull(pk);
+  }
+
+  @Test
+  public void testExtractPartitionKeyWithNullKeyName() {
+    Map<String, AttributeValue> key = createKey("user_id", "u123");
+    UpdateItemRequest request = UpdateItemRequest.builder().tableName("users").key(key).build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, null);
+    assertNull(pk);
+  }
+
+  // ========== Helper methods ==========
+
+  private Map<String, AttributeValue> createKey(String keyName, String keyValue) {
+    Map<String, AttributeValue> key = new HashMap<>();
+    key.put(keyName, AttributeValue.builder().s(keyValue).build());
+    return key;
+  }
+
+  private Map<String, AttributeValue> createItem(String keyName, String keyValue) {
+    Map<String, AttributeValue> item = new HashMap<>();
+    item.put(keyName, AttributeValue.builder().s(keyValue).build());
+    item.put("data", AttributeValue.builder().s("some data").build());
+    return item;
+  }
+}

--- a/src/test/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityConfigTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityConfigTest.java
@@ -1,0 +1,187 @@
+package com.scylladb.alternator.keyrouting;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Unit tests for KeyRouteAffinityConfig.
+ *
+ * @author dmitry.kropachev
+ */
+public class KeyRouteAffinityConfigTest {
+
+  @Test
+  public void testDefaultBuilder() {
+    KeyRouteAffinityConfig config = KeyRouteAffinityConfig.builder().build();
+
+    assertEquals(KeyRouteAffinity.NONE, config.getType());
+    assertTrue(config.getPkInfoPerTable().isEmpty());
+    assertFalse(config.isEnabled());
+  }
+
+  @Test
+  public void testBuilderWithType() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder().withType(KeyRouteAffinity.RMW).build();
+
+    assertEquals(KeyRouteAffinity.RMW, config.getType());
+    assertTrue(config.isEnabled());
+  }
+
+  @Test
+  public void testBuilderWithTypeAnyWrite() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder().withType(KeyRouteAffinity.ANY_WRITE).build();
+
+    assertEquals(KeyRouteAffinity.ANY_WRITE, config.getType());
+    assertTrue(config.isEnabled());
+  }
+
+  @Test
+  public void testBuilderWithTypeNone() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder().withType(KeyRouteAffinity.NONE).build();
+
+    assertEquals(KeyRouteAffinity.NONE, config.getType());
+    assertFalse(config.isEnabled());
+  }
+
+  @Test
+  public void testBuilderWithNullType() {
+    KeyRouteAffinityConfig config = KeyRouteAffinityConfig.builder().withType(null).build();
+
+    assertEquals(KeyRouteAffinity.NONE, config.getType());
+    assertFalse(config.isEnabled());
+  }
+
+  @Test
+  public void testBuilderWithPkInfo() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("users", "user_id")
+            .withPkInfo("orders", "order_id")
+            .build();
+
+    Map<String, String> pkInfo = config.getPkInfoPerTable();
+    assertEquals(2, pkInfo.size());
+    assertEquals("user_id", pkInfo.get("users"));
+    assertEquals("order_id", pkInfo.get("orders"));
+  }
+
+  @Test
+  public void testBuilderWithPkInfoMap() {
+    Map<String, String> pkInfoMap = new HashMap<>();
+    pkInfoMap.put("table1", "pk1");
+    pkInfoMap.put("table2", "pk2");
+    pkInfoMap.put("table3", "pk3");
+
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfoMap(pkInfoMap)
+            .build();
+
+    Map<String, String> pkInfo = config.getPkInfoPerTable();
+    assertEquals(3, pkInfo.size());
+    assertEquals("pk1", pkInfo.get("table1"));
+    assertEquals("pk2", pkInfo.get("table2"));
+    assertEquals("pk3", pkInfo.get("table3"));
+  }
+
+  @Test
+  public void testBuilderWithNullPkInfo() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo(null, "pk")
+            .withPkInfo("table", null)
+            .withPkInfoMap(null)
+            .build();
+
+    assertTrue(config.getPkInfoPerTable().isEmpty());
+  }
+
+  @Test
+  public void testStaticOfMethod() {
+    KeyRouteAffinityConfig config = KeyRouteAffinityConfig.of(KeyRouteAffinity.RMW);
+
+    assertEquals(KeyRouteAffinity.RMW, config.getType());
+    assertTrue(config.getPkInfoPerTable().isEmpty());
+    assertTrue(config.isEnabled());
+  }
+
+  @Test
+  public void testStaticOfMethodWithNone() {
+    KeyRouteAffinityConfig config = KeyRouteAffinityConfig.of(KeyRouteAffinity.NONE);
+
+    assertEquals(KeyRouteAffinity.NONE, config.getType());
+    assertFalse(config.isEnabled());
+  }
+
+  @Test
+  public void testStaticOfMethodWithNull() {
+    KeyRouteAffinityConfig config = KeyRouteAffinityConfig.of(null);
+
+    assertEquals(KeyRouteAffinity.NONE, config.getType());
+    assertFalse(config.isEnabled());
+  }
+
+  @Test
+  public void testPkInfoMapIsUnmodifiable() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.RMW)
+            .withPkInfo("users", "user_id")
+            .build();
+
+    try {
+      config.getPkInfoPerTable().put("new_table", "new_pk");
+      fail("Should throw UnsupportedOperationException");
+    } catch (UnsupportedOperationException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testBuilderPkInfoMerge() {
+    Map<String, String> pkInfoMap = new HashMap<>();
+    pkInfoMap.put("table1", "pk1");
+    pkInfoMap.put("table2", "pk2");
+
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder()
+            .withPkInfo("table0", "pk0")
+            .withPkInfoMap(pkInfoMap)
+            .withPkInfo("table3", "pk3")
+            .build();
+
+    Map<String, String> pkInfo = config.getPkInfoPerTable();
+    assertEquals(4, pkInfo.size());
+    assertEquals("pk0", pkInfo.get("table0"));
+    assertEquals("pk1", pkInfo.get("table1"));
+    assertEquals("pk2", pkInfo.get("table2"));
+    assertEquals("pk3", pkInfo.get("table3"));
+  }
+
+  @Test
+  public void testBuilderPkInfoOverwrite() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder()
+            .withPkInfo("users", "old_pk")
+            .withPkInfo("users", "new_pk")
+            .build();
+
+    assertEquals("new_pk", config.getPkInfoPerTable().get("users"));
+  }
+
+  @Test
+  public void testIsEnabledForAllTypes() {
+    assertFalse(KeyRouteAffinityConfig.of(KeyRouteAffinity.NONE).isEnabled());
+    assertTrue(KeyRouteAffinityConfig.of(KeyRouteAffinity.RMW).isEnabled());
+    assertTrue(KeyRouteAffinityConfig.of(KeyRouteAffinity.ANY_WRITE).isEnabled());
+  }
+}

--- a/src/test/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityContextTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityContextTest.java
@@ -1,0 +1,104 @@
+package com.scylladb.alternator.keyrouting;
+
+import static org.junit.Assert.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for KeyRouteAffinityContext.
+ *
+ * @author dmitry.kropachev
+ */
+public class KeyRouteAffinityContextTest {
+
+  @Before
+  public void setUp() {
+    KeyRouteAffinityContext.clear();
+  }
+
+  @After
+  public void tearDown() {
+    KeyRouteAffinityContext.clear();
+  }
+
+  @Test
+  public void testInitiallyEmpty() {
+    assertNull(KeyRouteAffinityContext.getTargetNode());
+    assertFalse(KeyRouteAffinityContext.hasTargetNode());
+  }
+
+  @Test
+  public void testSetAndGetTargetNode() throws URISyntaxException {
+    URI uri = new URI("http://node1.example.com:8000");
+    KeyRouteAffinityContext.setTargetNode(uri);
+
+    assertEquals(uri, KeyRouteAffinityContext.getTargetNode());
+    assertTrue(KeyRouteAffinityContext.hasTargetNode());
+  }
+
+  @Test
+  public void testClear() throws URISyntaxException {
+    URI uri = new URI("http://node1.example.com:8000");
+    KeyRouteAffinityContext.setTargetNode(uri);
+    assertTrue(KeyRouteAffinityContext.hasTargetNode());
+
+    KeyRouteAffinityContext.clear();
+
+    assertNull(KeyRouteAffinityContext.getTargetNode());
+    assertFalse(KeyRouteAffinityContext.hasTargetNode());
+  }
+
+  @Test
+  public void testSetNullClears() throws URISyntaxException {
+    URI uri = new URI("http://node1.example.com:8000");
+    KeyRouteAffinityContext.setTargetNode(uri);
+    assertTrue(KeyRouteAffinityContext.hasTargetNode());
+
+    KeyRouteAffinityContext.setTargetNode(null);
+
+    assertNull(KeyRouteAffinityContext.getTargetNode());
+    assertFalse(KeyRouteAffinityContext.hasTargetNode());
+  }
+
+  @Test
+  public void testOverwriteTargetNode() throws URISyntaxException {
+    URI uri1 = new URI("http://node1.example.com:8000");
+    URI uri2 = new URI("http://node2.example.com:8000");
+
+    KeyRouteAffinityContext.setTargetNode(uri1);
+    assertEquals(uri1, KeyRouteAffinityContext.getTargetNode());
+
+    KeyRouteAffinityContext.setTargetNode(uri2);
+    assertEquals(uri2, KeyRouteAffinityContext.getTargetNode());
+  }
+
+  @Test
+  public void testThreadIsolation() throws URISyntaxException, InterruptedException {
+    final URI uri1 = new URI("http://node1.example.com:8000");
+    final URI uri2 = new URI("http://node2.example.com:8000");
+    final URI[] threadResult = new URI[1];
+
+    // Set in main thread
+    KeyRouteAffinityContext.setTargetNode(uri1);
+
+    // Create a new thread and set a different value
+    Thread thread =
+        new Thread(
+            () -> {
+              KeyRouteAffinityContext.setTargetNode(uri2);
+              threadResult[0] = KeyRouteAffinityContext.getTargetNode();
+              KeyRouteAffinityContext.clear();
+            });
+    thread.start();
+    thread.join();
+
+    // Main thread should still have its value
+    assertEquals(uri1, KeyRouteAffinityContext.getTargetNode());
+    // Other thread should have had its own value
+    assertEquals(uri2, threadResult[0]);
+  }
+}

--- a/src/test/java/com/scylladb/alternator/keyrouting/MurmurHash3Test.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/MurmurHash3Test.java
@@ -1,0 +1,218 @@
+package com.scylladb.alternator.keyrouting;
+
+import static org.junit.Assert.*;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+/**
+ * Unit tests for MurmurHash3.
+ *
+ * <p>Tests verify that the Java implementation produces the same hashes as the Go reference
+ * implementation for various inputs.
+ *
+ * @author dmitry.kropachev
+ */
+public class MurmurHash3Test {
+
+  /**
+   * Test vectors verified against Go alternator-client implementation.
+   *
+   * <p>These values were verified using the Go murmur3 package with the same inputs and seed 0:
+   *
+   * <pre>{@code
+   * import "github.com/spaolacci/murmur3"
+   * h1, _ := murmur3.Sum128([]byte("test"))
+   * fmt.Printf("0x%016xL\n", h1)
+   * }</pre>
+   *
+   * <p>Cross-language compatibility is ensured for key route affinity feature.
+   */
+  @Test
+  public void testGoCompatibility_emptyInput() {
+    // Empty input with seed 0 produces h1 = 0
+    byte[] data = new byte[0];
+    long hash = MurmurHash3.hash(data);
+    assertEquals("Empty input should produce 0 with seed 0", 0L, hash);
+  }
+
+  @Test
+  public void testGoCompatibility_knownValues() {
+    // Test vectors - these specific values ensure consistent hashing across Java and Go clients.
+    // The hash function is MurmurHash3 x64 128-bit, returning the first 64 bits (h1).
+    // Verified against Go alternator-client implementation using github.com/spaolacci/murmur3.
+
+    // "test"
+    assertEquals(
+        "Hash of 'test'",
+        0xac7d28cc74bde19dL,
+        MurmurHash3.hash("test".getBytes(StandardCharsets.UTF_8)));
+
+    // "hello"
+    assertEquals(
+        "Hash of 'hello'",
+        0xcbd8a7b341bd9b02L,
+        MurmurHash3.hash("hello".getBytes(StandardCharsets.UTF_8)));
+
+    // "user_123" - typical partition key
+    assertEquals(
+        "Hash of 'user_123'",
+        0x104832bf621f0137L,
+        MurmurHash3.hash("user_123".getBytes(StandardCharsets.UTF_8)));
+
+    // 16 bytes (exactly one block)
+    assertEquals(
+        "Hash of '0123456789abcdef'",
+        0x4be06d94cf4ad1a7L,
+        MurmurHash3.hash("0123456789abcdef".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  public void testGoCompatibility_binaryWithHighBytes() {
+    // Test with bytes >= 0x80 to verify unsigned byte handling
+    // This is critical because Java bytes are signed, Go bytes are unsigned
+    byte[] data = new byte[] {(byte) 0xff, (byte) 0x80, (byte) 0x7f, (byte) 0x00};
+    long hash = MurmurHash3.hash(data);
+    // This specific value ensures the & 0xff masking is correct
+    assertEquals("Hash of binary data with high bytes", 0x3408b0fbe4cb130cL, hash);
+  }
+
+  @Test
+  public void testEmptyByteArray() {
+    byte[] data = new byte[0];
+    long hash = MurmurHash3.hash(data);
+    // Empty input with seed 0 should produce 0
+    assertEquals(0L, hash);
+  }
+
+  @Test
+  public void testSingleByte() {
+    byte[] data = new byte[] {0x42};
+    long hash = MurmurHash3.hash(data);
+    // Should produce a non-zero hash for non-empty input
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testShortString() {
+    byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
+    long hash = MurmurHash3.hash(data);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testExactly16Bytes() {
+    // Exactly one block
+    byte[] data = "0123456789abcdef".getBytes(StandardCharsets.UTF_8);
+    assertEquals(16, data.length);
+    long hash = MurmurHash3.hash(data);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void test17Bytes() {
+    // One block plus one tail byte
+    byte[] data = "0123456789abcdefg".getBytes(StandardCharsets.UTF_8);
+    assertEquals(17, data.length);
+    long hash = MurmurHash3.hash(data);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testLongerString() {
+    byte[] data = "this is a longer string that exceeds 16 bytes".getBytes(StandardCharsets.UTF_8);
+    long hash = MurmurHash3.hash(data);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testConsistency() {
+    // Same input should always produce the same hash
+    byte[] data = "partition_key_value".getBytes(StandardCharsets.UTF_8);
+    long hash1 = MurmurHash3.hash(data);
+    long hash2 = MurmurHash3.hash(data);
+    assertEquals("Same input should produce same hash", hash1, hash2);
+  }
+
+  @Test
+  public void testDifferentInputsProduceDifferentHashes() {
+    byte[] data1 = "user_123".getBytes(StandardCharsets.UTF_8);
+    byte[] data2 = "user_456".getBytes(StandardCharsets.UTF_8);
+    long hash1 = MurmurHash3.hash(data1);
+    long hash2 = MurmurHash3.hash(data2);
+    assertNotEquals("Different inputs should produce different hashes", hash1, hash2);
+  }
+
+  @Test
+  public void testWithOffset() {
+    byte[] data = "prefixHELLOsuffix".getBytes(StandardCharsets.UTF_8);
+    byte[] hello = "HELLO".getBytes(StandardCharsets.UTF_8);
+
+    long fullHash = MurmurHash3.hash(hello);
+    long offsetHash = MurmurHash3.hash(data, 6, 5);
+
+    assertEquals("Offset hash should match direct hash", fullHash, offsetHash);
+  }
+
+  @Test
+  public void test32Bytes() {
+    // Two full blocks
+    byte[] data = "01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8);
+    assertEquals(32, data.length);
+    long hash = MurmurHash3.hash(data);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void test48Bytes() {
+    // Three full blocks
+    byte[] data =
+        "012345678901234567890123456789012345678901234567".getBytes(StandardCharsets.UTF_8);
+    assertEquals(48, data.length);
+    long hash = MurmurHash3.hash(data);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testAllTailLengths() {
+    // Test all possible tail lengths (1-15 bytes)
+    for (int tailLen = 1; tailLen < 16; tailLen++) {
+      byte[] data = new byte[16 + tailLen];
+      for (int i = 0; i < data.length; i++) {
+        data[i] = (byte) i;
+      }
+      long hash = MurmurHash3.hash(data);
+      assertNotEquals("Tail length " + tailLen + " should produce non-zero hash", 0L, hash);
+    }
+  }
+
+  @Test
+  public void testQuickBrownFox() {
+    byte[] data = "The quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
+    long hash = MurmurHash3.hash(data);
+    // This is a known string, hash should be consistent
+    long hash2 = MurmurHash3.hash(data);
+    assertEquals(hash, hash2);
+  }
+
+  @Test
+  public void testBinaryData() {
+    // Test with binary data including null bytes
+    byte[] data = new byte[] {0x00, 0x01, 0x02, (byte) 0xff, (byte) 0xfe, (byte) 0xfd};
+    long hash = MurmurHash3.hash(data);
+    assertNotEquals(0L, hash);
+  }
+
+  @Test
+  public void testPartitionKeySimulation() {
+    // Simulate typical partition key values
+    String[] keys = {"user_id12345", "order_98765", "pk_abc_123", "session_xyz_789"};
+
+    for (String key : keys) {
+      byte[] data = key.getBytes(StandardCharsets.UTF_8);
+      long hash = MurmurHash3.hash(data);
+      // Verify hash can be used as a positive seed
+      assertTrue("Hash should be usable for node selection", hash != 0 || key.isEmpty());
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/keyrouting/PartitionKeyResolverTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/PartitionKeyResolverTest.java
@@ -1,0 +1,402 @@
+package com.scylladb.alternator.keyrouting;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+
+/**
+ * Unit tests for PartitionKeyResolver.
+ *
+ * @author dmitry.kropachev
+ */
+public class PartitionKeyResolverTest {
+
+  private PartitionKeyResolver resolver;
+  private DynamoDbClient mockClient;
+
+  @Before
+  public void setUp() {
+    resolver = new PartitionKeyResolver(null);
+    mockClient = mock(DynamoDbClient.class);
+  }
+
+  @After
+  public void tearDown() {
+    if (resolver != null) {
+      resolver.shutdown();
+    }
+  }
+
+  // ========== Basic functionality tests ==========
+
+  @Test
+  public void testPreConfiguredPartitionKeys() {
+    Map<String, String> preConfigured = new HashMap<>();
+    preConfigured.put("users", "user_id");
+    preConfigured.put("orders", "order_id");
+
+    resolver.shutdown(); // Shutdown default resolver
+    resolver = new PartitionKeyResolver(preConfigured);
+
+    assertEquals("user_id", resolver.getPartitionKeyName("users"));
+    assertEquals("order_id", resolver.getPartitionKeyName("orders"));
+    assertNull(resolver.getPartitionKeyName("unknown"));
+  }
+
+  @Test
+  public void testManualRegistration() {
+    assertNull(resolver.getPartitionKeyName("products"));
+
+    resolver.register("products", "product_id");
+
+    assertEquals("product_id", resolver.getPartitionKeyName("products"));
+    assertTrue(resolver.hasPartitionKeyInfo("products"));
+  }
+
+  @Test
+  public void testSuccessfulDiscovery() throws Exception {
+    // Setup mock response
+    DescribeTableResponse response = createDescribeTableResponse("session_id");
+    when(mockClient.describeTable(any(DescribeTableRequest.class))).thenReturn(response);
+
+    // Trigger discovery
+    CountDownLatch latch = new CountDownLatch(1);
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              latch.countDown();
+              return response;
+            });
+
+    resolver.triggerDiscovery("sessions", mockClient);
+
+    // Wait for async discovery to complete
+    assertTrue("Discovery should complete", latch.await(5, TimeUnit.SECONDS));
+    Thread.sleep(100); // Give time for cache update
+
+    assertEquals("session_id", resolver.getPartitionKeyName("sessions"));
+    assertFalse(resolver.isInFailureCooldown("sessions"));
+  }
+
+  @Test
+  public void testDiscoverySkipsAlreadyCached() {
+    resolver.register("users", "user_id");
+
+    // Should not call client since already cached
+    resolver.triggerDiscovery("users", mockClient);
+
+    verify(mockClient, never()).describeTable(any(DescribeTableRequest.class));
+  }
+
+  // ========== Retry logic tests ==========
+
+  @Test
+  public void testRetryOnTransientError() throws Exception {
+    AtomicInteger attempts = new AtomicInteger(0);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    // Fail twice, then succeed
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  int attempt = attempts.incrementAndGet();
+                  if (attempt < 3) {
+                    // Simulate transient error (500 Internal Server Error)
+                    throw DynamoDbException.builder()
+                        .message("Internal Server Error")
+                        .statusCode(500)
+                        .build();
+                  }
+                  latch.countDown();
+                  return createDescribeTableResponse("item_id");
+                });
+
+    resolver.triggerDiscovery("items", mockClient);
+
+    assertTrue("Discovery should complete", latch.await(10, TimeUnit.SECONDS));
+    Thread.sleep(100); // Give time for cache update
+
+    assertEquals("item_id", resolver.getPartitionKeyName("items"));
+    assertEquals(3, attempts.get()); // 2 failures + 1 success
+  }
+
+  @Test
+  public void testNoRetryOnResourceNotFound() throws Exception {
+    AtomicInteger attempts = new AtomicInteger(0);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  attempts.incrementAndGet();
+                  latch.countDown();
+                  throw ResourceNotFoundException.builder().message("Table not found").build();
+                });
+
+    resolver.triggerDiscovery("nonexistent", mockClient);
+
+    assertTrue("Discovery should complete", latch.await(5, TimeUnit.SECONDS));
+    Thread.sleep(100);
+
+    assertNull(resolver.getPartitionKeyName("nonexistent"));
+    assertEquals(1, attempts.get()); // No retries
+    assertTrue(resolver.isInFailureCooldown("nonexistent"));
+  }
+
+  @Test
+  public void testNoRetryOnAccessDenied() throws Exception {
+    AtomicInteger attempts = new AtomicInteger(0);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  attempts.incrementAndGet();
+                  latch.countDown();
+                  throw DynamoDbException.builder()
+                      .message("Access Denied")
+                      .statusCode(403)
+                      .awsErrorDetails(
+                          AwsErrorDetails.builder()
+                              .errorCode("AccessDeniedException")
+                              .errorMessage("Access Denied")
+                              .build())
+                      .build();
+                });
+
+    resolver.triggerDiscovery("protected", mockClient);
+
+    assertTrue("Discovery should complete", latch.await(5, TimeUnit.SECONDS));
+    Thread.sleep(100);
+
+    assertNull(resolver.getPartitionKeyName("protected"));
+    assertEquals(1, attempts.get()); // No retries for permanent failure
+    assertTrue(resolver.isInFailureCooldown("protected"));
+  }
+
+  @Test
+  public void testRetryOnThrottling() throws Exception {
+    AtomicInteger attempts = new AtomicInteger(0);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    // Throttle twice, then succeed
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  int attempt = attempts.incrementAndGet();
+                  if (attempt < 3) {
+                    // 429 Too Many Requests - should retry
+                    throw DynamoDbException.builder()
+                        .message("Rate exceeded")
+                        .statusCode(429)
+                        .awsErrorDetails(
+                            AwsErrorDetails.builder()
+                                .errorCode("ThrottlingException")
+                                .errorMessage("Rate exceeded")
+                                .build())
+                        .build();
+                  }
+                  latch.countDown();
+                  return createDescribeTableResponse("throttled_pk");
+                });
+
+    resolver.triggerDiscovery("throttled", mockClient);
+
+    assertTrue("Discovery should complete", latch.await(10, TimeUnit.SECONDS));
+    Thread.sleep(100);
+
+    assertEquals("throttled_pk", resolver.getPartitionKeyName("throttled"));
+    assertEquals(3, attempts.get()); // 2 throttles + 1 success
+  }
+
+  @Test
+  public void testMaxRetriesExceeded() throws Exception {
+    AtomicInteger attempts = new AtomicInteger(0);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    // Always fail with transient error
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  int attempt = attempts.incrementAndGet();
+                  if (attempt > PartitionKeyResolver.MAX_RETRIES) {
+                    latch.countDown();
+                  }
+                  throw DynamoDbException.builder()
+                      .message("Service Unavailable")
+                      .statusCode(503)
+                      .build();
+                });
+
+    resolver.triggerDiscovery("failing", mockClient);
+
+    assertTrue("Discovery should complete after max retries", latch.await(10, TimeUnit.SECONDS));
+    Thread.sleep(100);
+
+    assertNull(resolver.getPartitionKeyName("failing"));
+    assertEquals(PartitionKeyResolver.MAX_RETRIES + 1, attempts.get());
+    // Transient failures allow immediate retry via triggerDiscovery
+    assertFalse(resolver.isInFailureCooldown("failing"));
+  }
+
+  // ========== Failure cooldown tests ==========
+
+  @Test
+  public void testClearFailure() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+
+    // Fail with permanent error
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  latch.countDown();
+                  throw ResourceNotFoundException.builder().message("Not found").build();
+                });
+
+    resolver.triggerDiscovery("missing", mockClient);
+    assertTrue(latch.await(5, TimeUnit.SECONDS));
+    Thread.sleep(100);
+
+    assertTrue(resolver.isInFailureCooldown("missing"));
+
+    // Clear the failure
+    resolver.clearFailure("missing");
+
+    assertFalse(resolver.isInFailureCooldown("missing"));
+  }
+
+  @Test
+  public void testFailedTableCount() throws Exception {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  latch.countDown();
+                  throw ResourceNotFoundException.builder().message("Not found").build();
+                });
+
+    resolver.triggerDiscovery("missing1", mockClient);
+    resolver.triggerDiscovery("missing2", mockClient);
+
+    assertTrue(latch.await(5, TimeUnit.SECONDS));
+    Thread.sleep(200);
+
+    assertEquals(2, resolver.getFailedTableCount());
+
+    resolver.clearFailure("missing1");
+    assertEquals(1, resolver.getFailedTableCount());
+  }
+
+  @Test
+  public void testDiscoveryBlockedDuringCooldown() throws Exception {
+    AtomicInteger attempts = new AtomicInteger(0);
+    CountDownLatch firstLatch = new CountDownLatch(1);
+
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  attempts.incrementAndGet();
+                  firstLatch.countDown();
+                  throw ResourceNotFoundException.builder().message("Not found").build();
+                });
+
+    // First discovery - fails
+    resolver.triggerDiscovery("blocked", mockClient);
+    assertTrue(firstLatch.await(5, TimeUnit.SECONDS));
+    Thread.sleep(100);
+
+    assertTrue(resolver.isInFailureCooldown("blocked"));
+    int attemptAfterFirstFailure = attempts.get();
+
+    // Second discovery - should be blocked by cooldown
+    resolver.triggerDiscovery("blocked", mockClient);
+    Thread.sleep(100);
+
+    // No additional attempts should have been made
+    assertEquals(attemptAfterFirstFailure, attempts.get());
+  }
+
+  // ========== Concurrent discovery tests ==========
+
+  @Test
+  public void testConcurrentDiscoveryForSameTable() throws Exception {
+    AtomicInteger attempts = new AtomicInteger(0);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch completeLatch = new CountDownLatch(1);
+
+    when(mockClient.describeTable(any(DescribeTableRequest.class)))
+        .thenAnswer(
+            (Answer<DescribeTableResponse>)
+                invocation -> {
+                  attempts.incrementAndGet();
+                  startLatch.await(); // Wait for signal to proceed
+                  completeLatch.countDown();
+                  return createDescribeTableResponse("concurrent_pk");
+                });
+
+    // Trigger multiple discoveries for the same table
+    resolver.triggerDiscovery("concurrent", mockClient);
+    resolver.triggerDiscovery("concurrent", mockClient);
+    resolver.triggerDiscovery("concurrent", mockClient);
+
+    Thread.sleep(100); // Let the discovery start
+
+    // Release the blocked discovery
+    startLatch.countDown();
+    assertTrue(completeLatch.await(5, TimeUnit.SECONDS));
+    Thread.sleep(100);
+
+    assertEquals("concurrent_pk", resolver.getPartitionKeyName("concurrent"));
+    assertEquals(1, attempts.get()); // Only one actual discovery attempt
+  }
+
+  // ========== Helper methods ==========
+
+  private DescribeTableResponse createDescribeTableResponse(String partitionKeyName) {
+    return DescribeTableResponse.builder()
+        .table(
+            TableDescription.builder()
+                .tableName("test-table")
+                .keySchema(
+                    Arrays.asList(
+                        KeySchemaElement.builder()
+                            .attributeName(partitionKeyName)
+                            .keyType(KeyType.HASH)
+                            .build(),
+                        KeySchemaElement.builder()
+                            .attributeName("sort_key")
+                            .keyType(KeyType.RANGE)
+                            .build()))
+                .build())
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

- Add key-based route affinity that routes requests with the same partition key to the same Alternator node
- Improves performance for Lightweight Transactions (LWT) that use Paxos consensus by reducing Paxos round-trips
- Supports three modes: `NONE` (round-robin), `RMW` (read-before-write ops only), and `ANY_WRITE` (all writes)

## New Components

- `KeyRouteAffinity` enum defining affinity modes
- `KeyRouteAffinityConfig` for configuration with builder pattern
- `MurmurHash3` for deterministic partition key hashing (compatible with Go client)
- `AttributeValueHasher` for hashing all DynamoDB attribute value types
- `KeyAffinityRequestClassifier` for determining which operations qualify
- `PartitionKeyResolver` for PK name caching and async auto-discovery
- `KeyRouteAffinityInterceptor` as ExecutionInterceptor for request routing
- `KeyRouteAffinityContext` for passing target node between interceptor and endpoint provider


Closes: https://github.com/scylladb/alternator-client-java/issues/28, https://github.com/scylladb/alternator-client-java/issues/27, https://github.com/scylladb/alternator-client-java/issues/26, https://github.com/scylladb/alternator-client-java/issues/25
## Usage

```java
KeyRouteAffinityConfig keyAffinity = KeyRouteAffinityConfig.builder()
    .withType(KeyRouteAffinity.RMW)
    .withPkInfo("users", "user_id")
    .build();

DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(URI.create("https://localhost:8043"))
    .credentialsProvider(credentialsProvider)
    .withKeyRouteAffinity(keyAffinity)
    .build();
```

## Test plan

- [x] Unit tests for all new components (MurmurHash3, AttributeValueHasher, KeyAffinityRequestClassifier, etc.)
- [x] Integration tests verifying same-key routing consistency
- [x] Tests for hash distribution across nodes
- [x] Tests for both RMW and ANY_WRITE modes
- [x] Manual testing with ScyllaDB cluster
