### PR TITLE
Fix GitHub Actions pinning

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: 11
@@ -42,9 +42,9 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
@@ -63,7 +63,7 @@ jobs:
         run: make test-unit
 
       - name: Upload unit test results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: unit-test-results-java-${{ matrix.java-version }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Cache Docker image
         id: docker-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .docker-cache
           key: scylla-docker-${{ hashFiles('test/docker-compose.yml') }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Cache certificates
         id: cert-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .cert-cache
           key: scylla-certs-${{ hashFiles('Makefile') }}
@@ -95,7 +95,7 @@ jobs:
         run: make test-all
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: integration-test-results-java-${{ matrix.java-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Checkout Code One Commit Before ${{ inputs.version_tag }}
         if: inputs.target-tag != 'main'
@@ -45,7 +45,7 @@ jobs:
         run: make checkout-one-commit-before
 
       - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload release logs
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: maven-stdout
           path: /tmp/release-logs/*.log


### PR DESCRIPTION
## Summary
- Refresh all in-repo GitHub Action pins to current full-SHA tag commits
- Use exact action version comments next to pinned refs
- Note: the Jira reusable-workflow SHA update was pushed to `main` first to unblock `pull_request_target`, which loads workflow definitions from the base branch

## Testing
- git diff --check
- Verified every .github/workflows `uses:` ref resolves to a 40-character SHA
- Continuous Integration passed on PR head
- Re-triggered Jira sync after base workflow pin fix

Fixes the failure from https://github.com/scylladb/alternator-client-java/actions/runs/27644470036/job/81752697967?pr=87