### PR TITLE
Remove printStackTrace calls from demo applications

### DIFF
--- a/src/demo/java/com/scylladb/alternator/demo/Demo2.java
+++ b/src/demo/java/com/scylladb/alternator/demo/Demo2.java
@@ -204,7 +204,7 @@ public class Demo2 {
       sc.init(null, trustAllCerts, new java.security.SecureRandom());
       HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
     } catch (Exception e) {
-      e.printStackTrace();
+      System.err.println("Failed to configure SSL: " + e.getMessage());
     }
     HttpsURLConnection.setDefaultHostnameVerifier(
         new HostnameVerifier() {

--- a/src/demo/java/com/scylladb/alternator/demo/Demo4.java
+++ b/src/demo/java/com/scylladb/alternator/demo/Demo4.java
@@ -235,7 +235,7 @@ public class Demo4 {
       sc.init(null, trustAllCerts, new java.security.SecureRandom());
       HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
     } catch (Exception e) {
-      e.printStackTrace();
+      System.err.println("Failed to configure SSL: " + e.getMessage());
     }
     HttpsURLConnection.setDefaultHostnameVerifier(
         new HostnameVerifier() {


### PR DESCRIPTION
## Summary
- Remove inappropriate printStackTrace calls from demo applications
- Replace with proper error messages to prevent information disclosure

## Changes
- Demo2.java: Replace printStackTrace with descriptive SSL configuration error message
- Demo4.java: Replace printStackTrace with descriptive SSL configuration error message
- Maintain error handling but prevent stack trace information disclosure

## Test plan
- [x] Verify compilation passes
- [x] Test demo applications still handle SSL configuration errors gracefully
- [x] Confirm no functional behavior changes