### PR TITLE
Fix integer overflow in round-robin load balancing

### DIFF
--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -401,7 +401,9 @@ public class AlternatorLiveNodes extends Thread {
     if (nodes.isEmpty()) {
       throw new IllegalStateException("No live nodes available");
     }
-    return nodes.get(Math.abs(nextLiveNodeIndex.getAndIncrement() % nodes.size()));
+    int counter = nextLiveNodeIndex.getAndIncrement();
+    int index = (counter & Integer.MAX_VALUE) % nodes.size();
+    return nodes.get(index);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix potential ArrayIndexOutOfBoundsException from AtomicInteger overflow in round-robin selection
- Ensure safe index calculation even after billions of requests

## Changes
- Replace Math.abs() with bitwise AND operation to handle Integer.MIN_VALUE case
- Use `(counter & Integer.MAX_VALUE)` to ensure non-negative index
- Maintain round-robin distribution behavior while preventing crashes

## Test plan
- [x] Verify compilation passes
- [x] Test round-robin distribution still works correctly
- [x] Verify no crashes when counter approaches Integer.MAX_VALUE
- [x] Confirm behavior with Integer.MIN_VALUE overflow case