### PR TITLE
Add custom CA certificate support for TLS connections

### DIFF
--- a/src/main/java/com/scylladb/alternator/TlsConfig.java
+++ b/src/main/java/com/scylladb/alternator/TlsConfig.java
@@ -1,0 +1,366 @@
+package com.scylladb.alternator;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Configuration for TLS/SSL settings including custom CA certificate support.
+ *
+ * <p>This class consolidates all TLS-related settings for the Alternator client:
+ *
+ * <ul>
+ *   <li>Custom CA certificates from file paths (PEM format)
+ *   <li>Option to trust system CA certificates
+ *   <li>Trust-all mode for development/testing
+ *   <li>Hostname verification control
+ *   <li>Session cache configuration for TLS resumption
+ * </ul>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Trust all certificates (development/testing)
+ * TlsConfig config = TlsConfig.trustAll();
+ *
+ * // Use system CA certificates only
+ * TlsConfig config = TlsConfig.systemDefault();
+ *
+ * // Use custom CA certificate
+ * TlsConfig config = TlsConfig.builder()
+ *     .withCaCertPath(Paths.get("/path/to/ca.pem"))
+ *     .withTrustSystemCaCerts(false)  // only trust the custom CA
+ *     .build();
+ *
+ * // Combine custom CA with system CAs
+ * TlsConfig config = TlsConfig.builder()
+ *     .withCaCertPath(Paths.get("/path/to/ca.pem"))
+ *     .withTrustSystemCaCerts(true)
+ *     .build();
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.9
+ */
+public final class TlsConfig {
+
+  private static final TlsConfig TRUST_ALL_INSTANCE =
+      new TlsConfig(
+          Collections.<Path>emptyList(), false, true, false, TlsSessionCacheConfig.getDefault());
+
+  private static final TlsConfig SYSTEM_DEFAULT_INSTANCE =
+      new TlsConfig(
+          Collections.<Path>emptyList(), true, false, true, TlsSessionCacheConfig.getDefault());
+
+  private final List<Path> customCaCertPaths;
+  private final boolean trustSystemCaCerts;
+  private final boolean trustAllCertificates;
+  private final boolean verifyHostname;
+  private final TlsSessionCacheConfig sessionCacheConfig;
+
+  private TlsConfig(
+      List<Path> customCaCertPaths,
+      boolean trustSystemCaCerts,
+      boolean trustAllCertificates,
+      boolean verifyHostname,
+      TlsSessionCacheConfig sessionCacheConfig) {
+    this.customCaCertPaths =
+        customCaCertPaths != null
+            ? Collections.unmodifiableList(new ArrayList<>(customCaCertPaths))
+            : Collections.<Path>emptyList();
+    this.trustSystemCaCerts = trustSystemCaCerts;
+    this.trustAllCertificates = trustAllCertificates;
+    this.verifyHostname = verifyHostname;
+    this.sessionCacheConfig =
+        sessionCacheConfig != null ? sessionCacheConfig : TlsSessionCacheConfig.getDefault();
+  }
+
+  /**
+   * Returns a TlsConfig that trusts all certificates (including self-signed).
+   *
+   * <p><strong>Security Warning:</strong> This configuration should only be used for
+   * development/testing purposes. It disables certificate validation entirely, making connections
+   * vulnerable to man-in-the-middle attacks.
+   *
+   * <p>This configuration:
+   *
+   * <ul>
+   *   <li>Trusts ALL certificates (no validation)
+   *   <li>Disables hostname verification
+   *   <li>Uses default session cache settings
+   * </ul>
+   *
+   * @return a TlsConfig that trusts all certificates
+   */
+  public static TlsConfig trustAll() {
+    return TRUST_ALL_INSTANCE;
+  }
+
+  /**
+   * Returns a TlsConfig that uses the system's default CA certificates.
+   *
+   * <p>This configuration uses the JVM's default trust store (typically located at
+   * $JAVA_HOME/lib/security/cacerts) for certificate validation.
+   *
+   * <p>This configuration:
+   *
+   * <ul>
+   *   <li>Trusts system CA certificates
+   *   <li>Enables hostname verification
+   *   <li>Uses default session cache settings
+   * </ul>
+   *
+   * @return a TlsConfig that uses system CA certificates
+   */
+  public static TlsConfig systemDefault() {
+    return SYSTEM_DEFAULT_INSTANCE;
+  }
+
+  /**
+   * Creates a new builder for TlsConfig.
+   *
+   * @return a new {@link Builder}
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns the list of custom CA certificate file paths.
+   *
+   * <p>These are paths to PEM-encoded certificate files that will be used for server certificate
+   * validation.
+   *
+   * @return an unmodifiable list of CA certificate paths, never null but may be empty
+   */
+  public List<Path> getCustomCaCertPaths() {
+    return customCaCertPaths;
+  }
+
+  /**
+   * Returns whether system CA certificates should be trusted.
+   *
+   * <p>When true, the JVM's default trust store is included in certificate validation along with
+   * any custom CA certificates.
+   *
+   * @return true if system CA certificates should be trusted
+   */
+  public boolean isTrustSystemCaCerts() {
+    return trustSystemCaCerts;
+  }
+
+  /**
+   * Returns whether all certificates should be trusted (no validation).
+   *
+   * <p><strong>Security Warning:</strong> When true, certificate validation is completely disabled.
+   * This should only be used for development/testing.
+   *
+   * @return true if all certificates should be trusted
+   */
+  public boolean isTrustAllCertificates() {
+    return trustAllCertificates;
+  }
+
+  /**
+   * Returns whether hostname verification is enabled.
+   *
+   * <p>When true, the server's hostname is verified against the certificate's Subject Alternative
+   * Names (SANs) or Common Name (CN).
+   *
+   * @return true if hostname verification is enabled
+   */
+  public boolean isVerifyHostname() {
+    return verifyHostname;
+  }
+
+  /**
+   * Returns the TLS session cache configuration.
+   *
+   * @return the session cache configuration, never null
+   */
+  public TlsSessionCacheConfig getSessionCacheConfig() {
+    return sessionCacheConfig;
+  }
+
+  @Override
+  public String toString() {
+    return "TlsConfig{"
+        + "customCaCertPaths="
+        + customCaCertPaths
+        + ", trustSystemCaCerts="
+        + trustSystemCaCerts
+        + ", trustAllCertificates="
+        + trustAllCertificates
+        + ", verifyHostname="
+        + verifyHostname
+        + ", sessionCacheConfig="
+        + sessionCacheConfig
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TlsConfig tlsConfig = (TlsConfig) o;
+    return trustSystemCaCerts == tlsConfig.trustSystemCaCerts
+        && trustAllCertificates == tlsConfig.trustAllCertificates
+        && verifyHostname == tlsConfig.verifyHostname
+        && Objects.equals(customCaCertPaths, tlsConfig.customCaCertPaths)
+        && Objects.equals(sessionCacheConfig, tlsConfig.sessionCacheConfig);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        customCaCertPaths,
+        trustSystemCaCerts,
+        trustAllCertificates,
+        verifyHostname,
+        sessionCacheConfig);
+  }
+
+  /** Builder for creating {@link TlsConfig} instances. */
+  public static class Builder {
+    private List<Path> customCaCertPaths = new ArrayList<>();
+    private boolean trustSystemCaCerts = true;
+    private boolean trustAllCertificates = false;
+    private boolean verifyHostname = true;
+    private TlsSessionCacheConfig sessionCacheConfig = null;
+
+    Builder() {}
+
+    /**
+     * Adds a custom CA certificate path.
+     *
+     * <p>The file should be PEM-encoded and can contain one or more certificates. Multiple
+     * certificate files can be added by calling this method multiple times.
+     *
+     * @param path the path to a PEM-encoded CA certificate file
+     * @return this builder instance
+     * @throws IllegalArgumentException if path is null
+     */
+    public Builder withCaCertPath(Path path) {
+      if (path == null) {
+        throw new IllegalArgumentException("CA certificate path cannot be null");
+      }
+      this.customCaCertPaths.add(path);
+      return this;
+    }
+
+    /**
+     * Sets multiple custom CA certificate paths.
+     *
+     * <p>This replaces any previously added paths. Each file should be PEM-encoded and can contain
+     * one or more certificates.
+     *
+     * @param paths the paths to PEM-encoded CA certificate files
+     * @return this builder instance
+     */
+    public Builder withCaCertPaths(Collection<Path> paths) {
+      this.customCaCertPaths = paths != null ? new ArrayList<>(paths) : new ArrayList<Path>();
+      return this;
+    }
+
+    /**
+     * Sets whether to trust system CA certificates.
+     *
+     * <p>When true (default), the JVM's default trust store is included in certificate validation.
+     * Set to false to only trust explicitly configured custom CA certificates.
+     *
+     * @param trustSystemCaCerts true to include system CAs in trust evaluation
+     * @return this builder instance
+     */
+    public Builder withTrustSystemCaCerts(boolean trustSystemCaCerts) {
+      this.trustSystemCaCerts = trustSystemCaCerts;
+      return this;
+    }
+
+    /**
+     * Sets whether to trust all certificates (disable certificate validation).
+     *
+     * <p><strong>Security Warning:</strong> Setting this to true disables all certificate
+     * validation and should only be used for development/testing. This also disables hostname
+     * verification.
+     *
+     * @param trustAllCertificates true to trust all certificates
+     * @return this builder instance
+     */
+    public Builder withTrustAllCertificates(boolean trustAllCertificates) {
+      this.trustAllCertificates = trustAllCertificates;
+      return this;
+    }
+
+    /**
+     * Sets whether to verify hostnames in server certificates.
+     *
+     * <p>When true (default), the server's hostname is verified against the certificate's Subject
+     * Alternative Names (SANs) or Common Name (CN). Set to false to skip hostname verification.
+     *
+     * <p><strong>Security Warning:</strong> Disabling hostname verification makes connections
+     * vulnerable to man-in-the-middle attacks where an attacker could present a valid certificate
+     * for a different hostname.
+     *
+     * @param verifyHostname true to enable hostname verification
+     * @return this builder instance
+     */
+    public Builder withVerifyHostname(boolean verifyHostname) {
+      this.verifyHostname = verifyHostname;
+      return this;
+    }
+
+    /**
+     * Sets the TLS session cache configuration.
+     *
+     * <p>TLS session caching enables quick TLS renegotiation by caching session tickets.
+     *
+     * @param sessionCacheConfig the session cache configuration, or null to use default
+     * @return this builder instance
+     */
+    public Builder withSessionCacheConfig(TlsSessionCacheConfig sessionCacheConfig) {
+      this.sessionCacheConfig = sessionCacheConfig;
+      return this;
+    }
+
+    /**
+     * Builds and returns a {@link TlsConfig} instance.
+     *
+     * <p>Validation rules:
+     *
+     * <ul>
+     *   <li>If trustAllCertificates is true, other trust settings are ignored
+     *   <li>If trustAllCertificates is false and no custom CAs are provided and trustSystemCaCerts
+     *       is false, an exception is thrown
+     * </ul>
+     *
+     * @return a new TlsConfig instance
+     * @throws IllegalStateException if the configuration is invalid
+     */
+    public TlsConfig build() {
+      // If trust-all is enabled, hostname verification should be disabled
+      boolean effectiveVerifyHostname = trustAllCertificates ? false : verifyHostname;
+
+      // Validate that we have at least some way to validate certificates
+      if (!trustAllCertificates && !trustSystemCaCerts && customCaCertPaths.isEmpty()) {
+        throw new IllegalStateException(
+            "Invalid TLS configuration: no trust source configured. "
+                + "Either enable trustSystemCaCerts, add custom CA certificates, "
+                + "or enable trustAllCertificates (for development only).");
+      }
+
+      return new TlsConfig(
+          customCaCertPaths,
+          trustSystemCaCerts,
+          trustAllCertificates,
+          effectiveVerifyHostname,
+          sessionCacheConfig);
+    }
+  }
+}

--- a/src/main/java/com/scylladb/alternator/internal/TlsContextFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/TlsContextFactory.java
@@ -1,12 +1,27 @@
 package com.scylladb.alternator.internal;
 
+import com.scylladb.alternator.TlsConfig;
 import com.scylladb.alternator.TlsSessionCacheConfig;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -17,12 +32,14 @@ import javax.net.ssl.X509TrustManager;
  * <ul>
  *   <li>Modern TLS protocols (TLS 1.2+) that support session tickets
  *   <li>Configurable session caching for TLS session resumption
+ *   <li>Custom CA certificate support for production deployments
  *   <li>Trust-all certificate validation (for development/testing with self-signed certs)
  * </ul>
  *
- * <p><strong>Security Note:</strong> The created SSL contexts accept all certificates including
- * self-signed ones. This is intentional for development and testing scenarios but should be
- * carefully considered for production deployments.
+ * <p><strong>Security Note:</strong> For production deployments, use {@link
+ * #createSslContext(TlsConfig)} with properly configured CA certificates. The legacy {@link
+ * #createSslContext(TlsSessionCacheConfig)} method trusts all certificates and should only be used
+ * for development/testing.
  *
  * @author dmitry.kropachev
  * @since 1.0.5
@@ -31,6 +48,136 @@ public final class TlsContextFactory {
 
   private TlsContextFactory() {
     // Utility class
+  }
+
+  /**
+   * Creates an SSLContext configured according to the provided TLS configuration.
+   *
+   * <p>This method supports:
+   *
+   * <ul>
+   *   <li>Custom CA certificates from PEM files
+   *   <li>System CA certificates (JVM default trust store)
+   *   <li>Combination of custom and system CAs
+   *   <li>Trust-all mode for development/testing
+   * </ul>
+   *
+   * @param config the TLS configuration
+   * @return a configured SSLContext
+   * @throws RuntimeException if the SSL context cannot be created or certificates cannot be loaded
+   * @since 1.0.9
+   */
+  public static SSLContext createSslContext(TlsConfig config) {
+    if (config == null) {
+      config = TlsConfig.trustAll();
+    }
+
+    TrustManager[] trustManagers;
+    if (config.isTrustAllCertificates()) {
+      trustManagers = createTrustAllManagers();
+    } else {
+      trustManagers = createTrustManagers(config);
+    }
+
+    try {
+      SSLContext sslContext = createBaseContext();
+      sslContext.init(null, trustManagers, new java.security.SecureRandom());
+      configureSessionCache(sslContext, config.getSessionCacheConfig());
+      return sslContext;
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      throw new RuntimeException("Failed to create SSL context", e);
+    }
+  }
+
+  /**
+   * Creates trust managers based on the TLS configuration.
+   *
+   * @param config the TLS configuration
+   * @return an array of TrustManagers
+   */
+  private static TrustManager[] createTrustManagers(TlsConfig config) {
+    try {
+      List<TrustManager> allTrustManagers = new ArrayList<>();
+
+      // Add custom CA certificates if provided
+      if (!config.getCustomCaCertPaths().isEmpty()) {
+        KeyStore customKeyStore = loadCertificates(config.getCustomCaCertPaths());
+        TrustManagerFactory customTmf =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        customTmf.init(customKeyStore);
+        for (TrustManager tm : customTmf.getTrustManagers()) {
+          allTrustManagers.add(tm);
+        }
+      }
+
+      // Add system CA certificates if requested
+      if (config.isTrustSystemCaCerts()) {
+        TrustManagerFactory systemTmf =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        systemTmf.init((KeyStore) null); // null loads the default trust store
+        for (TrustManager tm : systemTmf.getTrustManagers()) {
+          allTrustManagers.add(tm);
+        }
+      }
+
+      // If we have multiple trust managers, combine them
+      if (allTrustManagers.size() > 1) {
+        return new TrustManager[] {new CompositeX509TrustManager(allTrustManagers)};
+      } else if (allTrustManagers.size() == 1) {
+        return new TrustManager[] {allTrustManagers.get(0)};
+      } else {
+        throw new RuntimeException(
+            "No trust managers configured. Enable system CAs or provide custom CA certificates.");
+      }
+    } catch (NoSuchAlgorithmException | KeyStoreException e) {
+      throw new RuntimeException("Failed to create trust managers", e);
+    }
+  }
+
+  /**
+   * Loads certificates from the specified PEM files into a KeyStore.
+   *
+   * @param certPaths the paths to PEM-encoded certificate files
+   * @return a KeyStore containing the loaded certificates
+   */
+  private static KeyStore loadCertificates(List<Path> certPaths) {
+    try {
+      KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keyStore.load(null, null); // Initialize empty keystore
+
+      CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+      int certIndex = 0;
+
+      for (Path certPath : certPaths) {
+        try (InputStream is = new BufferedInputStream(Files.newInputStream(certPath))) {
+          Collection<? extends Certificate> certs = certFactory.generateCertificates(is);
+          for (Certificate cert : certs) {
+            String alias = "custom-ca-" + certIndex++;
+            keyStore.setCertificateEntry(alias, cert);
+          }
+        }
+      }
+
+      return keyStore;
+    } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+      throw new RuntimeException("Failed to load CA certificates", e);
+    }
+  }
+
+  /**
+   * Creates the base SSLContext with appropriate TLS version.
+   *
+   * @return an uninitialized SSLContext
+   * @throws NoSuchAlgorithmException if TLS is not available
+   */
+  private static SSLContext createBaseContext() throws NoSuchAlgorithmException {
+    // Prefer TLSv1.3 for session ticket support, fall back to TLS if not available
+    try {
+      return SSLContext.getInstance("TLSv1.3");
+    } catch (NoSuchAlgorithmException e) {
+      // Fall back to generic TLS (will use highest available version)
+      return SSLContext.getInstance("TLS");
+    }
   }
 
   /**
@@ -48,31 +195,20 @@ public final class TlsContextFactory {
    * session tickets via {@code alternator_encryption_options.enable_session_tickets: true} in
    * scylla.yaml.
    *
+   * <p><strong>Security Note:</strong> This method trusts all certificates including self-signed
+   * ones. For production deployments, use {@link #createSslContext(TlsConfig)} with properly
+   * configured CA certificates instead.
+   *
    * @param config the TLS session cache configuration
    * @return a configured SSLContext
    * @throws RuntimeException if the SSL context cannot be created
+   * @deprecated Use {@link #createSslContext(TlsConfig)} for better security configuration
    */
+  @Deprecated
   public static SSLContext createSslContext(TlsSessionCacheConfig config) {
-    TrustManager[] trustAllCertificates = createTrustAllManagers();
-
-    try {
-      // Prefer TLSv1.3 for session ticket support, fall back to TLS if not available
-      SSLContext sslContext;
-      try {
-        sslContext = SSLContext.getInstance("TLSv1.3");
-      } catch (NoSuchAlgorithmException e) {
-        // Fall back to generic TLS (will use highest available version)
-        sslContext = SSLContext.getInstance("TLS");
-      }
-      sslContext.init(null, trustAllCertificates, new java.security.SecureRandom());
-
-      // Configure session caching
-      configureSessionCache(sslContext, config);
-
-      return sslContext;
-    } catch (NoSuchAlgorithmException | KeyManagementException e) {
-      throw new RuntimeException("Failed to create SSL context", e);
-    }
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withTrustAllCertificates(true).withSessionCacheConfig(config).build();
+    return createSslContext(tlsConfig);
   }
 
   /**
@@ -112,7 +248,7 @@ public final class TlsContextFactory {
    */
   private static void configureSessionCache(SSLContext sslContext, TlsSessionCacheConfig config) {
     SSLSessionContext clientSessionContext = sslContext.getClientSessionContext();
-    if (clientSessionContext != null) {
+    if (clientSessionContext != null && config != null) {
       if (config.isEnabled()) {
         // Enable session caching with configured size and timeout
         clientSessionContext.setSessionCacheSize(config.getSessionCacheSize());
@@ -121,6 +257,73 @@ public final class TlsContextFactory {
         // Disable session caching by setting cache size to 0
         clientSessionContext.setSessionCacheSize(0);
       }
+    }
+  }
+
+  /**
+   * A composite X509TrustManager that delegates to multiple trust managers.
+   *
+   * <p>This allows combining custom CA certificates with system CA certificates. A certificate is
+   * trusted if any of the underlying trust managers trusts it.
+   */
+  private static class CompositeX509TrustManager implements X509TrustManager {
+    private final List<X509TrustManager> trustManagers;
+
+    CompositeX509TrustManager(List<TrustManager> managers) {
+      this.trustManagers = new ArrayList<>();
+      for (TrustManager tm : managers) {
+        if (tm instanceof X509TrustManager) {
+          this.trustManagers.add((X509TrustManager) tm);
+        }
+      }
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+        throws CertificateException {
+      CertificateException lastException = null;
+      for (X509TrustManager tm : trustManagers) {
+        try {
+          tm.checkClientTrusted(chain, authType);
+          return; // Success
+        } catch (CertificateException e) {
+          lastException = e;
+        }
+      }
+      if (lastException != null) {
+        throw lastException;
+      }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType)
+        throws CertificateException {
+      CertificateException lastException = null;
+      for (X509TrustManager tm : trustManagers) {
+        try {
+          tm.checkServerTrusted(chain, authType);
+          return; // Success
+        } catch (CertificateException e) {
+          lastException = e;
+        }
+      }
+      if (lastException != null) {
+        throw lastException;
+      }
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      List<X509Certificate> issuers = new ArrayList<>();
+      for (X509TrustManager tm : trustManagers) {
+        X509Certificate[] certs = tm.getAcceptedIssuers();
+        if (certs != null) {
+          for (X509Certificate cert : certs) {
+            issuers.add(cert);
+          }
+        }
+      }
+      return issuers.toArray(new X509Certificate[0]);
     }
   }
 }

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigTlsTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigTlsTest.java
@@ -92,4 +92,129 @@ public class AlternatorConfigTlsTest {
     assertNotNull(tlsConfig);
     assertTrue(tlsConfig.isEnabled());
   }
+
+  // Tests for TlsConfig (new CA certificate support)
+
+  @Test
+  public void testDefaultTlsConfig() {
+    AlternatorConfig config =
+        AlternatorConfig.builder().withSeedNode(URI.create("https://localhost:8043")).build();
+
+    TlsConfig tlsConfig = config.getTlsConfig();
+    assertNotNull("TlsConfig should not be null", tlsConfig);
+    // Default should be trust-all for backwards compatibility
+    assertTrue("Default should trust all certificates", tlsConfig.isTrustAllCertificates());
+  }
+
+  @Test
+  public void testTlsConfigTrustAll() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsConfig(TlsConfig.trustAll())
+            .build();
+
+    TlsConfig tlsConfig = config.getTlsConfig();
+    assertTrue("Should trust all certificates", tlsConfig.isTrustAllCertificates());
+    assertFalse("Should not verify hostname", tlsConfig.isVerifyHostname());
+  }
+
+  @Test
+  public void testTlsConfigSystemDefault() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsConfig(TlsConfig.systemDefault())
+            .build();
+
+    TlsConfig tlsConfig = config.getTlsConfig();
+    assertFalse("Should not trust all certificates", tlsConfig.isTrustAllCertificates());
+    assertTrue("Should trust system CAs", tlsConfig.isTrustSystemCaCerts());
+    assertTrue("Should verify hostname", tlsConfig.isVerifyHostname());
+  }
+
+  @Test
+  public void testTlsConfigWithSessionCache() {
+    TlsSessionCacheConfig sessionConfig =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(256)
+            .withSessionTimeoutSeconds(1800)
+            .build();
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(sessionConfig)
+            .build();
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsConfig(tlsConfig)
+            .build();
+
+    assertEquals(sessionConfig, config.getTlsConfig().getSessionCacheConfig());
+    assertEquals(256, config.getTlsConfig().getSessionCacheConfig().getSessionCacheSize());
+  }
+
+  @Test
+  public void testTlsConfigNullUsesDefault() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsConfig(null)
+            .build();
+
+    TlsConfig tlsConfig = config.getTlsConfig();
+    assertNotNull("TlsConfig should not be null even when set to null", tlsConfig);
+    // Default should be trust-all for backwards compatibility
+    assertTrue("Default should trust all certificates", tlsConfig.isTrustAllCertificates());
+  }
+
+  @Test
+  public void testLegacyTlsSessionCacheConfigCreatesTlsConfig() {
+    // When only TlsSessionCacheConfig is set (legacy way), TlsConfig should be created
+    TlsSessionCacheConfig sessionConfig =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(512)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsSessionCacheConfig(sessionConfig)
+            .build();
+
+    TlsConfig tlsConfig = config.getTlsConfig();
+    assertNotNull("TlsConfig should be created from TlsSessionCacheConfig", tlsConfig);
+    assertTrue(
+        "Should trust all certificates for backwards compatibility",
+        tlsConfig.isTrustAllCertificates());
+    assertEquals(512, tlsConfig.getSessionCacheConfig().getSessionCacheSize());
+  }
+
+  @Test
+  public void testTlsConfigOverridesTlsSessionCacheConfig() {
+    // When both are set, TlsConfig should take precedence
+    TlsSessionCacheConfig legacyConfig =
+        TlsSessionCacheConfig.builder().withSessionCacheSize(100).build();
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustSystemCaCerts(true)
+            .withSessionCacheConfig(
+                TlsSessionCacheConfig.builder().withSessionCacheSize(200).build())
+            .build();
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("https://localhost:8043"))
+            .withTlsSessionCacheConfig(legacyConfig)
+            .withTlsConfig(tlsConfig)
+            .build();
+
+    // TlsConfig should be used
+    assertEquals(200, config.getTlsConfig().getSessionCacheConfig().getSessionCacheSize());
+  }
 }

--- a/src/test/java/com/scylladb/alternator/TlsConfigIT.java
+++ b/src/test/java/com/scylladb/alternator/TlsConfigIT.java
@@ -1,0 +1,840 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+import com.scylladb.alternator.internal.TlsContextFactory;
+import com.scylladb.alternator.routing.ClusterScope;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesRequest;
+
+/**
+ * Integration tests for TLS configuration features.
+ *
+ * <p>These tests verify the TlsConfig class functionality with real TLS connections:
+ *
+ * <ul>
+ *   <li>Custom CA certificate loading and validation
+ *   <li>System CA certificate trust
+ *   <li>Trust-all mode for development/testing
+ *   <li>Hostname verification behavior
+ *   <li>Combination with other client features (compression, headers optimization)
+ *   <li>Both synchronous and asynchronous clients
+ * </ul>
+ *
+ * <p>Set environment variables to configure:
+ *
+ * <ul>
+ *   <li>ALTERNATOR_HOST: Host address (default: 172.39.0.2)
+ *   <li>ALTERNATOR_HTTPS_PORT: Port number for HTTPS (default: 9999)
+ *   <li>INTEGRATION_TESTS: Set to "true" to enable tests
+ *   <li>ALTERNATOR_CA_CERT_PATH: Path to CA certificate (optional, for custom CA tests)
+ * </ul>
+ *
+ * @author dmitry.kropachev
+ * @since 1.0.9
+ */
+public class TlsConfigIT {
+
+  private static String host;
+  private static int httpsPort;
+  private static URI seedUri;
+  private static boolean integrationTestsEnabled;
+  private static StaticCredentialsProvider credentialsProvider;
+  private static Path customCaCertPath;
+
+  private AlternatorDynamoDbClientWrapper syncWrapper;
+  private AlternatorDynamoDbAsyncClientWrapper asyncWrapper;
+
+  @BeforeClass
+  public static void setUpClass() {
+    host = System.getenv().getOrDefault("ALTERNATOR_HOST", "172.39.0.2");
+    httpsPort = Integer.parseInt(System.getenv().getOrDefault("ALTERNATOR_HTTPS_PORT", "9999"));
+
+    try {
+      seedUri = new URI("https://" + host + ":" + httpsPort);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+
+    credentialsProvider =
+        StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test"));
+
+    integrationTestsEnabled =
+        Boolean.parseBoolean(System.getenv().getOrDefault("INTEGRATION_TESTS", "false"));
+
+    // Optional custom CA cert path from environment
+    String caCertEnv = System.getenv("ALTERNATOR_CA_CERT_PATH");
+    if (caCertEnv != null && !caCertEnv.isEmpty()) {
+      customCaCertPath = Path.of(caCertEnv);
+    }
+  }
+
+  @Before
+  public void setUp() {
+    assumeTrue(
+        "Integration tests disabled. Set INTEGRATION_TESTS=true to enable.",
+        integrationTestsEnabled);
+  }
+
+  @After
+  public void tearDown() {
+    if (syncWrapper != null) {
+      try {
+        syncWrapper.close();
+      } catch (Exception e) {
+        // Ignore cleanup errors
+      }
+      syncWrapper = null;
+    }
+    if (asyncWrapper != null) {
+      try {
+        asyncWrapper.close();
+      } catch (Exception e) {
+        // Ignore cleanup errors
+      }
+      asyncWrapper = null;
+    }
+  }
+
+  // ==========================================================================
+  // TrustAll Mode Tests
+  // ==========================================================================
+
+  @Test
+  public void testSyncClientWithTrustAllConfig() throws Exception {
+    TlsConfig tlsConfig = TlsConfig.trustAll();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify TLS config is applied
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertTrue("Should use trust-all mode", config.getTlsConfig().isTrustAllCertificates());
+    assertFalse(
+        "Hostname verification should be disabled in trust-all mode",
+        config.getTlsConfig().isVerifyHostname());
+  }
+
+  @Test
+  public void testAsyncClientWithTrustAllConfig() throws Exception {
+    TlsConfig tlsConfig = TlsConfig.trustAll();
+
+    asyncWrapper =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional
+    List<URI> nodes = asyncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Perform async operation
+    DynamoDbAsyncClient client = asyncWrapper.getClient();
+    CompletableFuture<Void> future =
+        client
+            .listTables(ListTablesRequest.builder().limit(1).build())
+            .thenAccept(response -> assertNotNull(response))
+            .exceptionally(
+                ex -> {
+                  // Ignore DynamoDB errors, we're testing TLS
+                  return null;
+                });
+
+    future.get(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testTrustAllWithMultipleRequests() throws Exception {
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(TlsConfig.trustAll())
+            .buildWithAlternatorAPI();
+
+    DynamoDbClient client = syncWrapper.getClient();
+
+    // Make multiple requests to test TLS connection stability
+    for (int i = 0; i < 10; i++) {
+      try {
+        client.listTables(ListTablesRequest.builder().limit(1).build());
+      } catch (Exception e) {
+        // Ignore DynamoDB errors, we're testing TLS
+      }
+    }
+
+    // Verify connection is still working
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should still have nodes after multiple requests", nodes.isEmpty());
+  }
+
+  // ==========================================================================
+  // System Default CA Tests
+  // ==========================================================================
+
+  @Test
+  public void testSyncClientWithSystemDefaultConfig() throws Exception {
+    // This test may fail if the server uses a self-signed certificate
+    // It verifies that the system default trust store is used
+
+    TlsConfig tlsConfig = TlsConfig.systemDefault();
+
+    try {
+      syncWrapper =
+          AlternatorDynamoDbClient.builder()
+              .endpointOverride(seedUri)
+              .credentialsProvider(credentialsProvider)
+              .withTlsConfig(tlsConfig)
+              .buildWithAlternatorAPI();
+
+      // If we get here, the server's certificate is trusted by system CAs
+      List<URI> nodes = syncWrapper.getLiveNodes();
+      assertFalse("Should have at least one node", nodes.isEmpty());
+
+      AlternatorConfig config = syncWrapper.getAlternatorConfig();
+      assertTrue("Should trust system CAs", config.getTlsConfig().isTrustSystemCaCerts());
+      assertFalse(
+          "Should not be in trust-all mode", config.getTlsConfig().isTrustAllCertificates());
+      assertTrue(
+          "Hostname verification should be enabled", config.getTlsConfig().isVerifyHostname());
+    } catch (Exception e) {
+      // Expected if server uses self-signed certificate
+      assertTrue(
+          "Should fail with SSL error for untrusted certificate",
+          e.getCause() instanceof SSLHandshakeException
+              || e.getMessage().contains("SSL")
+              || e.getMessage().contains("certificate"));
+      System.out.println(
+          "testSyncClientWithSystemDefaultConfig: Expected failure with self-signed cert - "
+              + e.getMessage());
+    }
+  }
+
+  // ==========================================================================
+  // Custom CA Certificate Tests
+  // ==========================================================================
+
+  @Test
+  public void testSyncClientWithCustomCaCert() throws Exception {
+    assumeTrue(
+        "Custom CA certificate path not set. Set ALTERNATOR_CA_CERT_PATH to enable this test.",
+        customCaCertPath != null && Files.exists(customCaCertPath));
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withCaCertPath(customCaCertPath)
+            .withTrustSystemCaCerts(false) // Only trust the custom CA
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify TLS config
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertEquals(1, config.getTlsConfig().getCustomCaCertPaths().size());
+    assertFalse(config.getTlsConfig().isTrustSystemCaCerts());
+    assertTrue(config.getTlsConfig().isVerifyHostname());
+  }
+
+  @Test
+  public void testAsyncClientWithCustomCaCert() throws Exception {
+    assumeTrue(
+        "Custom CA certificate path not set. Set ALTERNATOR_CA_CERT_PATH to enable this test.",
+        customCaCertPath != null && Files.exists(customCaCertPath));
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withCaCertPath(customCaCertPath).withTrustSystemCaCerts(false).build();
+
+    asyncWrapper =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional
+    List<URI> nodes = asyncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+  }
+
+  @Test
+  public void testCustomCaCertCombinedWithSystemCAs() throws Exception {
+    assumeTrue(
+        "Custom CA certificate path not set. Set ALTERNATOR_CA_CERT_PATH to enable this test.",
+        customCaCertPath != null && Files.exists(customCaCertPath));
+
+    // Trust both custom CA and system CAs
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withCaCertPath(customCaCertPath)
+            .withTrustSystemCaCerts(true) // Also trust system CAs
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    // Verify client is functional
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify config
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertTrue(config.getTlsConfig().isTrustSystemCaCerts());
+    assertEquals(1, config.getTlsConfig().getCustomCaCertPaths().size());
+  }
+
+  @Test
+  public void testInvalidCaCertPathFailsGracefully() throws Exception {
+    Path invalidPath = Path.of("/non/existent/ca.pem");
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withCaCertPath(invalidPath).withTrustSystemCaCerts(false).build();
+
+    try {
+      syncWrapper =
+          AlternatorDynamoDbClient.builder()
+              .endpointOverride(seedUri)
+              .credentialsProvider(credentialsProvider)
+              .withTlsConfig(tlsConfig)
+              .buildWithAlternatorAPI();
+      fail("Should fail with invalid CA certificate path");
+    } catch (RuntimeException e) {
+      assertTrue(
+          "Error should mention certificate loading failure",
+          e.getMessage().contains("certificate") || e.getMessage().contains("CA"));
+    }
+  }
+
+  @Test
+  public void testInvalidCaCertContentFailsGracefully() throws Exception {
+    // Create a temp file with invalid certificate content
+    Path tempFile = Files.createTempFile("invalid-ca-", ".pem");
+    try {
+      Files.writeString(tempFile, "This is not a valid certificate");
+
+      TlsConfig tlsConfig =
+          TlsConfig.builder().withCaCertPath(tempFile).withTrustSystemCaCerts(false).build();
+
+      try {
+        syncWrapper =
+            AlternatorDynamoDbClient.builder()
+                .endpointOverride(seedUri)
+                .credentialsProvider(credentialsProvider)
+                .withTlsConfig(tlsConfig)
+                .buildWithAlternatorAPI();
+        fail("Should fail with invalid CA certificate content");
+      } catch (RuntimeException e) {
+        // Expected - invalid certificate format
+        assertTrue(
+            "Error should be about certificate",
+            e.getMessage().toLowerCase().contains("certificate")
+                || e.getMessage().toLowerCase().contains("ca"));
+      }
+    } finally {
+      Files.deleteIfExists(tempFile);
+    }
+  }
+
+  // ==========================================================================
+  // Hostname Verification Tests
+  // ==========================================================================
+
+  @Test
+  public void testHostnameVerificationEnabled() throws Exception {
+    assumeTrue(
+        "Custom CA certificate path not set. Set ALTERNATOR_CA_CERT_PATH to enable this test.",
+        customCaCertPath != null && Files.exists(customCaCertPath));
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withCaCertPath(customCaCertPath)
+            .withTrustSystemCaCerts(false)
+            .withVerifyHostname(true) // Explicitly enable
+            .build();
+
+    // This may fail if the server certificate doesn't match the hostname
+    try {
+      syncWrapper =
+          AlternatorDynamoDbClient.builder()
+              .endpointOverride(seedUri)
+              .credentialsProvider(credentialsProvider)
+              .withTlsConfig(tlsConfig)
+              .buildWithAlternatorAPI();
+
+      List<URI> nodes = syncWrapper.getLiveNodes();
+      assertFalse("Should have at least one node", nodes.isEmpty());
+    } catch (Exception e) {
+      // May fail if hostname doesn't match certificate
+      System.out.println("Hostname verification test: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testHostnameVerificationDisabled() throws Exception {
+    assumeTrue(
+        "Custom CA certificate path not set. Set ALTERNATOR_CA_CERT_PATH to enable this test.",
+        customCaCertPath != null && Files.exists(customCaCertPath));
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withCaCertPath(customCaCertPath)
+            .withTrustSystemCaCerts(false)
+            .withVerifyHostname(false) // Disable hostname verification
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    // Should succeed even if hostname doesn't match certificate
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertFalse(
+        "Hostname verification should be disabled", config.getTlsConfig().isVerifyHostname());
+  }
+
+  // ==========================================================================
+  // TLS Session Cache Integration Tests
+  // ==========================================================================
+
+  @Test
+  public void testTlsConfigWithSessionCacheSettings() throws Exception {
+    TlsSessionCacheConfig sessionConfig =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(256)
+            .withSessionTimeoutSeconds(7200)
+            .build();
+
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(sessionConfig)
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify session cache config is preserved
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertEquals(256, config.getTlsConfig().getSessionCacheConfig().getSessionCacheSize());
+    assertEquals(7200, config.getTlsConfig().getSessionCacheConfig().getSessionTimeoutSeconds());
+  }
+
+  @Test
+  public void testTlsConfigWithSessionCacheDisabled() throws Exception {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(TlsSessionCacheConfig.disabled())
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify session cache is disabled
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertFalse(config.getTlsConfig().getSessionCacheConfig().isEnabled());
+  }
+
+  // ==========================================================================
+  // Combination with Other Features Tests
+  // ==========================================================================
+
+  @Test
+  public void testTlsConfigWithCompression() throws Exception {
+    TlsConfig tlsConfig = TlsConfig.trustAll();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withMinCompressionSizeBytes(512)
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // Verify both features are configured
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertTrue(config.getTlsConfig().isTrustAllCertificates());
+    assertEquals(RequestCompressionAlgorithm.GZIP, config.getCompressionAlgorithm());
+  }
+
+  @Test
+  public void testTlsConfigWithHeadersOptimization() throws Exception {
+    TlsConfig tlsConfig = TlsConfig.trustAll();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .withOptimizeHeaders(true)
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertTrue(config.getTlsConfig().isTrustAllCertificates());
+    assertTrue(config.isOptimizeHeaders());
+  }
+
+  @Test
+  public void testTlsConfigWithRoutingScope() throws Exception {
+    TlsConfig tlsConfig = TlsConfig.trustAll();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsConfig(tlsConfig)
+            .withRoutingScope(ClusterScope.create())
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+  }
+
+  @Test
+  public void testTlsConfigWithRefreshIntervals() throws Exception {
+    TlsConfig tlsConfig = TlsConfig.trustAll();
+
+    AlternatorConfig alternatorConfig =
+        AlternatorConfig.builder()
+            .withSeedNode(seedUri)
+            .withTlsConfig(tlsConfig)
+            .withActiveRefreshIntervalMs(500)
+            .withIdleRefreshIntervalMs(30000)
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withAlternatorConfig(alternatorConfig)
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertEquals(500, config.getActiveRefreshIntervalMs());
+    assertEquals(30000, config.getIdleRefreshIntervalMs());
+  }
+
+  @Test
+  public void testTlsConfigViaAlternatorConfig() throws Exception {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(
+                TlsSessionCacheConfig.builder()
+                    .withSessionCacheSize(150)
+                    .withSessionTimeoutSeconds(1800)
+                    .build())
+            .build();
+
+    AlternatorConfig alternatorConfig =
+        AlternatorConfig.builder()
+            .withSeedNode(seedUri)
+            .withRoutingScope(ClusterScope.create())
+            .withTlsConfig(tlsConfig)
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withAlternatorConfig(alternatorConfig)
+            .buildWithAlternatorAPI();
+
+    AlternatorConfig appliedConfig = syncWrapper.getAlternatorConfig();
+    assertTrue(appliedConfig.getTlsConfig().isTrustAllCertificates());
+    assertEquals(150, appliedConfig.getTlsConfig().getSessionCacheConfig().getSessionCacheSize());
+    assertEquals(
+        1800, appliedConfig.getTlsConfig().getSessionCacheConfig().getSessionTimeoutSeconds());
+  }
+
+  // ==========================================================================
+  // SSLContext Direct Tests
+  // ==========================================================================
+
+  @Test
+  public void testSslContextWithTrustAllConnectsToServer() throws Exception {
+    TlsConfig config = TlsConfig.trustAll();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+    SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+
+    SSLSocket socket = null;
+    try {
+      socket = (SSLSocket) socketFactory.createSocket(host, httpsPort);
+      socket.startHandshake();
+
+      SSLSession session = socket.getSession();
+      assertTrue("SSL session should be valid", session.isValid());
+      assertNotNull("Should have peer certificates", session.getPeerCertificates());
+
+      // Print certificate info for debugging
+      X509Certificate cert = (X509Certificate) session.getPeerCertificates()[0];
+      System.out.println("Server certificate subject: " + cert.getSubjectX500Principal());
+      System.out.println("Server certificate issuer: " + cert.getIssuerX500Principal());
+    } finally {
+      if (socket != null) {
+        socket.close();
+      }
+    }
+  }
+
+  @Test
+  public void testSslContextWithSystemDefaultMayRejectSelfSigned() throws Exception {
+    TlsConfig config = TlsConfig.systemDefault();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+    SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+
+    SSLSocket socket = null;
+    try {
+      socket = (SSLSocket) socketFactory.createSocket(host, httpsPort);
+      socket.startHandshake();
+
+      // If we get here, the certificate is trusted by system CAs
+      SSLSession session = socket.getSession();
+      assertTrue("SSL session should be valid", session.isValid());
+      System.out.println("Server certificate is trusted by system CAs");
+    } catch (SSLHandshakeException e) {
+      // Expected for self-signed certificates
+      System.out.println(
+          "Server certificate not trusted by system CAs (expected for self-signed): "
+              + e.getMessage());
+    } finally {
+      if (socket != null) {
+        socket.close();
+      }
+    }
+  }
+
+  @Test
+  public void testSslContextWithCustomCaCert() throws Exception {
+    assumeTrue(
+        "Custom CA certificate path not set. Set ALTERNATOR_CA_CERT_PATH to enable this test.",
+        customCaCertPath != null && Files.exists(customCaCertPath));
+
+    TlsConfig config =
+        TlsConfig.builder().withCaCertPath(customCaCertPath).withTrustSystemCaCerts(false).build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+    SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+
+    SSLSocket socket = null;
+    try {
+      socket = (SSLSocket) socketFactory.createSocket(host, httpsPort);
+      socket.startHandshake();
+
+      SSLSession session = socket.getSession();
+      assertTrue("SSL session should be valid", session.isValid());
+      System.out.println("Server certificate validated with custom CA");
+    } finally {
+      if (socket != null) {
+        socket.close();
+      }
+    }
+  }
+
+  @Test
+  public void testSslContextSessionCacheConfiguration() throws Exception {
+    TlsSessionCacheConfig sessionConfig =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(200)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    TlsConfig config =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(sessionConfig)
+            .build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    // Verify session cache configuration
+    assertEquals(
+        "Session cache size should be configured",
+        200,
+        sslContext.getClientSessionContext().getSessionCacheSize());
+    assertEquals(
+        "Session timeout should be configured",
+        3600,
+        sslContext.getClientSessionContext().getSessionTimeout());
+  }
+
+  // ==========================================================================
+  // Backwards Compatibility Tests
+  // ==========================================================================
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testLegacyTlsSessionCacheConfigStillWorks() throws Exception {
+    // Test that the deprecated withTlsSessionCacheConfig still works
+    TlsSessionCacheConfig sessionConfig =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(100)
+            .withSessionTimeoutSeconds(1800)
+            .build();
+
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withTlsSessionCacheConfig(sessionConfig)
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    // The old API should still provide a working TLS config
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertNotNull(config.getTlsConfig());
+  }
+
+  @Test
+  public void testDefaultConfigIsTrustAll() throws Exception {
+    // Default behavior should be trust-all for backwards compatibility
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertTrue(
+        "Default TLS config should be trust-all for backwards compatibility",
+        config.getTlsConfig().isTrustAllCertificates());
+  }
+
+  @Test
+  public void testDisableCertificateChecksStillWorks() throws Exception {
+    // Test that the old withDisableCertificateChecks API still works
+    syncWrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(credentialsProvider)
+            .withDisableCertificateChecks()
+            .buildWithAlternatorAPI();
+
+    List<URI> nodes = syncWrapper.getLiveNodes();
+    assertFalse("Should have at least one node", nodes.isEmpty());
+
+    AlternatorConfig config = syncWrapper.getAlternatorConfig();
+    assertTrue(
+        "disableCertificateChecks should result in trust-all config",
+        config.getTlsConfig().isTrustAllCertificates());
+  }
+
+  // ==========================================================================
+  // Helper Methods
+  // ==========================================================================
+
+  /**
+   * Creates a temporary PEM certificate file for testing.
+   *
+   * @return the path to the temporary certificate file
+   * @throws IOException if the file cannot be created
+   */
+  private Path createTempCertificate() throws IOException {
+    // Self-signed test certificate (PEM format)
+    // Generated with: openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout key.pem -out
+    // cert.pem -subj "/CN=test-ca"
+    String testCert =
+        "-----BEGIN CERTIFICATE-----\n"
+            + "MIIDBTCCAe2gAwIBAgIUSSxkkPZdq+pTKeALhEEpIrfWjeEwDQYJKoZIhvcNAQEL\n"
+            + "BQAwEjEQMA4GA1UEAwwHdGVzdC1jYTAeFw0yNjAxMzEwMTM0MjNaFw0zNjAxMjkw\n"
+            + "MTM0MjNaMBIxEDAOBgNVBAMMB3Rlc3QtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB\n"
+            + "DwAwggEKAoIBAQC7fotfXqSlJk0uM0RE/fbzV6bXsli9dezhC3sOP1XIS7DVnua7\n"
+            + "xYL6TnvWR2Y64x68REBXSl6iNYqaIxtlJdf5NwL1tqPI6qLA6y3o/hGXIqRZekke\n"
+            + "fv21BODJ/rHu9MrkBIkI+vFDazAUXz3agHV1Qnre3CRDPvHPmNVOac9exU1+qOXh\n"
+            + "FBYZOzKKrLkaTVxMjGOl8tzASTbrkBHnbUV1kzIraIvsM+S8AZDZTukCZ+370a3O\n"
+            + "MDx8CTv1kONVrpXaVnL9QLGFkpLx1jT1ApeZsMb7twgn/oEFJl8E7BXbG1T+lhza\n"
+            + "KF/wf9KXS+fC/xv1G7/ywftScdzP/0IGQEw1AgMBAAGjUzBRMB0GA1UdDgQWBBQI\n"
+            + "n37WLBvpKEKBa3LcMuSbyJYeHDAfBgNVHSMEGDAWgBQIn37WLBvpKEKBa3LcMuSb\n"
+            + "yJYeHDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBGG3rmBhh0\n"
+            + "eHWas+EdD3lifaJt36LdkBAkwE/HkZjCMLlZwyk09uBJCTb+5M5D8cFh17LqXdUz\n"
+            + "1xql2yok+r3UojkTGxeShIZZ7Lwkg6nCAygsvu9QZkv2bz382MHhvwoPoGqSpOen\n"
+            + "O/WPAZCpDMCfymhvE2C2yX9EUZNj+z3HRLgsyBqqAvx5NS7/whB3rZlLWuH+NMJp\n"
+            + "5At2UHnrXSFomBdJOkpvxQFGm8yHES79Yopc4VHA9lD8hQ1yF+Q23b64q161Vemn\n"
+            + "bA2+T05xQusR5P6tWOxwqQ1SXXaQYBh7czcms441WZV26Y0SRJTzne8iaNeCLTOJ\n"
+            + "11uOp5H+Pi7g\n"
+            + "-----END CERTIFICATE-----\n";
+
+    Path tempFile = Files.createTempFile("test-ca-", ".pem");
+    Files.writeString(tempFile, testCert);
+    return tempFile;
+  }
+}

--- a/src/test/java/com/scylladb/alternator/TlsConfigTest.java
+++ b/src/test/java/com/scylladb/alternator/TlsConfigTest.java
@@ -1,0 +1,218 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Unit tests for TlsConfig.
+ *
+ * @author dmitry.kropachev
+ */
+public class TlsConfigTest {
+
+  @Test
+  public void testTrustAllFactoryMethod() {
+    TlsConfig config = TlsConfig.trustAll();
+
+    assertTrue("trustAllCertificates should be true", config.isTrustAllCertificates());
+    assertFalse("trustSystemCaCerts should be false", config.isTrustSystemCaCerts());
+    assertFalse("verifyHostname should be false", config.isVerifyHostname());
+    assertTrue("customCaCertPaths should be empty", config.getCustomCaCertPaths().isEmpty());
+    assertNotNull("sessionCacheConfig should not be null", config.getSessionCacheConfig());
+  }
+
+  @Test
+  public void testSystemDefaultFactoryMethod() {
+    TlsConfig config = TlsConfig.systemDefault();
+
+    assertFalse("trustAllCertificates should be false", config.isTrustAllCertificates());
+    assertTrue("trustSystemCaCerts should be true", config.isTrustSystemCaCerts());
+    assertTrue("verifyHostname should be true", config.isVerifyHostname());
+    assertTrue("customCaCertPaths should be empty", config.getCustomCaCertPaths().isEmpty());
+    assertNotNull("sessionCacheConfig should not be null", config.getSessionCacheConfig());
+  }
+
+  @Test
+  public void testTrustAllIsSingletonInstance() {
+    TlsConfig config1 = TlsConfig.trustAll();
+    TlsConfig config2 = TlsConfig.trustAll();
+
+    assertSame("trustAll() should return the same instance", config1, config2);
+  }
+
+  @Test
+  public void testSystemDefaultIsSingletonInstance() {
+    TlsConfig config1 = TlsConfig.systemDefault();
+    TlsConfig config2 = TlsConfig.systemDefault();
+
+    assertSame("systemDefault() should return the same instance", config1, config2);
+  }
+
+  @Test
+  public void testBuilderWithCustomCaCertPath() {
+    Path certPath = Paths.get("/path/to/ca.pem");
+    TlsConfig config =
+        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(false).build();
+
+    assertFalse("trustAllCertificates should be false", config.isTrustAllCertificates());
+    assertFalse("trustSystemCaCerts should be false", config.isTrustSystemCaCerts());
+    assertTrue("verifyHostname should be true", config.isVerifyHostname());
+    assertEquals("Should have one CA cert path", 1, config.getCustomCaCertPaths().size());
+    assertEquals("CA cert path should match", certPath, config.getCustomCaCertPaths().get(0));
+  }
+
+  @Test
+  public void testBuilderWithMultipleCaCertPaths() {
+    List<Path> certPaths =
+        Arrays.asList(Paths.get("/path/to/ca1.pem"), Paths.get("/path/to/ca2.pem"));
+    TlsConfig config =
+        TlsConfig.builder().withCaCertPaths(certPaths).withTrustSystemCaCerts(false).build();
+
+    assertEquals("Should have two CA cert paths", 2, config.getCustomCaCertPaths().size());
+  }
+
+  @Test
+  public void testBuilderWithTrustAllCertificates() {
+    TlsConfig config = TlsConfig.builder().withTrustAllCertificates(true).build();
+
+    assertTrue("trustAllCertificates should be true", config.isTrustAllCertificates());
+    // When trust-all is enabled, hostname verification is automatically disabled
+    assertFalse(
+        "verifyHostname should be false when trust-all is enabled", config.isVerifyHostname());
+  }
+
+  @Test
+  public void testBuilderWithSystemCasAndCustomCas() {
+    Path certPath = Paths.get("/path/to/ca.pem");
+    TlsConfig config =
+        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(true).build();
+
+    assertFalse("trustAllCertificates should be false", config.isTrustAllCertificates());
+    assertTrue("trustSystemCaCerts should be true", config.isTrustSystemCaCerts());
+    assertEquals("Should have one CA cert path", 1, config.getCustomCaCertPaths().size());
+  }
+
+  @Test
+  public void testBuilderWithSessionCacheConfig() {
+    TlsSessionCacheConfig sessionConfig =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(200)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    TlsConfig config =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(sessionConfig)
+            .build();
+
+    assertEquals("sessionCacheConfig should match", sessionConfig, config.getSessionCacheConfig());
+  }
+
+  @Test
+  public void testBuilderWithVerifyHostnameDisabled() {
+    TlsConfig config =
+        TlsConfig.builder().withTrustSystemCaCerts(true).withVerifyHostname(false).build();
+
+    assertFalse("verifyHostname should be false", config.isVerifyHostname());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderRejectsNullCaCertPath() {
+    TlsConfig.builder().withCaCertPath(null).build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testBuilderRejectsNoTrustSource() {
+    // When trustSystemCaCerts is false, no custom CAs, and trustAll is false
+    TlsConfig.builder().withTrustSystemCaCerts(false).withTrustAllCertificates(false).build();
+  }
+
+  @Test
+  public void testBuilderDefaultsToSystemCas() {
+    // By default, system CAs should be trusted
+    TlsConfig config = TlsConfig.builder().withCaCertPath(Paths.get("/path/to/ca.pem")).build();
+
+    assertTrue("trustSystemCaCerts should be true by default", config.isTrustSystemCaCerts());
+  }
+
+  @Test
+  public void testBuilderDefaultsToHostnameVerification() {
+    TlsConfig config = TlsConfig.builder().withTrustSystemCaCerts(true).build();
+
+    assertTrue("verifyHostname should be true by default", config.isVerifyHostname());
+  }
+
+  @Test
+  public void testCustomCaCertPathsAreImmutable() {
+    Path certPath = Paths.get("/path/to/ca.pem");
+    TlsConfig config =
+        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(false).build();
+
+    List<Path> paths = config.getCustomCaCertPaths();
+    try {
+      paths.add(Paths.get("/another/path.pem"));
+      fail("Should not be able to modify the CA cert paths list");
+    } catch (UnsupportedOperationException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testToString() {
+    TlsConfig config =
+        TlsConfig.builder()
+            .withTrustSystemCaCerts(true)
+            .withCaCertPath(Paths.get("/path/to/ca.pem"))
+            .build();
+
+    String str = config.toString();
+    assertTrue("toString should contain customCaCertPaths", str.contains("customCaCertPaths"));
+    assertTrue("toString should contain trustSystemCaCerts", str.contains("trustSystemCaCerts"));
+    assertTrue(
+        "toString should contain trustAllCertificates", str.contains("trustAllCertificates"));
+    assertTrue("toString should contain verifyHostname", str.contains("verifyHostname"));
+    assertTrue("toString should contain sessionCacheConfig", str.contains("sessionCacheConfig"));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    Path certPath = Paths.get("/path/to/ca.pem");
+
+    TlsConfig config1 =
+        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(false).build();
+
+    TlsConfig config2 =
+        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(false).build();
+
+    TlsConfig config3 =
+        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(true).build();
+
+    assertEquals(config1, config2);
+    assertEquals(config1.hashCode(), config2.hashCode());
+    assertNotEquals(config1, config3);
+  }
+
+  @Test
+  public void testEqualsWithNull() {
+    TlsConfig config = TlsConfig.trustAll();
+    assertNotEquals(config, null);
+  }
+
+  @Test
+  public void testEqualsWithDifferentType() {
+    TlsConfig config = TlsConfig.trustAll();
+    assertNotEquals(config, "string");
+  }
+
+  @Test
+  public void testEqualsSameInstance() {
+    TlsConfig config = TlsConfig.trustAll();
+    assertEquals(config, config);
+  }
+}

--- a/src/test/java/com/scylladb/alternator/TlsContextFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/TlsContextFactoryTest.java
@@ -1,0 +1,201 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import com.scylladb.alternator.internal.TlsContextFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.net.ssl.SSLContext;
+import org.junit.Test;
+
+/**
+ * Unit tests for TlsContextFactory.
+ *
+ * @author dmitry.kropachev
+ */
+public class TlsContextFactoryTest {
+
+  @Test
+  public void testCreateSslContextWithTrustAll() {
+    TlsConfig config = TlsConfig.trustAll();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    assertNotNull("SSLContext should not be null", sslContext);
+    assertEquals("Protocol should be TLS", "TLS", sslContext.getProtocol().substring(0, 3));
+  }
+
+  @Test
+  public void testCreateSslContextWithSystemDefault() {
+    TlsConfig config = TlsConfig.systemDefault();
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    assertNotNull("SSLContext should not be null", sslContext);
+  }
+
+  @Test
+  public void testCreateSslContextWithNullConfig() {
+    // Should default to trust-all
+    SSLContext sslContext = TlsContextFactory.createSslContext((TlsConfig) null);
+
+    assertNotNull("SSLContext should not be null", sslContext);
+  }
+
+  @Test
+  public void testCreateSslContextWithSessionCacheConfig() {
+    TlsSessionCacheConfig sessionConfig =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(200)
+            .withSessionTimeoutSeconds(3600)
+            .build();
+
+    TlsConfig config =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(sessionConfig)
+            .build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    assertNotNull("SSLContext should not be null", sslContext);
+    // Verify session cache settings are applied
+    assertEquals(
+        "Session cache size should be configured",
+        200,
+        sslContext.getClientSessionContext().getSessionCacheSize());
+    assertEquals(
+        "Session timeout should be configured",
+        3600,
+        sslContext.getClientSessionContext().getSessionTimeout());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testLegacyCreateSslContextWithTlsSessionCacheConfig() {
+    TlsSessionCacheConfig config =
+        TlsSessionCacheConfig.builder()
+            .withSessionCacheSize(100)
+            .withSessionTimeoutSeconds(1800)
+            .build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    assertNotNull("SSLContext should not be null", sslContext);
+    assertEquals(
+        "Session cache size should be configured",
+        100,
+        sslContext.getClientSessionContext().getSessionCacheSize());
+  }
+
+  @Test
+  public void testCreateSslContextWithCustomCaCert() throws IOException {
+    // Create a temporary self-signed certificate for testing
+    Path tempCert = createTempCertificate();
+    try {
+      TlsConfig config =
+          TlsConfig.builder().withCaCertPath(tempCert).withTrustSystemCaCerts(false).build();
+
+      SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+      assertNotNull("SSLContext should not be null", sslContext);
+    } finally {
+      Files.deleteIfExists(tempCert);
+    }
+  }
+
+  @Test
+  public void testCreateSslContextWithCustomCaCertAndSystemCas() throws IOException {
+    // Create a temporary self-signed certificate for testing
+    Path tempCert = createTempCertificate();
+    try {
+      TlsConfig config =
+          TlsConfig.builder().withCaCertPath(tempCert).withTrustSystemCaCerts(true).build();
+
+      SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+      assertNotNull("SSLContext should not be null", sslContext);
+    } finally {
+      Files.deleteIfExists(tempCert);
+    }
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testCreateSslContextWithInvalidCaCertPath() throws IOException {
+    Path invalidPath = Files.createTempFile("invalid", ".pem");
+    Files.write(invalidPath, "invalid certificate data".getBytes());
+
+    try {
+      TlsConfig config =
+          TlsConfig.builder().withCaCertPath(invalidPath).withTrustSystemCaCerts(false).build();
+
+      TlsContextFactory.createSslContext(config);
+    } finally {
+      Files.deleteIfExists(invalidPath);
+    }
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testCreateSslContextWithNonExistentCaCertPath() {
+    Path nonExistentPath = Path.of("/non/existent/path/ca.pem");
+
+    TlsConfig config =
+        TlsConfig.builder().withCaCertPath(nonExistentPath).withTrustSystemCaCerts(false).build();
+
+    TlsContextFactory.createSslContext(config);
+  }
+
+  @Test
+  public void testCreateSslContextWithSessionCacheDisabled() {
+    TlsConfig config =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withSessionCacheConfig(TlsSessionCacheConfig.disabled())
+            .build();
+
+    SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+    assertNotNull("SSLContext should not be null", sslContext);
+    assertEquals(
+        "Session cache size should be 0 when disabled",
+        0,
+        sslContext.getClientSessionContext().getSessionCacheSize());
+  }
+
+  /**
+   * Creates a temporary self-signed certificate for testing.
+   *
+   * <p>This certificate was generated with: {@code openssl req -x509 -nodes -days 3650 -newkey
+   * rsa:2048 -keyout key.pem -out cert.pem -subj "/CN=test-ca"}
+   *
+   * @return the path to the temporary certificate file
+   * @throws IOException if the file cannot be created
+   */
+  private Path createTempCertificate() throws IOException {
+    // This is a self-signed test certificate (PEM format)
+    // Generated for testing purposes only - DO NOT use in production
+    String testCert =
+        "-----BEGIN CERTIFICATE-----\n"
+            + "MIIDBTCCAe2gAwIBAgIUSSxkkPZdq+pTKeALhEEpIrfWjeEwDQYJKoZIhvcNAQEL\n"
+            + "BQAwEjEQMA4GA1UEAwwHdGVzdC1jYTAeFw0yNjAxMzEwMTM0MjNaFw0zNjAxMjkw\n"
+            + "MTM0MjNaMBIxEDAOBgNVBAMMB3Rlc3QtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB\n"
+            + "DwAwggEKAoIBAQC7fotfXqSlJk0uM0RE/fbzV6bXsli9dezhC3sOP1XIS7DVnua7\n"
+            + "xYL6TnvWR2Y64x68REBXSl6iNYqaIxtlJdf5NwL1tqPI6qLA6y3o/hGXIqRZekke\n"
+            + "fv21BODJ/rHu9MrkBIkI+vFDazAUXz3agHV1Qnre3CRDPvHPmNVOac9exU1+qOXh\n"
+            + "FBYZOzKKrLkaTVxMjGOl8tzASTbrkBHnbUV1kzIraIvsM+S8AZDZTukCZ+370a3O\n"
+            + "MDx8CTv1kONVrpXaVnL9QLGFkpLx1jT1ApeZsMb7twgn/oEFJl8E7BXbG1T+lhza\n"
+            + "KF/wf9KXS+fC/xv1G7/ywftScdzP/0IGQEw1AgMBAAGjUzBRMB0GA1UdDgQWBBQI\n"
+            + "n37WLBvpKEKBa3LcMuSbyJYeHDAfBgNVHSMEGDAWgBQIn37WLBvpKEKBa3LcMuSb\n"
+            + "yJYeHDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBGG3rmBhh0\n"
+            + "eHWas+EdD3lifaJt36LdkBAkwE/HkZjCMLlZwyk09uBJCTb+5M5D8cFh17LqXdUz\n"
+            + "1xql2yok+r3UojkTGxeShIZZ7Lwkg6nCAygsvu9QZkv2bz382MHhvwoPoGqSpOen\n"
+            + "O/WPAZCpDMCfymhvE2C2yX9EUZNj+z3HRLgsyBqqAvx5NS7/whB3rZlLWuH+NMJp\n"
+            + "5At2UHnrXSFomBdJOkpvxQFGm8yHES79Yopc4VHA9lD8hQ1yF+Q23b64q161Vemn\n"
+            + "bA2+T05xQusR5P6tWOxwqQ1SXXaQYBh7czcms441WZV26Y0SRJTzne8iaNeCLTOJ\n"
+            + "11uOp5H+Pi7g\n"
+            + "-----END CERTIFICATE-----\n";
+
+    Path tempFile = Files.createTempFile("test-ca-", ".pem");
+    Files.write(tempFile, testCert.getBytes());
+    return tempFile;
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for custom CA certificates (closes #13) to enable proper TLS certificate validation instead of the current "trust-all" approach.

### Changes

- Add `TlsConfig` class with builder pattern for flexible TLS configuration
- Support custom CA certificates from PEM files via `withCaCertPath()`
- Support combining custom CAs with system CAs via `withTrustSystemCaCerts()`
- Add factory methods: `TlsConfig.trustAll()` (dev/testing) and `TlsConfig.systemDefault()` (production)
- Update `TlsContextFactory` to create SSLContext from TlsConfig with custom trust managers
- Add `CompositeX509TrustManager` for combining multiple trust sources
- Add `withTlsConfig()` to both sync and async client builders
- Support hostname verification control via `withVerifyHostname()`
- Deprecate `withTlsSessionCacheConfig()` in favor of `withTlsConfig()`
- Maintain backwards compatibility with existing trust-all default behavior

### Usage Examples

```java
// Trust all certificates (development/testing)
TlsConfig tlsConfig = TlsConfig.trustAll();

// Use system CA certificates (production recommended)
TlsConfig tlsConfig = TlsConfig.systemDefault();

// Use custom CA certificate
TlsConfig tlsConfig = TlsConfig.builder()
    .withCaCertPath(Paths.get("/path/to/ca.pem"))
    .withTrustSystemCaCerts(false)
    .build();

// Use in client builder
DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(URI.create("https://localhost:8043"))
    .credentialsProvider(credentialsProvider)
    .withTlsConfig(tlsConfig)
    .build();
```

## Test plan

- [x] Unit tests for TlsConfig (20 tests)
- [x] Unit tests for TlsContextFactory (10 tests)
- [x] Unit tests for AlternatorConfig TLS settings (13 tests)
- [x] All existing tests pass (357 tests total)
- [x] Verify build: `make verify`

Closes [DRIVER-336](https://scylladb.atlassian.net/browse/DRIVER-336)


[DRIVER-336]: https://scylladb.atlassian.net/browse/DRIVER-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ