### PR TITLE
Add HttpClientType enum to explicitly select HTTP client implementation

### DIFF
--- a/src/integration-test/java/com/scylladb/alternator/KeyRouteAffinityAutodiscoveryIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/KeyRouteAffinityAutodiscoveryIT.java
@@ -142,6 +142,7 @@ public class KeyRouteAffinityAutodiscoveryIT {
               GetItemRequest.builder()
                   .tableName(tableName)
                   .key(Map.of("user_id", AttributeValue.builder().s("user-001").build()))
+                  .consistentRead(true)
                   .build());
       assertNotNull("First item should exist", response1.item());
       assertEquals("Alice", response1.item().get("name").s());
@@ -151,6 +152,7 @@ public class KeyRouteAffinityAutodiscoveryIT {
               GetItemRequest.builder()
                   .tableName(tableName)
                   .key(Map.of("user_id", AttributeValue.builder().s("user-002").build()))
+                  .consistentRead(true)
                   .build());
       assertNotNull("Second item should exist", response2.item());
       assertEquals("Bob", response2.item().get("name").s());
@@ -226,6 +228,7 @@ public class KeyRouteAffinityAutodiscoveryIT {
               GetItemRequest.builder()
                   .tableName(tableName)
                   .key(Map.of("user_id", AttributeValue.builder().s("route-test").build()))
+                  .consistentRead(true)
                   .build());
 
       assertNotNull("Item should exist after repeated writes", finalResponse.item());
@@ -254,6 +257,7 @@ public class KeyRouteAffinityAutodiscoveryIT {
                 GetItemRequest.builder()
                     .tableName(tableName)
                     .key(Map.of("user_id", AttributeValue.builder().s(pk).build()))
+                    .consistentRead(true)
                     .build());
         assertNotNull("Item " + pk + " should exist", response.item());
         assertEquals("val-" + i, response.item().get("value").s());
@@ -316,6 +320,7 @@ public class KeyRouteAffinityAutodiscoveryIT {
               GetItemRequest.builder()
                   .tableName(tableName)
                   .key(Map.of("user_id", AttributeValue.builder().s("preconf-user").build()))
+                  .consistentRead(true)
                   .build());
 
       assertNotNull("Item should exist", response.item());
@@ -342,6 +347,7 @@ public class KeyRouteAffinityAutodiscoveryIT {
                 GetItemRequest.builder()
                     .tableName(tableName)
                     .key(Map.of("user_id", AttributeValue.builder().s("user-" + i).build()))
+                    .consistentRead(true)
                     .build());
         assertNotNull("Item user-" + i + " should exist", readResponse.item());
         assertEquals("data-" + i, readResponse.item().get("data").s());

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -12,6 +12,7 @@ import com.scylladb.alternator.queryplan.BasicQueryPlanInterceptor;
 import com.scylladb.alternator.routing.RoutingScope;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.function.Consumer;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -96,6 +97,7 @@ public class AlternatorDynamoDbAsyncClient {
     private boolean credentialsProviderSet = false;
     private Consumer<NettyNioAsyncHttpClient.Builder> nettyCustomizer;
     private Consumer<AwsCrtAsyncHttpClient.Builder> crtAsyncCustomizer;
+    private HttpClientType httpClientType;
 
     private AlternatorDynamoDbAsyncClientBuilder() {
       this.delegate = DynamoDbAsyncClient.builder();
@@ -326,6 +328,9 @@ public class AlternatorDynamoDbAsyncClient {
         configBuilder.withMaxConnections(config.getMaxConnections());
         configBuilder.withConnectionMaxIdleTimeMs(config.getConnectionMaxIdleTimeMs());
         configBuilder.withConnectionTimeToLiveMs(config.getConnectionTimeToLiveMs());
+        configBuilder.withConnectionAcquisitionTimeoutMs(
+            config.getConnectionAcquisitionTimeoutMs());
+        configBuilder.withConnectionTimeoutMs(config.getConnectionTimeoutMs());
       }
       return this;
     }
@@ -385,6 +390,31 @@ public class AlternatorDynamoDbAsyncClient {
     public AlternatorDynamoDbAsyncClientBuilder withCrtAsyncHttpClientCustomizer(
         Consumer<AwsCrtAsyncHttpClient.Builder> customizer) {
       this.crtAsyncCustomizer = customizer;
+      return this;
+    }
+
+    /**
+     * Explicitly selects which HTTP client implementation to use.
+     *
+     * <p>By default, the builder auto-detects the HTTP client from the classpath (Netty &gt; CRT).
+     * Use this method to force a specific implementation. If the requested implementation is not on
+     * the classpath, the builder will throw {@link IllegalStateException} at build time.
+     *
+     * <p>Only {@link HttpClientType#NETTY}, {@link HttpClientType#CRT}, and {@link
+     * HttpClientType#AUTO} are valid for async clients. Setting {@link HttpClientType#APACHE} will
+     * throw {@link IllegalStateException} since Apache is sync-only.
+     *
+     * <p>This is mutually exclusive with {@link #httpClient(SdkAsyncHttpClient)} and {@link
+     * #httpClientBuilder}. It can be combined with a matching customizer (e.g., {@link
+     * HttpClientType#NETTY} with {@link #withNettyHttpClientCustomizer}), but not with a mismatched
+     * one.
+     *
+     * @param httpClientType the HTTP client type to use
+     * @return this builder instance
+     * @since 2.1.0
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withHttpClientType(HttpClientType httpClientType) {
+      this.httpClientType = Objects.requireNonNull(httpClientType, "httpClientType");
       return this;
     }
 
@@ -540,27 +570,21 @@ public class AlternatorDynamoDbAsyncClient {
                 + "Call endpointOverride(URI) with the seed Alternator node URI.");
       }
 
-      // Validate mutually exclusive options
-      validateHttpClientOptions();
+      AsyncClientDetector.AsyncClientType asyncType = validateAndDetectAsyncClientType();
 
-      // Use anonymous credentials if no credentials were provided
       if (!credentialsProviderSet) {
         configBuilder.authenticationEnabled(false);
         delegate.credentialsProvider(AnonymousCredentialsProvider.create());
       }
 
-      // Set the seed node on the config
       configBuilder.withSeedNode(seedUri);
 
-      // If disableCertificateChecks was called, set trust-all TLS config
       if (disableCertificateChecks) {
         configBuilder.withTlsConfig(TlsConfig.trustAll());
       }
 
-      // Build the AlternatorConfig from the internal builder
       AlternatorConfig alternatorConfig = configBuilder.build();
 
-      // Apply SDK-level interceptors from config (compression only)
       if (alternatorConfig.getCompressionAlgorithm().isEnabled()) {
         ClientOverrideConfiguration.Builder overrideBuilder =
             delegate.overrideConfiguration() != null
@@ -574,16 +598,10 @@ public class AlternatorDynamoDbAsyncClient {
       TlsConfig tlsConfig = alternatorConfig.getTlsConfig();
       boolean optimizeHeaders = alternatorConfig.isOptimizeHeaders();
 
-      // Create the async HTTP client for the SDK
       if (!httpClientSet) {
-        // Determine which async implementation to use
-        AsyncClientDetector.AsyncClientType asyncType = detectAsyncClientType();
-
-        // Create the main async HTTP client via factory
         SdkAsyncHttpClient mainClient =
             createMainAsyncClient(asyncType, alternatorConfig, tlsConfig);
 
-        // Wrap with header filtering if enabled
         if (optimizeHeaders) {
           delegate.httpClient(
               new HeadersFilteringSdkAsyncHttpClient(
@@ -593,15 +611,12 @@ public class AlternatorDynamoDbAsyncClient {
         }
       }
 
-      // Create a separate sync polling client for LiveNodes (always needed)
       SyncClientDetector.SyncClientType syncType = SyncClientDetector.detect();
       SdkHttpClient pollingClient = SyncClientDetector.createPollingClient(syncType, tlsConfig);
 
-      // Create AlternatorLiveNodes and start node discovery
       AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(alternatorConfig, pollingClient);
       liveNodes.start();
 
-      // Add query plan interceptor
       ClientOverrideConfiguration.Builder overrideBuilder =
           delegate.overrideConfiguration() != null
               ? delegate.overrideConfiguration().toBuilder()
@@ -618,22 +633,26 @@ public class AlternatorDynamoDbAsyncClient {
       }
       delegate.overrideConfiguration(overrideBuilder.build());
 
-      // Use seed URI as base endpoint - interceptor will override with actual target node
       delegate.endpointOverride(seedUri);
 
-      // Set default region if not specified
       if (region == null) {
         delegate.region(Region.of("fake-aws-region"));
       }
 
-      // Build the underlying client and wrap it
       DynamoDbAsyncClient client = delegate.build();
       return new AlternatorDynamoDbAsyncClientWrapper(
           client, liveNodes, alternatorConfig, pollingClient);
     }
 
-    private void validateHttpClientOptions() {
+    /**
+     * Validates mutually exclusive HTTP client options and detects the async client type.
+     *
+     * @return the resolved client type, or {@code null} if a custom HTTP client was provided via
+     *     {@link #httpClient} / {@link #httpClientBuilder}
+     */
+    AsyncClientDetector.AsyncClientType validateAndDetectAsyncClientType() {
       boolean hasCustomizer = nettyCustomizer != null || crtAsyncCustomizer != null;
+
       if (httpClientSet && hasCustomizer) {
         throw new IllegalStateException(
             "Cannot use httpClient()/httpClientBuilder() together with "
@@ -645,18 +664,53 @@ public class AlternatorDynamoDbAsyncClient {
             "Cannot set both withNettyHttpClientCustomizer() and "
                 + "withCrtAsyncHttpClientCustomizer(). Choose one HTTP client implementation.");
       }
-    }
+      if (httpClientType != null && httpClientSet) {
+        throw new IllegalStateException(
+            "Cannot use httpClient()/httpClientBuilder() together with withHttpClientType(). "
+                + "Use one approach or the other.");
+      }
 
-    private AsyncClientDetector.AsyncClientType detectAsyncClientType() {
-      // If a customizer was set, use the corresponding type
-      if (nettyCustomizer != null) {
-        return AsyncClientDetector.AsyncClientType.NETTY;
+      if (httpClientSet) {
+        return null;
       }
-      if (crtAsyncCustomizer != null) {
-        return AsyncClientDetector.AsyncClientType.CRT;
+
+      HttpClientType effectiveType = httpClientType != null ? httpClientType : HttpClientType.AUTO;
+
+      switch (effectiveType) {
+        case NETTY:
+          if (crtAsyncCustomizer != null) {
+            throw new IllegalStateException(
+                "HttpClientType.NETTY was set, but withCrtAsyncHttpClientCustomizer() was also "
+                    + "called. Use withNettyHttpClientCustomizer() or change HttpClientType to CRT.");
+          }
+          AsyncClientDetector.requireAvailableHttpClient(AsyncClientDetector.AsyncClientType.NETTY);
+          return AsyncClientDetector.AsyncClientType.NETTY;
+        case CRT:
+          if (nettyCustomizer != null) {
+            throw new IllegalStateException(
+                "HttpClientType.CRT was set, but withNettyHttpClientCustomizer() was also called. "
+                    + "Use withCrtAsyncHttpClientCustomizer() or change HttpClientType to NETTY.");
+          }
+          AsyncClientDetector.requireAvailableHttpClient(AsyncClientDetector.AsyncClientType.CRT);
+          return AsyncClientDetector.AsyncClientType.CRT;
+        case APACHE:
+          throw new IllegalStateException(
+              "HttpClientType.APACHE does not support asynchronous clients. "
+                  + "Use HttpClientType.NETTY, HttpClientType.CRT, or HttpClientType.AUTO.");
+        case AUTO:
+          if (nettyCustomizer != null) {
+            AsyncClientDetector.requireAvailableHttpClient(
+                AsyncClientDetector.AsyncClientType.NETTY);
+            return AsyncClientDetector.AsyncClientType.NETTY;
+          }
+          if (crtAsyncCustomizer != null) {
+            AsyncClientDetector.requireAvailableHttpClient(AsyncClientDetector.AsyncClientType.CRT);
+            return AsyncClientDetector.AsyncClientType.CRT;
+          }
+          return AsyncClientDetector.detect();
+        default:
+          throw new IllegalStateException("Unknown HttpClientType: " + effectiveType);
       }
-      // Auto-detect from classpath
-      return AsyncClientDetector.detect();
     }
 
     private SdkAsyncHttpClient createMainAsyncClient(

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -11,6 +11,7 @@ import com.scylladb.alternator.queryplan.BasicQueryPlanInterceptor;
 import com.scylladb.alternator.routing.RoutingScope;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.function.Consumer;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -96,6 +97,7 @@ public class AlternatorDynamoDbClient {
     private boolean credentialsProviderSet = false;
     private Consumer<ApacheHttpClient.Builder> apacheCustomizer;
     private Consumer<AwsCrtHttpClient.Builder> crtCustomizer;
+    private HttpClientType httpClientType;
 
     private AlternatorDynamoDbClientBuilder() {
       this.delegate = DynamoDbClient.builder();
@@ -363,6 +365,9 @@ public class AlternatorDynamoDbClient {
         configBuilder.withMaxConnections(config.getMaxConnections());
         configBuilder.withConnectionMaxIdleTimeMs(config.getConnectionMaxIdleTimeMs());
         configBuilder.withConnectionTimeToLiveMs(config.getConnectionTimeToLiveMs());
+        configBuilder.withConnectionAcquisitionTimeoutMs(
+            config.getConnectionAcquisitionTimeoutMs());
+        configBuilder.withConnectionTimeoutMs(config.getConnectionTimeoutMs());
       }
       return this;
     }
@@ -422,6 +427,31 @@ public class AlternatorDynamoDbClient {
     public AlternatorDynamoDbClientBuilder withCrtHttpClientCustomizer(
         Consumer<AwsCrtHttpClient.Builder> customizer) {
       this.crtCustomizer = customizer;
+      return this;
+    }
+
+    /**
+     * Explicitly selects which HTTP client implementation to use.
+     *
+     * <p>By default, the builder auto-detects the HTTP client from the classpath (Apache &gt; CRT).
+     * Use this method to force a specific implementation. If the requested implementation is not on
+     * the classpath, the builder will throw {@link IllegalStateException} at build time.
+     *
+     * <p>Only {@link HttpClientType#APACHE}, {@link HttpClientType#CRT}, and {@link
+     * HttpClientType#AUTO} are valid for sync clients. Setting {@link HttpClientType#NETTY} will
+     * throw {@link IllegalStateException} since Netty is async-only.
+     *
+     * <p>This is mutually exclusive with {@link #httpClient(SdkHttpClient)} and {@link
+     * #httpClientBuilder}. It can be combined with a matching customizer (e.g., {@link
+     * HttpClientType#APACHE} with {@link #withApacheHttpClientCustomizer}), but not with a
+     * mismatched one.
+     *
+     * @param httpClientType the HTTP client type to use
+     * @return this builder instance
+     * @since 2.1.0
+     */
+    public AlternatorDynamoDbClientBuilder withHttpClientType(HttpClientType httpClientType) {
+      this.httpClientType = Objects.requireNonNull(httpClientType, "httpClientType");
       return this;
     }
 
@@ -561,27 +591,21 @@ public class AlternatorDynamoDbClient {
                 + "Call endpointOverride(URI) with the seed Alternator node URI.");
       }
 
-      // Validate mutually exclusive options
-      validateHttpClientOptions();
+      SyncClientDetector.SyncClientType clientType = validateAndDetectSyncClientType();
 
-      // Use anonymous credentials if no credentials were provided
       if (!credentialsProviderSet) {
         configBuilder.authenticationEnabled(false);
         delegate.credentialsProvider(AnonymousCredentialsProvider.create());
       }
 
-      // Set the seed node on the config
       configBuilder.withSeedNode(seedUri);
 
-      // If disableCertificateChecks was called, set trust-all TLS config
       if (disableCertificateChecks) {
         configBuilder.withTlsConfig(TlsConfig.trustAll());
       }
 
-      // Build the AlternatorConfig from the internal builder
       AlternatorConfig alternatorConfig = configBuilder.build();
 
-      // Apply SDK-level interceptors from config (compression only)
       if (alternatorConfig.getCompressionAlgorithm().isEnabled()) {
         ClientOverrideConfiguration.Builder overrideBuilder =
             delegate.overrideConfiguration() != null
@@ -595,16 +619,10 @@ public class AlternatorDynamoDbClient {
       TlsConfig tlsConfig = alternatorConfig.getTlsConfig();
       boolean optimizeHeaders = alternatorConfig.isOptimizeHeaders();
 
-      // Create the HTTP client for the SDK
       SdkHttpClient pollingClient = null;
       if (!httpClientSet) {
-        // Determine which sync implementation to use
-        SyncClientDetector.SyncClientType clientType = detectSyncClientType();
-
-        // Create the main SDK HTTP client via factory
         SdkHttpClient mainClient = createMainSyncClient(clientType, alternatorConfig, tlsConfig);
 
-        // Wrap with header filtering if enabled
         if (optimizeHeaders) {
           delegate.httpClient(
               new HeadersFilteringSdkHttpClient(
@@ -613,19 +631,15 @@ public class AlternatorDynamoDbClient {
           delegate.httpClient(mainClient);
         }
 
-        // Create polling client for LiveNodes
         pollingClient = SyncClientDetector.createPollingClient(clientType, tlsConfig);
       } else {
-        // User provided custom HTTP client - still need a polling client for LiveNodes
-        SyncClientDetector.SyncClientType clientType = SyncClientDetector.detect();
-        pollingClient = SyncClientDetector.createPollingClient(clientType, tlsConfig);
+        SyncClientDetector.SyncClientType pollingType = SyncClientDetector.detect();
+        pollingClient = SyncClientDetector.createPollingClient(pollingType, tlsConfig);
       }
 
-      // Create AlternatorLiveNodes and start node discovery
       AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(alternatorConfig, pollingClient);
       liveNodes.start();
 
-      // Add query plan interceptor
       ClientOverrideConfiguration.Builder overrideBuilder =
           delegate.overrideConfiguration() != null
               ? delegate.overrideConfiguration().toBuilder()
@@ -643,22 +657,26 @@ public class AlternatorDynamoDbClient {
       }
       delegate.overrideConfiguration(overrideBuilder.build());
 
-      // Use seed URI as base endpoint - interceptor will override with actual target node
       delegate.endpointOverride(seedUri);
 
-      // Set default region if not specified
       if (region == null) {
         delegate.region(Region.of("fake-aws-region"));
       }
 
-      // Build the underlying client and wrap it
       DynamoDbClient client = delegate.build();
       return new AlternatorDynamoDbClientWrapper(
           client, liveNodes, alternatorConfig, affinityInterceptor, pollingClient);
     }
 
-    private void validateHttpClientOptions() {
+    /**
+     * Validates mutually exclusive HTTP client options and detects the sync client type.
+     *
+     * @return the resolved client type, or {@code null} if a custom HTTP client was provided via
+     *     {@link #httpClient} / {@link #httpClientBuilder}
+     */
+    SyncClientDetector.SyncClientType validateAndDetectSyncClientType() {
       boolean hasCustomizer = apacheCustomizer != null || crtCustomizer != null;
+
       if (httpClientSet && hasCustomizer) {
         throw new IllegalStateException(
             "Cannot use httpClient()/httpClientBuilder() together with "
@@ -670,18 +688,52 @@ public class AlternatorDynamoDbClient {
             "Cannot set both withApacheHttpClientCustomizer() and "
                 + "withCrtHttpClientCustomizer(). Choose one HTTP client implementation.");
       }
-    }
+      if (httpClientType != null && httpClientSet) {
+        throw new IllegalStateException(
+            "Cannot use httpClient()/httpClientBuilder() together with withHttpClientType(). "
+                + "Use one approach or the other.");
+      }
 
-    private SyncClientDetector.SyncClientType detectSyncClientType() {
-      // If a customizer was set, use the corresponding type
-      if (apacheCustomizer != null) {
-        return SyncClientDetector.SyncClientType.APACHE;
+      if (httpClientSet) {
+        return null;
       }
-      if (crtCustomizer != null) {
-        return SyncClientDetector.SyncClientType.CRT;
+
+      HttpClientType effectiveType = httpClientType != null ? httpClientType : HttpClientType.AUTO;
+
+      switch (effectiveType) {
+        case APACHE:
+          if (crtCustomizer != null) {
+            throw new IllegalStateException(
+                "HttpClientType.APACHE was set, but withCrtHttpClientCustomizer() was also called. "
+                    + "Use withApacheHttpClientCustomizer() or change HttpClientType to CRT.");
+          }
+          SyncClientDetector.requireAvailableHttpClient(SyncClientDetector.SyncClientType.APACHE);
+          return SyncClientDetector.SyncClientType.APACHE;
+        case CRT:
+          if (apacheCustomizer != null) {
+            throw new IllegalStateException(
+                "HttpClientType.CRT was set, but withApacheHttpClientCustomizer() was also called. "
+                    + "Use withCrtHttpClientCustomizer() or change HttpClientType to APACHE.");
+          }
+          SyncClientDetector.requireAvailableHttpClient(SyncClientDetector.SyncClientType.CRT);
+          return SyncClientDetector.SyncClientType.CRT;
+        case NETTY:
+          throw new IllegalStateException(
+              "HttpClientType.NETTY does not support synchronous clients. "
+                  + "Use HttpClientType.APACHE, HttpClientType.CRT, or HttpClientType.AUTO.");
+        case AUTO:
+          if (apacheCustomizer != null) {
+            SyncClientDetector.requireAvailableHttpClient(SyncClientDetector.SyncClientType.APACHE);
+            return SyncClientDetector.SyncClientType.APACHE;
+          }
+          if (crtCustomizer != null) {
+            SyncClientDetector.requireAvailableHttpClient(SyncClientDetector.SyncClientType.CRT);
+            return SyncClientDetector.SyncClientType.CRT;
+          }
+          return SyncClientDetector.detect();
+        default:
+          throw new IllegalStateException("Unknown HttpClientType: " + effectiveType);
       }
-      // Auto-detect from classpath
-      return SyncClientDetector.detect();
     }
 
     private SdkHttpClient createMainSyncClient(

--- a/src/main/java/com/scylladb/alternator/HttpClientType.java
+++ b/src/main/java/com/scylladb/alternator/HttpClientType.java
@@ -1,0 +1,136 @@
+package com.scylladb.alternator;
+
+import com.scylladb.alternator.internal.AsyncClientDetector;
+import com.scylladb.alternator.internal.SyncClientDetector;
+
+/**
+ * Enumeration of HTTP client implementations that can be used with Alternator client builders.
+ *
+ * <p>By default, the builder auto-detects the HTTP client from the classpath. Use this enum to
+ * explicitly select a specific implementation. If the requested implementation is not on the
+ * classpath, the builder will throw an {@link IllegalStateException} at build time.
+ *
+ * <p>Not all implementations support both sync and async clients:
+ *
+ * <table>
+ * <caption>HTTP client compatibility matrix</caption>
+ * <tr><th>Type</th><th>Sync</th><th>Async</th><th>Custom CA certs</th><th>Connection TTL</th></tr>
+ * <tr><td>{@link #APACHE}</td><td>Yes</td><td>No</td><td>Yes</td><td>Yes</td></tr>
+ * <tr><td>{@link #NETTY}</td><td>No</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+ * <tr><td>{@link #CRT}</td><td>Yes</td><td>Yes</td><td>No</td><td>No</td></tr>
+ * <tr><td>{@link #AUTO}</td><td>Yes</td><td>Yes</td><td>Depends</td><td>Depends</td></tr>
+ * </table>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Force CRT HTTP client for sync
+ * DynamoDbClient client = AlternatorDynamoDbClient.builder()
+ *     .endpointOverride(URI.create("https://localhost:8043"))
+ *     .withHttpClientType(HttpClientType.CRT)
+ *     .build();
+ *
+ * // Force Netty for async
+ * DynamoDbAsyncClient asyncClient = AlternatorDynamoDbAsyncClient.builder()
+ *     .endpointOverride(URI.create("https://localhost:8043"))
+ *     .withHttpClientType(HttpClientType.NETTY)
+ *     .build();
+ * }</pre>
+ *
+ * @author dmitry.kropachev
+ * @since 2.1.0
+ */
+public enum HttpClientType {
+
+  /**
+   * Auto-detect the HTTP client from the classpath.
+   *
+   * <p>For sync clients, the detection order is: Apache &gt; CRT. For async clients: Netty &gt;
+   * CRT. This is the default behavior when {@code withHttpClientType} is not called.
+   */
+  AUTO(true, true),
+
+  /**
+   * Apache HTTP Client ({@code software.amazon.awssdk:apache-client}).
+   *
+   * <p>Sync only. Supports custom CA certificates and connection time-to-live. Using this type on
+   * an async client builder will throw {@link IllegalStateException}.
+   */
+  APACHE(true, false),
+
+  /**
+   * Netty NIO HTTP Client ({@code software.amazon.awssdk:netty-nio-client}).
+   *
+   * <p>Async only. Supports custom CA certificates and connection time-to-live. Using this type on
+   * a sync client builder will throw {@link IllegalStateException}.
+   */
+  NETTY(false, true),
+
+  /**
+   * AWS CRT HTTP Client ({@code software.amazon.awssdk:aws-crt-client}).
+   *
+   * <p>Supports both sync and async clients. Does not support custom CA certificates or connection
+   * time-to-live.
+   */
+  CRT(true, true);
+
+  private final boolean supportsSync;
+  private final boolean supportsAsync;
+
+  HttpClientType(boolean supportsSync, boolean supportsAsync) {
+    this.supportsSync = supportsSync;
+    this.supportsAsync = supportsAsync;
+  }
+
+  boolean supportsSync() {
+    return supportsSync;
+  }
+
+  boolean supportsAsync() {
+    return supportsAsync;
+  }
+
+  /**
+   * Maps this type to a concrete sync client type.
+   *
+   * @return the corresponding {@link SyncClientDetector.SyncClientType}
+   * @throws IllegalArgumentException if this type is {@link #AUTO} (must be resolved first) or does
+   *     not support sync clients
+   */
+  SyncClientDetector.SyncClientType toSyncClientType() {
+    switch (this) {
+      case APACHE:
+        return SyncClientDetector.SyncClientType.APACHE;
+      case CRT:
+        return SyncClientDetector.SyncClientType.CRT;
+      case AUTO:
+        throw new IllegalArgumentException(
+            "AUTO must be resolved before mapping to a concrete sync client type");
+      default:
+        throw new IllegalArgumentException(
+            "HttpClientType." + this.name() + " cannot be mapped to a sync client type");
+    }
+  }
+
+  /**
+   * Maps this type to a concrete async client type.
+   *
+   * @return the corresponding {@link AsyncClientDetector.AsyncClientType}
+   * @throws IllegalArgumentException if this type is {@link #AUTO} (must be resolved first) or does
+   *     not support async clients
+   */
+  AsyncClientDetector.AsyncClientType toAsyncClientType() {
+    switch (this) {
+      case NETTY:
+        return AsyncClientDetector.AsyncClientType.NETTY;
+      case CRT:
+        return AsyncClientDetector.AsyncClientType.CRT;
+      case AUTO:
+        throw new IllegalArgumentException(
+            "AUTO must be resolved before mapping to a concrete async client type");
+      default:
+        throw new IllegalArgumentException(
+            "HttpClientType." + this.name() + " cannot be mapped to an async client type");
+    }
+  }
+}

--- a/src/main/java/com/scylladb/alternator/internal/AsyncClientDetector.java
+++ b/src/main/java/com/scylladb/alternator/internal/AsyncClientDetector.java
@@ -14,7 +14,9 @@ public final class AsyncClientDetector {
 
   private static final Logger logger = Logger.getLogger(AsyncClientDetector.class.getName());
 
-  // Class names split to satisfy checkstyle (no fully-qualified names inline)
+  // WARNING: String concatenation is intentional — do not "simplify" into a single literal.
+  // The checkstyle RegexpMultiline rule bans fully-qualified class names outside imports;
+  // splitting the string prevents the regex from matching the constant value.
   private static final String NETTY_CLASS =
       "software.amazon.awssdk" + ".http.nio.netty.NettyNioAsyncHttpClient";
   private static final String CRT_CLASS =
@@ -37,11 +39,11 @@ public final class AsyncClientDetector {
    * @throws IllegalStateException if no supported implementation is found
    */
   public static AsyncClientType detect() {
-    if (isClassAvailable(NETTY_CLASS)) {
+    if (ClasspathUtil.isClassAvailable(NETTY_CLASS)) {
       logger.log(Level.FINE, "Detected Netty NIO async HTTP client on classpath");
       return AsyncClientType.NETTY;
     }
-    if (isClassAvailable(CRT_CLASS)) {
+    if (ClasspathUtil.isClassAvailable(CRT_CLASS)) {
       logger.log(Level.FINE, "Detected AWS CRT async HTTP client on classpath");
       return AsyncClientType.CRT;
     }
@@ -52,12 +54,30 @@ public final class AsyncClientDetector {
             + "software.amazon.awssdk:aws-crt-client");
   }
 
-  private static boolean isClassAvailable(String className) {
-    try {
-      Class.forName(className);
-      return true;
-    } catch (ClassNotFoundException e) {
-      return false;
+  /**
+   * Verifies that the specified async HTTP client implementation is available on the classpath.
+   *
+   * @param type the client type to check
+   * @throws IllegalStateException if the implementation is not on the classpath
+   */
+  public static void requireAvailableHttpClient(AsyncClientType type) {
+    switch (type) {
+      case NETTY:
+        if (!ClasspathUtil.isClassAvailable(NETTY_CLASS)) {
+          throw new IllegalStateException(
+              "HttpClientType.NETTY was requested, but Netty NIO HTTP client is not on the "
+                  + "classpath. Add dependency: software.amazon.awssdk:netty-nio-client");
+        }
+        return;
+      case CRT:
+        if (!ClasspathUtil.isClassAvailable(CRT_CLASS)) {
+          throw new IllegalStateException(
+              "HttpClientType.CRT was requested, but AWS CRT async HTTP client is not on the "
+                  + "classpath. Add dependency: software.amazon.awssdk:aws-crt-client");
+        }
+        return;
+      default:
+        throw new IllegalStateException("Unknown async client type: " + type);
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/internal/ClasspathUtil.java
+++ b/src/main/java/com/scylladb/alternator/internal/ClasspathUtil.java
@@ -1,0 +1,51 @@
+package com.scylladb.alternator.internal;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Utility for classpath presence checks.
+ *
+ * @since 2.1.0
+ */
+final class ClasspathUtil {
+
+  private static final Logger logger = Logger.getLogger(ClasspathUtil.class.getName());
+
+  private ClasspathUtil() {}
+
+  /**
+   * Checks whether a class is available on the classpath without triggering static initializers.
+   *
+   * <p>Uses the thread's context classloader so that library code running inside application
+   * servers, OSGi containers, or other environments with classloader hierarchies can see the
+   * application's dependencies.
+   *
+   * @param className fully-qualified class name
+   * @return {@code true} if the class can be loaded
+   */
+  static boolean isClassAvailable(String className) {
+    try {
+      ClassLoader cl = Thread.currentThread().getContextClassLoader();
+      if (cl == null) {
+        cl = ClasspathUtil.class.getClassLoader();
+      }
+      Class.forName(className, false, cl);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    } catch (LinkageError e) {
+      logger.log(
+          Level.FINE,
+          "Class {0} found but failed to link: {1}",
+          new Object[] {className, e.getMessage()});
+      return false;
+    } catch (SecurityException e) {
+      logger.log(
+          Level.WARNING,
+          "Class {0} blocked by security manager: {1}",
+          new Object[] {className, e.getMessage()});
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/scylladb/alternator/internal/SyncClientDetector.java
+++ b/src/main/java/com/scylladb/alternator/internal/SyncClientDetector.java
@@ -16,7 +16,9 @@ public final class SyncClientDetector {
 
   private static final Logger logger = Logger.getLogger(SyncClientDetector.class.getName());
 
-  // Class names split to satisfy checkstyle (no fully-qualified names inline)
+  // WARNING: String concatenation is intentional — do not "simplify" into a single literal.
+  // The checkstyle RegexpMultiline rule bans fully-qualified class names outside imports;
+  // splitting the string prevents the regex from matching the constant value.
   private static final String APACHE_CLASS =
       "software.amazon.awssdk" + ".http.apache.ApacheHttpClient";
   private static final String CRT_CLASS = "software.amazon.awssdk" + ".http.crt.AwsCrtHttpClient";
@@ -38,11 +40,11 @@ public final class SyncClientDetector {
    * @throws IllegalStateException if no supported implementation is found
    */
   public static SyncClientType detect() {
-    if (isClassAvailable(APACHE_CLASS)) {
+    if (ClasspathUtil.isClassAvailable(APACHE_CLASS)) {
       logger.log(Level.FINE, "Detected Apache HTTP client on classpath");
       return SyncClientType.APACHE;
     }
-    if (isClassAvailable(CRT_CLASS)) {
+    if (ClasspathUtil.isClassAvailable(CRT_CLASS)) {
       logger.log(Level.FINE, "Detected AWS CRT HTTP client on classpath");
       return SyncClientType.CRT;
     }
@@ -51,6 +53,33 @@ public final class SyncClientDetector {
             + "Add one of the following dependencies: "
             + "software.amazon.awssdk:apache-client or "
             + "software.amazon.awssdk:aws-crt-client");
+  }
+
+  /**
+   * Verifies that the specified sync HTTP client implementation is available on the classpath.
+   *
+   * @param type the client type to check
+   * @throws IllegalStateException if the implementation is not on the classpath
+   */
+  public static void requireAvailableHttpClient(SyncClientType type) {
+    switch (type) {
+      case APACHE:
+        if (!ClasspathUtil.isClassAvailable(APACHE_CLASS)) {
+          throw new IllegalStateException(
+              "HttpClientType.APACHE was requested, but Apache HTTP client is not on the "
+                  + "classpath. Add dependency: software.amazon.awssdk:apache-client");
+        }
+        return;
+      case CRT:
+        if (!ClasspathUtil.isClassAvailable(CRT_CLASS)) {
+          throw new IllegalStateException(
+              "HttpClientType.CRT was requested, but AWS CRT HTTP client is not on the "
+                  + "classpath. Add dependency: software.amazon.awssdk:aws-crt-client");
+        }
+        return;
+      default:
+        throw new IllegalStateException("Unknown sync client type: " + type);
+    }
   }
 
   /**
@@ -68,15 +97,6 @@ public final class SyncClientDetector {
         return CrtSyncClientFactory.createPollingClient(tlsConfig);
       default:
         throw new IllegalStateException("Unknown sync client type: " + type);
-    }
-  }
-
-  private static boolean isClassAvailable(String className) {
-    try {
-      Class.forName(className);
-      return true;
-    } catch (ClassNotFoundException e) {
-      return false;
     }
   }
 }

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
@@ -2,6 +2,7 @@ package com.scylladb.alternator;
 
 import static org.junit.Assert.*;
 
+import com.scylladb.alternator.internal.AsyncClientDetector;
 import java.net.URI;
 import org.junit.Test;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -95,7 +96,7 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
             .withConnectionMaxIdleTimeMs(30000)
             .withConnectionTimeToLiveMs(60000)
             .withNettyHttpClientCustomizer(b -> b.maxConcurrency(200));
-    assertNotNull("Builder with config and Netty customizer should be valid", builder);
+    builder.validateAndDetectAsyncClientType();
   }
 
   @Test
@@ -106,7 +107,230 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
             .withMaxConnections(100)
             .withConnectionMaxIdleTimeMs(30000)
             .withCrtAsyncHttpClientCustomizer(b -> b.maxConcurrency(200));
-    assertNotNull("Builder with config and CRT customizer should be valid", builder);
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testApacheHttpClientTypeOnAsyncBuilder() {
+    AlternatorDynamoDbAsyncClient.builder()
+        .endpointOverride(SEED_URI)
+        .withHttpClientType(HttpClientType.APACHE)
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeNettyConflictsWithCrtCustomizer() {
+    AlternatorDynamoDbAsyncClient.builder()
+        .endpointOverride(SEED_URI)
+        .withHttpClientType(HttpClientType.NETTY)
+        .withCrtAsyncHttpClientCustomizer(b -> {})
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeCrtConflictsWithNettyCustomizer() {
+    AlternatorDynamoDbAsyncClient.builder()
+        .endpointOverride(SEED_URI)
+        .withHttpClientType(HttpClientType.CRT)
+        .withNettyHttpClientCustomizer(b -> {})
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeConflictsWithHttpClient() {
+    SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.create();
+    try {
+      AlternatorDynamoDbAsyncClient.builder()
+          .endpointOverride(SEED_URI)
+          .httpClient(httpClient)
+          .withHttpClientType(HttpClientType.NETTY)
+          .build();
+    } finally {
+      httpClient.close();
+    }
+  }
+
+  @Test
+  public void testHttpClientTypeBuilderReturnsThis() {
+    AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.NETTY);
+    assertNotNull("Builder should return itself for chaining", builder);
+  }
+
+  @Test
+  public void testHttpClientTypeAutoWithNettyCustomizerPassesValidation() {
+    AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO)
+            .withNettyHttpClientCustomizer(b -> {});
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeNettyWithMatchingCustomizerPassesValidation() {
+    AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.NETTY)
+            .withNettyHttpClientCustomizer(b -> b.maxConcurrency(100));
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeCrtWithMatchingCustomizerPassesValidation() {
+    AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.CRT)
+            .withCrtAsyncHttpClientCustomizer(b -> b.maxConcurrency(200));
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeAutoAlonePassesValidation() {
+    AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO);
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeAutoConflictsWithHttpClient() {
+    SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.create();
+    try {
+      AlternatorDynamoDbAsyncClient.builder()
+          .endpointOverride(SEED_URI)
+          .httpClient(httpClient)
+          .withHttpClientType(HttpClientType.AUTO)
+          .build();
+    } finally {
+      httpClient.close();
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testHttpClientTypeRejectsNull() {
+    AlternatorDynamoDbAsyncClient.builder().endpointOverride(SEED_URI).withHttpClientType(null);
+  }
+
+  @Test
+  public void testHttpClientTypeNettyAlonePassesValidation() {
+    var builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.NETTY);
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeCrtAlonePassesValidation() {
+    var builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.CRT);
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeAutoWithCrtAsyncCustomizerPassesValidation() {
+    var builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO)
+            .withCrtAsyncHttpClientCustomizer(b -> {});
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test
+  public void testDetectAsyncClientTypeWithNettyCustomizerOnly() {
+    assertEquals(
+        AsyncClientDetector.AsyncClientType.NETTY,
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withNettyHttpClientCustomizer(b -> {})
+            .validateAndDetectAsyncClientType());
+  }
+
+  @Test
+  public void testDetectAsyncClientTypeWithCrtCustomizerOnly() {
+    assertEquals(
+        AsyncClientDetector.AsyncClientType.CRT,
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withCrtAsyncHttpClientCustomizer(b -> {})
+            .validateAndDetectAsyncClientType());
+  }
+
+  @Test
+  public void testDetectAsyncClientTypeWithExplicitNetty() {
+    assertEquals(
+        AsyncClientDetector.AsyncClientType.NETTY,
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.NETTY)
+            .validateAndDetectAsyncClientType());
+  }
+
+  @Test
+  public void testDetectAsyncClientTypeWithExplicitCrt() {
+    assertEquals(
+        AsyncClientDetector.AsyncClientType.CRT,
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.CRT)
+            .validateAndDetectAsyncClientType());
+  }
+
+  @Test
+  public void testHttpClientTypeAutoResolveSameAsNull() {
+    AsyncClientDetector.AsyncClientType autoResult =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO)
+            .validateAndDetectAsyncClientType();
+    AsyncClientDetector.AsyncClientType nullResult =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .validateAndDetectAsyncClientType();
+    assertEquals(
+        "AUTO and null (default) should resolve to the same client type", nullResult, autoResult);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testHttpClientTypeCrtWithAlternatorConfigPassesValidation() {
+    AlternatorConfig config = AlternatorConfig.builder().withMaxConnections(100).build();
+    var builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withAlternatorConfig(config)
+            .withHttpClientType(HttpClientType.CRT);
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testHttpClientTypeNettyWithAlternatorConfigPassesValidation() {
+    AlternatorConfig config = AlternatorConfig.builder().withMaxConnections(100).build();
+    var builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.NETTY)
+            .withAlternatorConfig(config);
+    builder.validateAndDetectAsyncClientType();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeConflictsWithHttpClientBuilder() {
+    AlternatorDynamoDbAsyncClient.builder()
+        .endpointOverride(SEED_URI)
+        .httpClientBuilder(NettyNioAsyncHttpClient.builder())
+        .withHttpClientType(HttpClientType.NETTY)
+        .build();
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
@@ -2,6 +2,7 @@ package com.scylladb.alternator;
 
 import static org.junit.Assert.*;
 
+import com.scylladb.alternator.internal.SyncClientDetector;
 import java.net.URI;
 import org.junit.Test;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -88,8 +89,6 @@ public class AlternatorDynamoDbClientCustomizerTest {
 
   @Test
   public void testApacheCustomizerWithConfig() {
-    // Verify that config + customizer work together without errors
-    // This should not throw - build will fail to connect but the builder setup is valid
     AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder =
         AlternatorDynamoDbClient.builder()
             .endpointOverride(SEED_URI)
@@ -97,7 +96,7 @@ public class AlternatorDynamoDbClientCustomizerTest {
             .withConnectionMaxIdleTimeMs(30000)
             .withConnectionTimeToLiveMs(60000)
             .withApacheHttpClientCustomizer(b -> b.maxConnections(200));
-    assertNotNull("Builder with config and customizer should be valid", builder);
+    builder.validateAndDetectSyncClientType();
   }
 
   @Test
@@ -108,7 +107,230 @@ public class AlternatorDynamoDbClientCustomizerTest {
             .withMaxConnections(100)
             .withConnectionMaxIdleTimeMs(30000)
             .withCrtHttpClientCustomizer(b -> b.maxConcurrency(200));
-    assertNotNull("Builder with config and CRT customizer should be valid", builder);
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testNettyHttpClientTypeOnSyncBuilder() {
+    AlternatorDynamoDbClient.builder()
+        .endpointOverride(SEED_URI)
+        .withHttpClientType(HttpClientType.NETTY)
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeApacheConflictsWithCrtCustomizer() {
+    AlternatorDynamoDbClient.builder()
+        .endpointOverride(SEED_URI)
+        .withHttpClientType(HttpClientType.APACHE)
+        .withCrtHttpClientCustomizer(b -> {})
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeCrtConflictsWithApacheCustomizer() {
+    AlternatorDynamoDbClient.builder()
+        .endpointOverride(SEED_URI)
+        .withHttpClientType(HttpClientType.CRT)
+        .withApacheHttpClientCustomizer(b -> {})
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeConflictsWithHttpClient() {
+    SdkHttpClient httpClient = ApacheHttpClient.create();
+    try {
+      AlternatorDynamoDbClient.builder()
+          .endpointOverride(SEED_URI)
+          .httpClient(httpClient)
+          .withHttpClientType(HttpClientType.APACHE)
+          .build();
+    } finally {
+      httpClient.close();
+    }
+  }
+
+  @Test
+  public void testHttpClientTypeBuilderReturnsThis() {
+    AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.APACHE);
+    assertNotNull("Builder should return itself for chaining", builder);
+  }
+
+  @Test
+  public void testHttpClientTypeAutoWithApacheCustomizerPassesValidation() {
+    AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO)
+            .withApacheHttpClientCustomizer(b -> {});
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeApacheWithMatchingCustomizerPassesValidation() {
+    AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.APACHE)
+            .withApacheHttpClientCustomizer(b -> b.maxConnections(100));
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeCrtWithMatchingCustomizerPassesValidation() {
+    AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.CRT)
+            .withCrtHttpClientCustomizer(b -> b.maxConcurrency(200));
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeAutoAlonePassesValidation() {
+    AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO);
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeAutoConflictsWithHttpClient() {
+    SdkHttpClient httpClient = ApacheHttpClient.create();
+    try {
+      AlternatorDynamoDbClient.builder()
+          .endpointOverride(SEED_URI)
+          .httpClient(httpClient)
+          .withHttpClientType(HttpClientType.AUTO)
+          .build();
+    } finally {
+      httpClient.close();
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testHttpClientTypeRejectsNull() {
+    AlternatorDynamoDbClient.builder().endpointOverride(SEED_URI).withHttpClientType(null);
+  }
+
+  @Test
+  public void testHttpClientTypeApacheAlonePassesValidation() {
+    var builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.APACHE);
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeCrtAlonePassesValidation() {
+    var builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.CRT);
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test
+  public void testHttpClientTypeAutoWithCrtCustomizerPassesValidation() {
+    var builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO)
+            .withCrtHttpClientCustomizer(b -> {});
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test
+  public void testDetectSyncClientTypeWithApacheCustomizerOnly() {
+    assertEquals(
+        SyncClientDetector.SyncClientType.APACHE,
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withApacheHttpClientCustomizer(b -> {})
+            .validateAndDetectSyncClientType());
+  }
+
+  @Test
+  public void testDetectSyncClientTypeWithCrtCustomizerOnly() {
+    assertEquals(
+        SyncClientDetector.SyncClientType.CRT,
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withCrtHttpClientCustomizer(b -> {})
+            .validateAndDetectSyncClientType());
+  }
+
+  @Test
+  public void testDetectSyncClientTypeWithExplicitApache() {
+    assertEquals(
+        SyncClientDetector.SyncClientType.APACHE,
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.APACHE)
+            .validateAndDetectSyncClientType());
+  }
+
+  @Test
+  public void testDetectSyncClientTypeWithExplicitCrt() {
+    assertEquals(
+        SyncClientDetector.SyncClientType.CRT,
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.CRT)
+            .validateAndDetectSyncClientType());
+  }
+
+  @Test
+  public void testHttpClientTypeAutoResolveSameAsNull() {
+    SyncClientDetector.SyncClientType autoResult =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.AUTO)
+            .validateAndDetectSyncClientType();
+    SyncClientDetector.SyncClientType nullResult =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .validateAndDetectSyncClientType();
+    assertEquals(
+        "AUTO and null (default) should resolve to the same client type", nullResult, autoResult);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testHttpClientTypeCrtWithAlternatorConfigPassesValidation() {
+    AlternatorConfig config = AlternatorConfig.builder().withMaxConnections(100).build();
+    var builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withAlternatorConfig(config)
+            .withHttpClientType(HttpClientType.CRT);
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testHttpClientTypeApacheWithAlternatorConfigPassesValidation() {
+    AlternatorConfig config = AlternatorConfig.builder().withMaxConnections(100).build();
+    var builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withHttpClientType(HttpClientType.APACHE)
+            .withAlternatorConfig(config);
+    builder.validateAndDetectSyncClientType();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHttpClientTypeConflictsWithHttpClientBuilder() {
+    AlternatorDynamoDbClient.builder()
+        .endpointOverride(SEED_URI)
+        .httpClientBuilder(ApacheHttpClient.builder())
+        .withHttpClientType(HttpClientType.APACHE)
+        .build();
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/HttpClientTypeTest.java
+++ b/src/test/java/com/scylladb/alternator/HttpClientTypeTest.java
@@ -1,0 +1,87 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import com.scylladb.alternator.internal.AsyncClientDetector;
+import com.scylladb.alternator.internal.SyncClientDetector;
+import org.junit.Test;
+
+/** Unit tests for {@link HttpClientType} enum. */
+public class HttpClientTypeTest {
+
+  @Test
+  public void testEnumValues() {
+    HttpClientType[] values = HttpClientType.values();
+    assertEquals(4, values.length);
+    assertNotNull(HttpClientType.valueOf("AUTO"));
+    assertNotNull(HttpClientType.valueOf("APACHE"));
+    assertNotNull(HttpClientType.valueOf("NETTY"));
+    assertNotNull(HttpClientType.valueOf("CRT"));
+  }
+
+  @Test
+  public void testAutoSupportsBothSyncAndAsync() {
+    assertTrue(HttpClientType.AUTO.supportsSync());
+    assertTrue(HttpClientType.AUTO.supportsAsync());
+  }
+
+  @Test
+  public void testApacheSupportsSyncOnly() {
+    assertTrue(HttpClientType.APACHE.supportsSync());
+    assertFalse(HttpClientType.APACHE.supportsAsync());
+  }
+
+  @Test
+  public void testNettySupportAsyncOnly() {
+    assertFalse(HttpClientType.NETTY.supportsSync());
+    assertTrue(HttpClientType.NETTY.supportsAsync());
+  }
+
+  @Test
+  public void testCrtSupportsBothSyncAndAsync() {
+    assertTrue(HttpClientType.CRT.supportsSync());
+    assertTrue(HttpClientType.CRT.supportsAsync());
+  }
+
+  @Test
+  public void testToSyncClientTypeApache() {
+    assertEquals(
+        SyncClientDetector.SyncClientType.APACHE, HttpClientType.APACHE.toSyncClientType());
+  }
+
+  @Test
+  public void testToSyncClientTypeCrt() {
+    assertEquals(SyncClientDetector.SyncClientType.CRT, HttpClientType.CRT.toSyncClientType());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testToSyncClientTypeAutoThrows() {
+    HttpClientType.AUTO.toSyncClientType();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testToSyncClientTypeNettyThrows() {
+    HttpClientType.NETTY.toSyncClientType();
+  }
+
+  @Test
+  public void testToAsyncClientTypeNetty() {
+    assertEquals(
+        AsyncClientDetector.AsyncClientType.NETTY, HttpClientType.NETTY.toAsyncClientType());
+  }
+
+  @Test
+  public void testToAsyncClientTypeCrt() {
+    assertEquals(AsyncClientDetector.AsyncClientType.CRT, HttpClientType.CRT.toAsyncClientType());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testToAsyncClientTypeAutoThrows() {
+    HttpClientType.AUTO.toAsyncClientType();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testToAsyncClientTypeApacheThrows() {
+    HttpClientType.APACHE.toAsyncClientType();
+  }
+}

--- a/src/test/java/com/scylladb/alternator/internal/AsyncClientDetectorTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AsyncClientDetectorTest.java
@@ -13,19 +13,27 @@ public class AsyncClientDetectorTest {
 
   @Test
   public void testDetectFindsImplementation() {
-    // Both Netty and CRT are on the test classpath, so detection should succeed
     AsyncClientDetector.AsyncClientType type = AsyncClientDetector.detect();
     assertNotNull("Should detect an async client type", type);
   }
 
   @Test
   public void testDetectPrefersNettyOverCrt() {
-    // Both are on classpath; Netty should win by priority
     AsyncClientDetector.AsyncClientType type = AsyncClientDetector.detect();
     assertEquals(
         "Netty should be preferred when both are available",
         AsyncClientDetector.AsyncClientType.NETTY,
         type);
+  }
+
+  @Test
+  public void testRequireAvailableHttpClientNetty() {
+    AsyncClientDetector.requireAvailableHttpClient(AsyncClientDetector.AsyncClientType.NETTY);
+  }
+
+  @Test
+  public void testRequireAvailableHttpClientCrt() {
+    AsyncClientDetector.requireAvailableHttpClient(AsyncClientDetector.AsyncClientType.CRT);
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/internal/ClasspathUtilTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/ClasspathUtilTest.java
@@ -1,0 +1,19 @@
+package com.scylladb.alternator.internal;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/** Unit tests for {@link ClasspathUtil}. */
+public class ClasspathUtilTest {
+
+  @Test
+  public void testKnownClassIsAvailable() {
+    assertTrue(ClasspathUtil.isClassAvailable("java.lang.String"));
+  }
+
+  @Test
+  public void testNonexistentClassIsNotAvailable() {
+    assertFalse(ClasspathUtil.isClassAvailable("com.nonexistent.NoSuchClass"));
+  }
+}

--- a/src/test/java/com/scylladb/alternator/internal/SyncClientDetectorTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/SyncClientDetectorTest.java
@@ -15,14 +15,12 @@ public class SyncClientDetectorTest {
 
   @Test
   public void testDetectFindsImplementation() {
-    // Both Apache and CRT are on the test classpath, so detection should succeed
     SyncClientDetector.SyncClientType type = SyncClientDetector.detect();
     assertNotNull("Should detect a sync client type", type);
   }
 
   @Test
   public void testDetectPrefersApacheOverCrt() {
-    // Both are on classpath; Apache should win by priority
     SyncClientDetector.SyncClientType type = SyncClientDetector.detect();
     assertEquals(
         "Apache should be preferred when both are available",
@@ -54,6 +52,16 @@ public class SyncClientDetectorTest {
       assertNotNull("Should create polling client with trust-all TLS for " + type, client);
       client.close();
     }
+  }
+
+  @Test
+  public void testRequireAvailableHttpClientApache() {
+    SyncClientDetector.requireAvailableHttpClient(SyncClientDetector.SyncClientType.APACHE);
+  }
+
+  @Test
+  public void testRequireAvailableHttpClientCrt() {
+    SyncClientDetector.requireAvailableHttpClient(SyncClientDetector.SyncClientType.CRT);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Adds `HttpClientType` enum (`AUTO`, `APACHE`, `NETTY`, `CRT`) to both sync and async client builders via `withHttpClientType()`
- Each type declares sync/async compatibility: APACHE (sync-only), NETTY (async-only), CRT (both), AUTO (classpath auto-detection)
- Fail-fast validation at build time for: incompatible type/builder combo, mismatched type+customizer, type+httpClient() conflict, missing classpath dependency
- Extracts `ClasspathUtil` and adds `requireAvailableHttpClient()` to `SyncClientDetector` and `AsyncClientDetector` for clean error messages
- Fixes flaky `KeyRouteAffinityAutodiscoveryIT` by adding `consistentRead(true)` to all GetItem calls

## Usage

```java
// Force CRT on sync builder
DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(uri)
    .withHttpClientType(HttpClientType.CRT)
    .build();

// Force Netty on async builder
DynamoDbAsyncClient asyncClient = AlternatorDynamoDbAsyncClient.builder()
    .endpointOverride(uri)
    .withHttpClientType(HttpClientType.NETTY)
    .build();

// Combine with matching customizer
DynamoDbClient client = AlternatorDynamoDbClient.builder()
    .endpointOverride(uri)
    .withHttpClientType(HttpClientType.APACHE)
    .withApacheHttpClientCustomizer(b -> b.maxConnections(200))
    .build();
```

## Test plan

- [x] `HttpClientTypeTest` — enum values, sync/async support flags, mapping to concrete types
- [x] `ClasspathUtilTest` — class availability checks
- [x] `SyncClientDetectorTest` — detection priority, `requireAvailableHttpClient()` for Apache and CRT
- [x] `AsyncClientDetectorTest` — detection priority, `requireAvailableHttpClient()` for Netty and CRT
- [x] `AlternatorDynamoDbClientCustomizerTest` — 8 new tests covering incompatible type, type+customizer conflicts, type+httpClient conflict, matching combos
- [x] `AlternatorDynamoDbAsyncClientCustomizerTest` — 8 new tests, parallel coverage for async
- [x] CI green (Lint + Java 11 + Java 17, 648 unit + 177 integration tests)