### PR TITLE
Fix silent exception swallowing in consumeAndClose

### DIFF
--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -532,7 +532,7 @@ public class AlternatorLiveNodes extends Thread {
       try {
         stream.abort();
       } catch (Exception abortEx) {
-        // ignore
+        logger.log(Level.WARNING, "Failed to abort AbortableInputStream during cleanup", abortEx);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace silent exception swallowing with proper logging in consumeAndClose() method
- Improve observability of connection pool health issues

## Changes
- Replace `// ignore` comment with proper WARNING level logging for abort failures
- Add descriptive log message to help diagnose connection pool issues

## Test plan
- [x] Verify compilation passes
- [x] Test that abort failures are now logged appropriately
- [x] Confirm no behavioral changes to normal operation