### PR TITLE
Simplify AttributeValueHasher to only support S, N, B types

### DIFF
--- a/src/main/java/com/scylladb/alternator/keyrouting/AttributeValueHasher.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/AttributeValueHasher.java
@@ -1,38 +1,21 @@
 package com.scylladb.alternator.keyrouting;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * Hashes DynamoDB AttributeValue objects using MurmurHash3.
  *
- * <p>Supports all DynamoDB attribute types with type-prefixed encoding to prevent collisions
- * between different types:
+ * <p>Supports the partition key types allowed by ScyllaDB Alternator:
  *
  * <ul>
  *   <li>S (String) - Type prefix 0x01 + UTF-8 bytes
  *   <li>N (Number) - Type prefix 0x02 + UTF-8 bytes of string representation
  *   <li>B (Binary) - Type prefix 0x03 + raw bytes
- *   <li>BOOL (Boolean) - Type prefix 0x04 + 1 byte (0x01 for true, 0x00 for false)
- *   <li>NULL - Type prefix 0x05 + 1 byte (0x01 for true, 0x00 for false)
- *   <li>SS (String Set) - Type prefix 0x06 + length-prefixed elements (sorted)
- *   <li>NS (Number Set) - Type prefix 0x07 + length-prefixed elements (sorted)
- *   <li>BS (Binary Set) - Type prefix 0x08 + length-prefixed elements (sorted)
- *   <li>L (List) - Type prefix 0x09 + length-prefixed recursive elements
- *   <li>M (Map) - Type prefix 0x0A + length-prefixed key-value pairs (keys sorted)
  * </ul>
  *
- * <p>Sets are sorted before hashing to ensure deterministic results, since DynamoDB sets are
- * unordered collections and iteration order is not guaranteed.
- *
- * <p>Collection elements use 4-byte big-endian length prefixes to prevent boundary collisions (e.g.
- * ["a", "bc"] vs ["ab", "c"]).
+ * <p>Other DynamoDB types (BOOL, NULL, SS, NS, BS, L, M) are not supported as partition keys in
+ * Alternator and will throw an {@link IllegalArgumentException}.
  *
  * <h3>Composite Partition Keys</h3>
  *
@@ -71,12 +54,8 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  * key values, all implementations must follow the same encoding format:
  *
  * <ul>
- *   <li>Type prefixes must use the exact byte values (0x01-0x0A) specified above
+ *   <li>Type prefixes must use the exact byte values (0x01 for S, 0x02 for N, 0x03 for B)
  *   <li>Strings must be encoded as UTF-8 bytes
- *   <li>Length prefixes must be 4-byte big-endian integers
- *   <li>Sets must be sorted lexicographically (strings by UTF-8 bytes, binaries by unsigned byte
- *       comparison)
- *   <li>Map keys must be sorted lexicographically by their UTF-8 byte representation
  *   <li>The MurmurHash3 implementation must use the x86_128 variant with seed 0, returning the
  *       first 64 bits
  * </ul>
@@ -86,43 +65,31 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  *
  * <h3>Performance Characteristics</h3>
  *
- * <p>Time complexity varies by attribute type:
+ * <p>Time complexity is O(n) for all supported types where n is the byte length.
  *
- * <ul>
- *   <li><b>O(n)</b> for primitive types (S, N, B, BOOL, NULL) where n is the byte length
- *   <li><b>O(n)</b> for Lists (L) where n is the total size of all elements
- *   <li><b>O(n log n)</b> for Sets (SS, NS, BS) due to sorting, where n is the number of elements
- *   <li><b>O(n log n)</b> for Maps (M) due to key sorting, where n is the number of entries
- * </ul>
- *
- * <p>Space complexity is O(n) for all types, as the entire value is converted to bytes before
- * hashing.
+ * <p>Space complexity is O(n) as the entire value is converted to bytes before hashing.
  *
  * @author dmitry.kropachev
  * @since 1.0.7
  */
 public final class AttributeValueHasher {
 
-  // Type prefix constants
+  // Type prefix constants for partition key types
   private static final byte TYPE_STRING = 0x01;
   private static final byte TYPE_NUMBER = 0x02;
   private static final byte TYPE_BINARY = 0x03;
-  private static final byte TYPE_BOOLEAN = 0x04;
-  private static final byte TYPE_NULL = 0x05;
-  private static final byte TYPE_STRING_SET = 0x06;
-  private static final byte TYPE_NUMBER_SET = 0x07;
-  private static final byte TYPE_BINARY_SET = 0x08;
-  private static final byte TYPE_LIST = 0x09;
-  private static final byte TYPE_MAP = 0x0A;
 
   private AttributeValueHasher() {}
 
   /**
    * Computes a hash for a DynamoDB AttributeValue.
    *
+   * <p>Only S (String), N (Number), and B (Binary) types are supported, as these are the only
+   * partition key types allowed by ScyllaDB Alternator.
+   *
    * @param value the attribute value to hash
    * @return the hash value
-   * @throws IllegalArgumentException if the attribute value type is not supported
+   * @throws IllegalArgumentException if the attribute value type is not S, N, or B
    */
   public static long hash(AttributeValue value) {
     if (value == null) {
@@ -158,47 +125,9 @@ public final class AttributeValueHasher {
       return prependTypePrefix(TYPE_BINARY, binBytes);
     }
 
-    // Boolean
-    if (value.bool() != null) {
-      return new byte[] {TYPE_BOOLEAN, (byte) (value.bool() ? 1 : 0)};
-    }
-
-    // Null - DynamoDB NULL type is semantically always true.
-    // nul(false) is an invalid state that should not occur in practice.
-    if (value.nul() != null) {
-      if (!value.nul()) {
-        throw new IllegalArgumentException(
-            "Invalid NULL attribute: nul(false) is not a valid DynamoDB NULL value");
-      }
-      return new byte[] {TYPE_NULL, (byte) 1};
-    }
-
-    // String Set
-    if (value.hasSs() && value.ss() != null) {
-      return hashStringSet(value.ss());
-    }
-
-    // Number Set
-    if (value.hasNs() && value.ns() != null) {
-      return hashNumberSet(value.ns());
-    }
-
-    // Binary Set
-    if (value.hasBs() && value.bs() != null) {
-      return hashBinarySet(value.bs());
-    }
-
-    // List
-    if (value.hasL() && value.l() != null) {
-      return hashList(value.l());
-    }
-
-    // Map
-    if (value.hasM() && value.m() != null) {
-      return hashMap(value.m());
-    }
-
-    throw new IllegalArgumentException("Unsupported AttributeValue type");
+    throw new IllegalArgumentException(
+        "Unsupported AttributeValue type. Only S (String), N (Number), and B (Binary) "
+            + "are supported as partition key types in Alternator.");
   }
 
   /**
@@ -212,189 +141,6 @@ public final class AttributeValueHasher {
     byte[] result = new byte[1 + data.length];
     result[0] = typePrefix;
     System.arraycopy(data, 0, result, 1, data.length);
-    return result;
-  }
-
-  /**
-   * Encodes an integer as 4-byte big-endian.
-   *
-   * <p>Uses direct byte manipulation instead of ByteBuffer for better performance, as this method
-   * is called frequently when encoding collection elements.
-   *
-   * @param value the integer value
-   * @return 4-byte big-endian representation
-   */
-  private static byte[] intToBytes(int value) {
-    return new byte[] {
-      (byte) (value >> 24), (byte) (value >> 16), (byte) (value >> 8), (byte) value
-    };
-  }
-
-  /**
-   * Builds a byte array with type prefix and length-prefixed elements.
-   *
-   * <p>This is a shared helper method used by all set hashing methods to avoid code duplication.
-   * The elements must be pre-sorted by the caller to ensure deterministic hashing.
-   *
-   * @param typePrefix the type prefix byte for this set type
-   * @param sortedElements the pre-sorted list of byte arrays to encode
-   * @return encoded bytes with type prefix and length-prefixed elements
-   */
-  private static byte[] buildLengthPrefixedBytes(byte typePrefix, List<byte[]> sortedElements) {
-    // Calculate total length: 1 (type) + sum of (4 + len) for each element
-    int totalLength = 1;
-    for (byte[] bytes : sortedElements) {
-      totalLength += 4 + bytes.length;
-    }
-
-    // Build result with type prefix and length-prefixed elements
-    byte[] result = new byte[totalLength];
-    result[0] = typePrefix;
-    int offset = 1;
-    for (byte[] bytes : sortedElements) {
-      // Write 4-byte length prefix
-      byte[] lenBytes = intToBytes(bytes.length);
-      System.arraycopy(lenBytes, 0, result, offset, 4);
-      offset += 4;
-      // Write element data
-      System.arraycopy(bytes, 0, result, offset, bytes.length);
-      offset += bytes.length;
-    }
-    return result;
-  }
-
-  /**
-   * Hashes a String Set with type prefix and length-prefixed elements.
-   *
-   * @param values the string set values; must not be null (caller is responsible for null check)
-   * @return encoded bytes
-   */
-  private static byte[] hashStringSet(List<String> values) {
-    // Sort strings lexicographically for deterministic hashing
-    List<String> sorted = new ArrayList<>(values);
-    Collections.sort(sorted);
-
-    // Convert to byte arrays
-    List<byte[]> bytesList = new ArrayList<>();
-    for (String s : sorted) {
-      bytesList.add(s.getBytes(StandardCharsets.UTF_8));
-    }
-
-    return buildLengthPrefixedBytes(TYPE_STRING_SET, bytesList);
-  }
-
-  /**
-   * Hashes a Number Set with type prefix and length-prefixed elements.
-   *
-   * @param values the number set values (as strings); must not be null (caller is responsible for
-   *     null check)
-   * @return encoded bytes
-   */
-  private static byte[] hashNumberSet(List<String> values) {
-    // Sort strings lexicographically for deterministic hashing
-    List<String> sorted = new ArrayList<>(values);
-    Collections.sort(sorted);
-
-    // Convert to byte arrays
-    List<byte[]> bytesList = new ArrayList<>();
-    for (String s : sorted) {
-      bytesList.add(s.getBytes(StandardCharsets.UTF_8));
-    }
-
-    return buildLengthPrefixedBytes(TYPE_NUMBER_SET, bytesList);
-  }
-
-  /**
-   * Hashes a Binary Set with type prefix and length-prefixed elements.
-   *
-   * @param values the binary set values; must not be null (caller is responsible for null check)
-   * @return encoded bytes
-   */
-  private static byte[] hashBinarySet(List<SdkBytes> values) {
-    // Convert to byte arrays and sort for deterministic hashing
-    List<byte[]> byteArrays = new ArrayList<>();
-    for (SdkBytes b : values) {
-      byteArrays.add(b.asByteArray());
-    }
-    Collections.sort(byteArrays, BYTE_ARRAY_COMPARATOR);
-
-    return buildLengthPrefixedBytes(TYPE_BINARY_SET, byteArrays);
-  }
-
-  /** Comparator for sorting byte arrays lexicographically (unsigned byte comparison). */
-  private static final Comparator<byte[]> BYTE_ARRAY_COMPARATOR =
-      (a, b) -> {
-        int minLength = Math.min(a.length, b.length);
-        for (int i = 0; i < minLength; i++) {
-          int cmp = (a[i] & 0xff) - (b[i] & 0xff);
-          if (cmp != 0) {
-            return cmp;
-          }
-        }
-        return a.length - b.length;
-      };
-
-  /**
-   * Hashes a List with type prefix and length-prefixed elements.
-   *
-   * @param values the list values; must not be null (caller is responsible for null check)
-   * @return encoded bytes
-   */
-  private static byte[] hashList(List<AttributeValue> values) {
-    // Recursively encode each element (order preserved, no sorting)
-    List<byte[]> bytesList = new ArrayList<>();
-    for (AttributeValue v : values) {
-      bytesList.add(toBytes(v));
-    }
-
-    return buildLengthPrefixedBytes(TYPE_LIST, bytesList);
-  }
-
-  /**
-   * Hashes a Map with type prefix and length-prefixed key-value pairs.
-   *
-   * @param map the map values; must not be null (caller is responsible for null check)
-   * @return encoded bytes
-   */
-  private static byte[] hashMap(Map<String, AttributeValue> map) {
-    // Sort keys lexicographically, then encode key-value pairs with length prefixes
-    List<String> keys = new ArrayList<>(map.keySet());
-    Collections.sort(keys);
-
-    // Calculate total length and collect encoded pairs
-    int totalLength = 1; // type prefix
-    List<byte[]> keyBytesList = new ArrayList<>();
-    List<byte[]> valueBytesList = new ArrayList<>();
-    for (String key : keys) {
-      byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
-      byte[] valueBytes = toBytes(map.get(key));
-      keyBytesList.add(keyBytes);
-      valueBytesList.add(valueBytes);
-      totalLength += 4 + keyBytes.length + 4 + valueBytes.length;
-    }
-
-    // Build result with type prefix and length-prefixed key-value pairs
-    byte[] result = new byte[totalLength];
-    result[0] = TYPE_MAP;
-    int offset = 1;
-    for (int i = 0; i < keys.size(); i++) {
-      byte[] keyBytes = keyBytesList.get(i);
-      byte[] valueBytes = valueBytesList.get(i);
-
-      // Write key with length prefix
-      byte[] keyLenBytes = intToBytes(keyBytes.length);
-      System.arraycopy(keyLenBytes, 0, result, offset, 4);
-      offset += 4;
-      System.arraycopy(keyBytes, 0, result, offset, keyBytes.length);
-      offset += keyBytes.length;
-
-      // Write value with length prefix
-      byte[] valueLenBytes = intToBytes(valueBytes.length);
-      System.arraycopy(valueLenBytes, 0, result, offset, 4);
-      offset += 4;
-      System.arraycopy(valueBytes, 0, result, offset, valueBytes.length);
-      offset += valueBytes.length;
-    }
     return result;
   }
 }

--- a/src/test/java/com/scylladb/alternator/keyrouting/AttributeValueHasherCrossLanguageTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/AttributeValueHasherCrossLanguageTest.java
@@ -2,9 +2,6 @@ package com.scylladb.alternator.keyrouting;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -14,6 +11,9 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  *
  * <p>These tests use exact expected hash values from the cross-language specification to ensure
  * compatibility with implementations in other languages (e.g., Go).
+ *
+ * <p>Only S (String), N (Number), and B (Binary) types are tested as these are the only partition
+ * key types supported by ScyllaDB Alternator.
  *
  * <p>Test vectors from: https://github.com/scylladb/alternator-load-balancing/issues/165
  *
@@ -106,131 +106,6 @@ public class AttributeValueHasherCrossLanguageTest {
     assertEquals(14533934253577680L, AttributeValueHasher.hash(value));
   }
 
-  // ========== Boolean Type Tests ==========
-
-  @Test
-  public void testBooleanTrue() {
-    AttributeValue value = AttributeValue.builder().bool(true).build();
-    assertEquals(8486936384116756332L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testBooleanFalse() {
-    AttributeValue value = AttributeValue.builder().bool(false).build();
-    assertEquals(-4126391008895418907L, AttributeValueHasher.hash(value));
-  }
-
-  // ========== NULL Type Tests ==========
-
-  @Test
-  public void testNullTrue() {
-    AttributeValue value = AttributeValue.builder().nul(true).build();
-    assertEquals(-561667943985901489L, AttributeValueHasher.hash(value));
-  }
-
-  // ========== String Set Tests ==========
-
-  @Test
-  public void testStringSetABC() {
-    AttributeValue value = AttributeValue.builder().ss(Arrays.asList("a", "b", "c")).build();
-    assertEquals(7306159961466191513L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testStringSetABCDifferentOrder() {
-    // Same set but different input order - should produce same hash
-    AttributeValue value = AttributeValue.builder().ss(Arrays.asList("c", "a", "b")).build();
-    assertEquals(7306159961466191513L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testStringSetEmpty() {
-    AttributeValue value = AttributeValue.builder().ss(Arrays.<String>asList()).build();
-    assertEquals(1389283912212466035L, AttributeValueHasher.hash(value));
-  }
-
-  // ========== Number Set Tests ==========
-
-  @Test
-  public void testNumberSet123() {
-    AttributeValue value = AttributeValue.builder().ns(Arrays.asList("1", "2", "3")).build();
-    assertEquals(7671176432463372843L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testNumberSet123DifferentOrder() {
-    // Same set but different input order - should produce same hash
-    AttributeValue value = AttributeValue.builder().ns(Arrays.asList("3", "1", "2")).build();
-    assertEquals(7671176432463372843L, AttributeValueHasher.hash(value));
-  }
-
-  // ========== Binary Set Tests ==========
-
-  @Test
-  public void testBinarySet0102() {
-    AttributeValue value =
-        AttributeValue.builder()
-            .bs(
-                Arrays.asList(
-                    SdkBytes.fromByteArray(new byte[] {0x01}),
-                    SdkBytes.fromByteArray(new byte[] {0x02})))
-            .build();
-    assertEquals(1665953200922610785L, AttributeValueHasher.hash(value));
-  }
-
-  // ========== List Tests ==========
-
-  @Test
-  public void testListSaN1() {
-    // L [S("a"), N("1")]
-    AttributeValue value =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().s("a").build(),
-                    AttributeValue.builder().n("1").build()))
-            .build();
-    assertEquals(2820707766025454319L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testListEmpty() {
-    AttributeValue value = AttributeValue.builder().l(Arrays.<AttributeValue>asList()).build();
-    assertEquals(-9218108584195748763L, AttributeValueHasher.hash(value));
-  }
-
-  // ========== Map Tests ==========
-
-  @Test
-  public void testMapAgeNameJohn() {
-    // M {"age": N("30"), "name": S("John")}
-    Map<String, AttributeValue> map = new HashMap<>();
-    map.put("age", AttributeValue.builder().n("30").build());
-    map.put("name", AttributeValue.builder().s("John").build());
-    AttributeValue value = AttributeValue.builder().m(map).build();
-    assertEquals(-902430298826217654L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testMapEmpty() {
-    AttributeValue value =
-        AttributeValue.builder().m(new HashMap<String, AttributeValue>()).build();
-    assertEquals(3924702969362948632L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testMapNestedList() {
-    // M {"key": L([S("nested")])}
-    Map<String, AttributeValue> map = new HashMap<>();
-    map.put(
-        "key",
-        AttributeValue.builder()
-            .l(Arrays.asList(AttributeValue.builder().s("nested").build()))
-            .build());
-    AttributeValue value = AttributeValue.builder().m(map).build();
-    assertEquals(-5371960927743395604L, AttributeValueHasher.hash(value));
-  }
-
   // ========== Type Collision Prevention Tests ==========
 
   @Test
@@ -253,47 +128,5 @@ public class AttributeValueHasherCrossLanguageTest {
             .b(SdkBytes.fromByteArray("12345".getBytes(java.nio.charset.StandardCharsets.UTF_8)))
             .build();
     assertEquals(-3752463870508600385L, AttributeValueHasher.hash(value));
-  }
-
-  // ========== Boundary Collision Prevention Tests ==========
-
-  @Test
-  public void testBoundaryStringSetABC() {
-    // SS ["a", "bc"]
-    AttributeValue value = AttributeValue.builder().ss(Arrays.asList("a", "bc")).build();
-    assertEquals(1290520225009436005L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testBoundaryStringSetABC2() {
-    // SS ["ab", "c"]
-    AttributeValue value = AttributeValue.builder().ss(Arrays.asList("ab", "c")).build();
-    assertEquals(-5535761315402902992L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testBoundaryListABC() {
-    // L [S("a"), S("bc")]
-    AttributeValue value =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().s("a").build(),
-                    AttributeValue.builder().s("bc").build()))
-            .build();
-    assertEquals(-8510235581865967010L, AttributeValueHasher.hash(value));
-  }
-
-  @Test
-  public void testBoundaryListABC2() {
-    // L [S("ab"), S("c")]
-    AttributeValue value =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().s("ab").build(),
-                    AttributeValue.builder().s("c").build()))
-            .build();
-    assertEquals(1154309738056842165L, AttributeValueHasher.hash(value));
   }
 }

--- a/src/test/java/com/scylladb/alternator/keyrouting/AttributeValueHasherTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/AttributeValueHasherTest.java
@@ -2,10 +2,8 @@ package com.scylladb.alternator.keyrouting;
 
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -73,120 +71,6 @@ public class AttributeValueHasherTest {
   }
 
   @Test
-  public void testBooleanTrue() {
-    AttributeValue value = AttributeValue.builder().bool(true).build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotEquals(0L, hash);
-  }
-
-  @Test
-  public void testBooleanFalse() {
-    AttributeValue value = AttributeValue.builder().bool(false).build();
-    long hashFalse = AttributeValueHasher.hash(value);
-    // Note: false becomes byte 0, which hashes differently than empty
-    assertNotNull(hashFalse);
-  }
-
-  @Test
-  public void testBooleanTrueAndFalseDiffer() {
-    AttributeValue trueVal = AttributeValue.builder().bool(true).build();
-    AttributeValue falseVal = AttributeValue.builder().bool(false).build();
-    assertNotEquals(AttributeValueHasher.hash(trueVal), AttributeValueHasher.hash(falseVal));
-  }
-
-  @Test
-  public void testNullAttribute() {
-    AttributeValue value = AttributeValue.builder().nul(true).build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotNull(hash);
-  }
-
-  @Test
-  public void testStringSet() {
-    AttributeValue value =
-        AttributeValue.builder().ss(Arrays.asList("apple", "banana", "cherry")).build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotEquals(0L, hash);
-  }
-
-  @Test
-  public void testNumberSet() {
-    AttributeValue value = AttributeValue.builder().ns(Arrays.asList("1", "2", "3")).build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotEquals(0L, hash);
-  }
-
-  @Test
-  public void testBinarySet() {
-    AttributeValue value =
-        AttributeValue.builder()
-            .bs(
-                Arrays.asList(
-                    SdkBytes.fromByteArray(new byte[] {1, 2}),
-                    SdkBytes.fromByteArray(new byte[] {3, 4})))
-            .build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotEquals(0L, hash);
-  }
-
-  @Test
-  public void testList() {
-    AttributeValue value =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().s("item1").build(),
-                    AttributeValue.builder().n("42").build()))
-            .build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotEquals(0L, hash);
-  }
-
-  @Test
-  public void testMap() {
-    Map<String, AttributeValue> map = new HashMap<>();
-    map.put("name", AttributeValue.builder().s("John").build());
-    map.put("age", AttributeValue.builder().n("30").build());
-    AttributeValue value = AttributeValue.builder().m(map).build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotEquals(0L, hash);
-  }
-
-  @Test
-  public void testMapKeyOrderIndependence() {
-    // Maps should hash the same regardless of insertion order
-    // because we sort keys before hashing
-    Map<String, AttributeValue> map1 = new HashMap<>();
-    map1.put("b", AttributeValue.builder().s("second").build());
-    map1.put("a", AttributeValue.builder().s("first").build());
-
-    Map<String, AttributeValue> map2 = new HashMap<>();
-    map2.put("a", AttributeValue.builder().s("first").build());
-    map2.put("b", AttributeValue.builder().s("second").build());
-
-    AttributeValue value1 = AttributeValue.builder().m(map1).build();
-    AttributeValue value2 = AttributeValue.builder().m(map2).build();
-
-    assertEquals(AttributeValueHasher.hash(value1), AttributeValueHasher.hash(value2));
-  }
-
-  @Test
-  public void testNestedStructure() {
-    Map<String, AttributeValue> innerMap = new HashMap<>();
-    innerMap.put("inner", AttributeValue.builder().s("value").build());
-
-    AttributeValue value =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().m(innerMap).build(),
-                    AttributeValue.builder().s("item").build()))
-            .build();
-    long hash = AttributeValueHasher.hash(value);
-    assertNotEquals(0L, hash);
-  }
-
-  @Test
   public void testTypicalPartitionKeys() {
     // Test common partition key patterns
     String[] keys = {"user_12345", "ORDER#2024-01-15", "pk_abc123", "session-uuid-here"};
@@ -247,159 +131,6 @@ public class AttributeValueHasherTest {
     assertNotEquals("String and Binary with same bytes should NOT collide", stringHash, binaryHash);
   }
 
-  /** Verifies that Boolean and Null types produce different hashes. */
-  @Test
-  public void testBooleanNullNoCollision() {
-    // Boolean true and Null true should hash to different values
-    AttributeValue boolTrue = AttributeValue.builder().bool(true).build();
-    AttributeValue nullTrue = AttributeValue.builder().nul(true).build();
-
-    long boolHash = AttributeValueHasher.hash(boolTrue);
-    long nullHash = AttributeValueHasher.hash(nullTrue);
-
-    assertNotEquals("Boolean true and Null true should NOT collide", boolHash, nullHash);
-
-    // Boolean false should differ from Null true
-    AttributeValue boolFalse = AttributeValue.builder().bool(false).build();
-    assertNotEquals(
-        "Boolean false and Null true should NOT collide",
-        AttributeValueHasher.hash(boolFalse),
-        nullHash);
-  }
-
-  /** Verifies that nul(false) throws an exception since it's not a valid DynamoDB value. */
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullFalseThrowsException() {
-    // nul(false) is not a valid DynamoDB NULL value - NULL is semantically always true
-    AttributeValue nullFalse = AttributeValue.builder().nul(false).build();
-    AttributeValueHasher.hash(nullFalse);
-  }
-
-  // ========== Collection Boundary Collision Prevention Tests ==========
-  // These tests verify that different element boundaries produce different hashes.
-
-  /** Verifies that different String Set element boundaries produce different hashes. */
-  @Test
-  public void testStringSetBoundaryNoCollision() {
-    // SS ["a", "bc"] and SS ["ab", "c"] should hash to different values
-    // because of length-prefixed encoding
-    AttributeValue set1 = AttributeValue.builder().ss(Arrays.asList("a", "bc")).build();
-    AttributeValue set2 = AttributeValue.builder().ss(Arrays.asList("ab", "c")).build();
-
-    long hash1 = AttributeValueHasher.hash(set1);
-    long hash2 = AttributeValueHasher.hash(set2);
-
-    assertNotEquals("Different SS element boundaries should NOT collide", hash1, hash2);
-  }
-
-  /** Verifies that different Number Set element boundaries produce different hashes. */
-  @Test
-  public void testNumberSetBoundaryNoCollision() {
-    // NS ["1", "23"] and NS ["12", "3"] should hash to different values
-    AttributeValue set1 = AttributeValue.builder().ns(Arrays.asList("1", "23")).build();
-    AttributeValue set2 = AttributeValue.builder().ns(Arrays.asList("12", "3")).build();
-
-    long hash1 = AttributeValueHasher.hash(set1);
-    long hash2 = AttributeValueHasher.hash(set2);
-
-    assertNotEquals("Different NS element boundaries should NOT collide", hash1, hash2);
-  }
-
-  /** Verifies that different Binary Set element boundaries produce different hashes. */
-  @Test
-  public void testBinarySetBoundaryNoCollision() {
-    // BS [{0x01}, {0x02, 0x03}] and BS [{0x01, 0x02}, {0x03}] should differ
-    AttributeValue set1 =
-        AttributeValue.builder()
-            .bs(
-                Arrays.asList(
-                    SdkBytes.fromByteArray(new byte[] {0x01}),
-                    SdkBytes.fromByteArray(new byte[] {0x02, 0x03})))
-            .build();
-    AttributeValue set2 =
-        AttributeValue.builder()
-            .bs(
-                Arrays.asList(
-                    SdkBytes.fromByteArray(new byte[] {0x01, 0x02}),
-                    SdkBytes.fromByteArray(new byte[] {0x03})))
-            .build();
-
-    long hash1 = AttributeValueHasher.hash(set1);
-    long hash2 = AttributeValueHasher.hash(set2);
-
-    assertNotEquals("Different BS element boundaries should NOT collide", hash1, hash2);
-  }
-
-  /** Verifies that different List element boundaries produce different hashes. */
-  @Test
-  public void testListBoundaryNoCollision() {
-    // L [S("a"), S("bc")] and L [S("ab"), S("c")] should hash to different values
-    AttributeValue list1 =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().s("a").build(),
-                    AttributeValue.builder().s("bc").build()))
-            .build();
-    AttributeValue list2 =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().s("ab").build(),
-                    AttributeValue.builder().s("c").build()))
-            .build();
-
-    long hash1 = AttributeValueHasher.hash(list1);
-    long hash2 = AttributeValueHasher.hash(list2);
-
-    assertNotEquals("Different List element boundaries should NOT collide", hash1, hash2);
-  }
-
-  /** Verifies that different Map key boundaries produce different hashes. */
-  @Test
-  public void testMapKeyBoundaryNoCollision() {
-    // M {"a": S("x"), "bc": S("y")} and M {"ab": S("x"), "c": S("y")} should differ
-    Map<String, AttributeValue> map1 = new HashMap<>();
-    map1.put("a", AttributeValue.builder().s("x").build());
-    map1.put("bc", AttributeValue.builder().s("y").build());
-
-    Map<String, AttributeValue> map2 = new HashMap<>();
-    map2.put("ab", AttributeValue.builder().s("x").build());
-    map2.put("c", AttributeValue.builder().s("y").build());
-
-    long hash1 = AttributeValueHasher.hash(AttributeValue.builder().m(map1).build());
-    long hash2 = AttributeValueHasher.hash(AttributeValue.builder().m(map2).build());
-
-    assertNotEquals("Different Map key boundaries should NOT collide", hash1, hash2);
-  }
-
-  // ========== Empty Collection Collision Prevention Tests ==========
-
-  /** Verifies that empty collections of different types produce different hashes. */
-  @Test
-  public void testEmptyCollectionsNoCollision() {
-    // Empty SS, NS, BS, L, and M should all produce different hashes
-    AttributeValue emptySS = AttributeValue.builder().ss(Arrays.<String>asList()).build();
-    AttributeValue emptyNS = AttributeValue.builder().ns(Arrays.<String>asList()).build();
-    AttributeValue emptyBS = AttributeValue.builder().bs(Arrays.<SdkBytes>asList()).build();
-    AttributeValue emptyL = AttributeValue.builder().l(Arrays.<AttributeValue>asList()).build();
-    AttributeValue emptyM =
-        AttributeValue.builder().m(new HashMap<String, AttributeValue>()).build();
-
-    long hashSS = AttributeValueHasher.hash(emptySS);
-    long hashNS = AttributeValueHasher.hash(emptyNS);
-    long hashBS = AttributeValueHasher.hash(emptyBS);
-    long hashL = AttributeValueHasher.hash(emptyL);
-    long hashM = AttributeValueHasher.hash(emptyM);
-
-    // All empty collections should produce different hashes due to type prefixes
-    assertNotEquals("Empty SS and NS should NOT collide", hashSS, hashNS);
-    assertNotEquals("Empty NS and BS should NOT collide", hashNS, hashBS);
-    assertNotEquals("Empty BS and L should NOT collide", hashBS, hashL);
-    assertNotEquals("Empty L and M should NOT collide", hashL, hashM);
-    assertNotEquals("Empty SS and L should NOT collide", hashSS, hashL);
-  }
-
   // ========== Binary Partition Key Tests ==========
 
   @Test
@@ -438,61 +169,6 @@ public class AttributeValueHasherTest {
     // Verify consistency
     assertEquals(hash, AttributeValueHasher.hash(value));
     assertNotEquals("Binary with high bytes should produce non-zero hash", 0L, hash);
-  }
-
-  // ========== String Set Order Independence Tests ==========
-
-  @Test
-  public void testStringSetOrderIndependence() {
-    // String sets should hash the same regardless of input order
-    // because we sort before hashing
-    AttributeValue set1 =
-        AttributeValue.builder().ss(Arrays.asList("cherry", "apple", "banana")).build();
-    AttributeValue set2 =
-        AttributeValue.builder().ss(Arrays.asList("apple", "banana", "cherry")).build();
-    AttributeValue set3 =
-        AttributeValue.builder().ss(Arrays.asList("banana", "cherry", "apple")).build();
-
-    long hash1 = AttributeValueHasher.hash(set1);
-    long hash2 = AttributeValueHasher.hash(set2);
-    long hash3 = AttributeValueHasher.hash(set3);
-
-    assertEquals("SS order should not affect hash (1 vs 2)", hash1, hash2);
-    assertEquals("SS order should not affect hash (2 vs 3)", hash2, hash3);
-  }
-
-  @Test
-  public void testNumberSetOrderIndependence() {
-    AttributeValue set1 = AttributeValue.builder().ns(Arrays.asList("3", "1", "2")).build();
-    AttributeValue set2 = AttributeValue.builder().ns(Arrays.asList("1", "2", "3")).build();
-
-    assertEquals(
-        "NS order should not affect hash",
-        AttributeValueHasher.hash(set1),
-        AttributeValueHasher.hash(set2));
-  }
-
-  @Test
-  public void testBinarySetOrderIndependence() {
-    AttributeValue set1 =
-        AttributeValue.builder()
-            .bs(
-                Arrays.asList(
-                    SdkBytes.fromByteArray(new byte[] {3, 4}),
-                    SdkBytes.fromByteArray(new byte[] {1, 2})))
-            .build();
-    AttributeValue set2 =
-        AttributeValue.builder()
-            .bs(
-                Arrays.asList(
-                    SdkBytes.fromByteArray(new byte[] {1, 2}),
-                    SdkBytes.fromByteArray(new byte[] {3, 4})))
-            .build();
-
-    assertEquals(
-        "BS order should not affect hash",
-        AttributeValueHasher.hash(set1),
-        AttributeValueHasher.hash(set2));
   }
 
   // ========== Edge Case Tests ==========
@@ -544,128 +220,94 @@ public class AttributeValueHasherTest {
     assertEquals(hash, AttributeValueHasher.hash(value));
   }
 
+  // ========== All Partition Key Types Unique Tests ==========
+
+  /** Verifies that all supported partition key types produce unique hashes. */
   @Test
-  public void testDeeplyNestedStructure() {
-    // Create a deeply nested map
-    Map<String, AttributeValue> level3 = new HashMap<>();
-    level3.put("deep", AttributeValue.builder().s("value").build());
-
-    Map<String, AttributeValue> level2 = new HashMap<>();
-    level2.put("nested", AttributeValue.builder().m(level3).build());
-
-    Map<String, AttributeValue> level1 = new HashMap<>();
-    level1.put("outer", AttributeValue.builder().m(level2).build());
-
-    AttributeValue value = AttributeValue.builder().m(level1).build();
-    long hash = AttributeValueHasher.hash(value);
-
-    assertNotEquals(0L, hash);
-    assertEquals(hash, AttributeValueHasher.hash(value));
-  }
-
-  // ========== All Types Unique Tests ==========
-
-  /** Verifies that all primitive types produce unique hashes for reasonable test values. */
-  @Test
-  public void testAllPrimitiveTypesUnique() {
-    // Create one value of each primitive type with similar-looking data
+  public void testAllPartitionKeyTypesUnique() {
+    // Create one value of each supported type with similar-looking data
     AttributeValue stringVal = AttributeValue.builder().s("1").build();
     AttributeValue numberVal = AttributeValue.builder().n("1").build();
     AttributeValue binaryVal =
         AttributeValue.builder()
             .b(SdkBytes.fromByteArray(new byte[] {0x31})) // ASCII '1'
             .build();
-    AttributeValue boolVal = AttributeValue.builder().bool(true).build();
-    AttributeValue nullVal = AttributeValue.builder().nul(true).build();
 
     long hashS = AttributeValueHasher.hash(stringVal);
     long hashN = AttributeValueHasher.hash(numberVal);
     long hashB = AttributeValueHasher.hash(binaryVal);
-    long hashBool = AttributeValueHasher.hash(boolVal);
-    long hashNull = AttributeValueHasher.hash(nullVal);
 
     // All should be different
     assertNotEquals("S vs N", hashS, hashN);
     assertNotEquals("S vs B", hashS, hashB);
-    assertNotEquals("S vs BOOL", hashS, hashBool);
-    assertNotEquals("S vs NULL", hashS, hashNull);
     assertNotEquals("N vs B", hashN, hashB);
-    assertNotEquals("N vs BOOL", hashN, hashBool);
-    assertNotEquals("N vs NULL", hashN, hashNull);
-    assertNotEquals("B vs BOOL", hashB, hashBool);
-    assertNotEquals("B vs NULL", hashB, hashNull);
-    assertNotEquals("BOOL vs NULL", hashBool, hashNull);
   }
 
-  /** Verifies that all collection types produce unique hashes when empty. */
-  @Test
-  public void testAllCollectionTypesUnique() {
-    AttributeValue ss = AttributeValue.builder().ss(Arrays.asList("a")).build();
-    AttributeValue ns = AttributeValue.builder().ns(Arrays.asList("1")).build();
-    AttributeValue bs =
-        AttributeValue.builder()
-            .bs(Arrays.asList(SdkBytes.fromByteArray(new byte[] {0x61})))
-            .build();
-    AttributeValue list =
-        AttributeValue.builder().l(Arrays.asList(AttributeValue.builder().s("a").build())).build();
+  // ========== Unsupported Type Tests ==========
 
-    Map<String, AttributeValue> mapData = new HashMap<>();
-    mapData.put("k", AttributeValue.builder().s("v").build());
-    AttributeValue map = AttributeValue.builder().m(mapData).build();
-
-    long hashSS = AttributeValueHasher.hash(ss);
-    long hashNS = AttributeValueHasher.hash(ns);
-    long hashBS = AttributeValueHasher.hash(bs);
-    long hashL = AttributeValueHasher.hash(list);
-    long hashM = AttributeValueHasher.hash(map);
-
-    // All collection types should produce different hashes
-    assertNotEquals("SS vs NS", hashSS, hashNS);
-    assertNotEquals("SS vs BS", hashSS, hashBS);
-    assertNotEquals("SS vs L", hashSS, hashL);
-    assertNotEquals("SS vs M", hashSS, hashM);
-    assertNotEquals("NS vs BS", hashNS, hashBS);
-    assertNotEquals("NS vs L", hashNS, hashL);
-    assertNotEquals("NS vs M", hashNS, hashM);
-    assertNotEquals("BS vs L", hashBS, hashL);
-    assertNotEquals("BS vs M", hashBS, hashM);
-    assertNotEquals("L vs M", hashL, hashM);
+  /** Verifies that Boolean type throws an exception. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testBooleanThrowsException() {
+    AttributeValue value = AttributeValue.builder().bool(true).build();
+    AttributeValueHasher.hash(value);
   }
 
-  // ========== Mixed Type in Collections Tests ==========
-
-  /** Verifies that lists with different element types but same values produce different hashes. */
-  @Test
-  public void testListWithDifferentElementTypes() {
-    // L [S("123")] vs L [N("123")] should differ
-    AttributeValue listWithString =
-        AttributeValue.builder()
-            .l(Arrays.asList(AttributeValue.builder().s("123").build()))
-            .build();
-    AttributeValue listWithNumber =
-        AttributeValue.builder()
-            .l(Arrays.asList(AttributeValue.builder().n("123").build()))
-            .build();
-
-    assertNotEquals(
-        "Lists with S vs N elements should differ",
-        AttributeValueHasher.hash(listWithString),
-        AttributeValueHasher.hash(listWithNumber));
+  /** Verifies that NULL type throws an exception. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullTypeThrowsException() {
+    AttributeValue value = AttributeValue.builder().nul(true).build();
+    AttributeValueHasher.hash(value);
   }
 
-  /** Verifies that maps with same keys but different value types produce different hashes. */
-  @Test
-  public void testMapWithDifferentValueTypes() {
-    Map<String, AttributeValue> map1 = new HashMap<>();
-    map1.put("key", AttributeValue.builder().s("123").build());
+  /** Verifies that String Set throws an exception. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testStringSetThrowsException() {
+    AttributeValue value =
+        AttributeValue.builder().ss(Arrays.asList("apple", "banana", "cherry")).build();
+    AttributeValueHasher.hash(value);
+  }
 
-    Map<String, AttributeValue> map2 = new HashMap<>();
-    map2.put("key", AttributeValue.builder().n("123").build());
+  /** Verifies that Number Set throws an exception. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNumberSetThrowsException() {
+    AttributeValue value = AttributeValue.builder().ns(Arrays.asList("1", "2", "3")).build();
+    AttributeValueHasher.hash(value);
+  }
 
-    assertNotEquals(
-        "Maps with S vs N values should differ",
-        AttributeValueHasher.hash(AttributeValue.builder().m(map1).build()),
-        AttributeValueHasher.hash(AttributeValue.builder().m(map2).build()));
+  /** Verifies that Binary Set throws an exception. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testBinarySetThrowsException() {
+    AttributeValue value =
+        AttributeValue.builder()
+            .bs(
+                Arrays.asList(
+                    SdkBytes.fromByteArray(new byte[] {1, 2}),
+                    SdkBytes.fromByteArray(new byte[] {3, 4})))
+            .build();
+    AttributeValueHasher.hash(value);
+  }
+
+  /** Verifies that List throws an exception. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testListThrowsException() {
+    AttributeValue value =
+        AttributeValue.builder()
+            .l(
+                Arrays.asList(
+                    AttributeValue.builder().s("item1").build(),
+                    AttributeValue.builder().n("42").build()))
+            .build();
+    AttributeValueHasher.hash(value);
+  }
+
+  /** Verifies that Map throws an exception. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testMapThrowsException() {
+    Map<String, AttributeValue> map = new HashMap<>();
+    map.put("name", AttributeValue.builder().s("John").build());
+    map.put("age", AttributeValue.builder().n("30").build());
+    AttributeValue value = AttributeValue.builder().m(map).build();
+    AttributeValueHasher.hash(value);
   }
 
   // ========== Thread Safety Tests ==========
@@ -676,21 +318,16 @@ public class AttributeValueHasherTest {
     final int threadCount = 10;
     final int iterationsPerThread = 1000;
 
-    // Create test values of different types
+    // Create test values of supported types
     final AttributeValue stringValue = AttributeValue.builder().s("test_user_123").build();
     final AttributeValue numberValue = AttributeValue.builder().n("12345").build();
-    final AttributeValue listValue =
-        AttributeValue.builder()
-            .l(
-                Arrays.asList(
-                    AttributeValue.builder().s("item1").build(),
-                    AttributeValue.builder().n("42").build()))
-            .build();
+    final AttributeValue binaryValue =
+        AttributeValue.builder().b(SdkBytes.fromByteArray(new byte[] {0x01, 0x02, 0x03})).build();
 
     // Compute expected hashes
     final long expectedStringHash = AttributeValueHasher.hash(stringValue);
     final long expectedNumberHash = AttributeValueHasher.hash(numberValue);
-    final long expectedListHash = AttributeValueHasher.hash(listValue);
+    final long expectedBinaryHash = AttributeValueHasher.hash(binaryValue);
 
     final AtomicBoolean failed = new AtomicBoolean(false);
     final CountDownLatch startLatch = new CountDownLatch(1);
@@ -706,11 +343,11 @@ public class AttributeValueHasherTest {
               for (int i = 0; i < iterationsPerThread && !failed.get(); i++) {
                 long stringHash = AttributeValueHasher.hash(stringValue);
                 long numberHash = AttributeValueHasher.hash(numberValue);
-                long listHash = AttributeValueHasher.hash(listValue);
+                long binaryHash = AttributeValueHasher.hash(binaryValue);
 
                 if (stringHash != expectedStringHash
                     || numberHash != expectedNumberHash
-                    || listHash != expectedListHash) {
+                    || binaryHash != expectedBinaryHash) {
                   failed.set(true);
                 }
               }
@@ -731,64 +368,5 @@ public class AttributeValueHasherTest {
     executor.shutdown();
 
     assertFalse("Concurrent hash computation produced inconsistent results", failed.get());
-  }
-
-  // ========== Large Collection Tests ==========
-
-  /** Verifies hashing works correctly with large collections (10,000+ elements). */
-  @Test
-  public void testLargeStringSet() {
-    List<String> largeSet = new ArrayList<>();
-    for (int i = 0; i < 10000; i++) {
-      largeSet.add("element_" + i);
-    }
-
-    AttributeValue value = AttributeValue.builder().ss(largeSet).build();
-    long hash = AttributeValueHasher.hash(value);
-
-    // Verify non-zero hash
-    assertNotEquals("Large string set should produce non-zero hash", 0L, hash);
-
-    // Verify consistency
-    assertEquals(
-        "Large string set hash should be consistent",
-        hash,
-        AttributeValueHasher.hash(AttributeValue.builder().ss(largeSet).build()));
-  }
-
-  /** Verifies hashing works correctly with large lists (10,000+ elements). */
-  @Test
-  public void testLargeList() {
-    List<AttributeValue> largeList = new ArrayList<>();
-    for (int i = 0; i < 10000; i++) {
-      largeList.add(AttributeValue.builder().s("item_" + i).build());
-    }
-
-    AttributeValue value = AttributeValue.builder().l(largeList).build();
-    long hash = AttributeValueHasher.hash(value);
-
-    // Verify non-zero hash
-    assertNotEquals("Large list should produce non-zero hash", 0L, hash);
-
-    // Verify consistency
-    assertEquals("Large list hash should be consistent", hash, AttributeValueHasher.hash(value));
-  }
-
-  /** Verifies hashing works correctly with large maps (10,000+ entries). */
-  @Test
-  public void testLargeMap() {
-    Map<String, AttributeValue> largeMap = new HashMap<>();
-    for (int i = 0; i < 10000; i++) {
-      largeMap.put("key_" + i, AttributeValue.builder().s("value_" + i).build());
-    }
-
-    AttributeValue value = AttributeValue.builder().m(largeMap).build();
-    long hash = AttributeValueHasher.hash(value);
-
-    // Verify non-zero hash
-    assertNotEquals("Large map should produce non-zero hash", 0L, hash);
-
-    // Verify consistency
-    assertEquals("Large map hash should be consistent", hash, AttributeValueHasher.hash(value));
   }
 }


### PR DESCRIPTION
## Summary

ScyllaDB Alternator only supports S (String), N (Number), and B (Binary) types for partition keys. This PR removes unnecessary support for other DynamoDB types from `AttributeValueHasher`.

## Changes

- Remove collection type handling (SS, NS, BS, L, M)
- Remove BOOL and NULL type handling
- Update Javadoc to reflect supported types
- Update tests to verify unsupported types throw `IllegalArgumentException`
- Simplify cross-language tests to only test partition key types

## Code Reduction

- ~150 lines removed from `AttributeValueHasher.java`
- ~550 lines removed from test files (tests for unsupported types replaced with exception tests)

## Test plan

- [x] All hasher unit tests pass
- [x] Cross-language compatibility tests pass for S, N, B types
- [x] Unsupported types throw `IllegalArgumentException`

Fixes #43