### PR TITLE
Fix BatchWriteItem affinity in ANY_WRITE mode

### DIFF
--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
@@ -1,16 +1,19 @@
 package com.scylladb.alternator.keyrouting;
 
+import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
 /**
  * Determines if a DynamoDB request qualifies for key route affinity.
@@ -43,10 +46,9 @@ public final class KeyAffinityRequestClassifier {
     if (request instanceof DeleteItemRequest) {
       return shouldApplyDeleteItem(mode, (DeleteItemRequest) request);
     }
-    // Note: BatchWriteItemRequest is intentionally not supported for key route affinity.
-    // It can contain items for multiple tables with different partition keys, making it
-    // impossible to route deterministically to a single node. These requests will use
-    // the default round-robin routing.
+    if (request instanceof BatchWriteItemRequest) {
+      return shouldApplyBatchWriteItem(mode, (BatchWriteItemRequest) request);
+    }
 
     // Read operations and unsupported operations don't qualify
     return false;
@@ -126,6 +128,11 @@ public final class KeyAffinityRequestClassifier {
     return false;
   }
 
+  private static boolean shouldApplyBatchWriteItem(
+      KeyRouteAffinity mode, BatchWriteItemRequest request) {
+    return mode == KeyRouteAffinity.ANY_WRITE && findBatchWriteRoutingTarget(request) != null;
+  }
+
   /**
    * Extracts the table name from a DynamoDB request.
    *
@@ -161,10 +168,10 @@ public final class KeyAffinityRequestClassifier {
     if (request instanceof QueryRequest) {
       return ((QueryRequest) request).tableName();
     }
-    // BatchWriteItem can contain items for multiple tables.
-    // Key route affinity for BatchWriteItem is not implemented - would require either:
-    // 1. Single-table batches only (limiting functionality)
-    // 2. Splitting batches by partition key (complex, changes semantics)
+    if (request instanceof BatchWriteItemRequest) {
+      BatchWriteRoutingTarget target = findBatchWriteRoutingTarget((BatchWriteItemRequest) request);
+      return target == null ? null : target.tableName;
+    }
     return null;
   }
 
@@ -186,11 +193,47 @@ public final class KeyAffinityRequestClassifier {
       key = ((DeleteItemRequest) request).key();
     } else if (request instanceof GetItemRequest) {
       key = ((GetItemRequest) request).key();
+    } else if (request instanceof BatchWriteItemRequest) {
+      BatchWriteRoutingTarget target = findBatchWriteRoutingTarget((BatchWriteItemRequest) request);
+      key = target == null ? null : target.key;
     }
 
     if (key != null && pkAttributeName != null) {
       return key.get(pkAttributeName);
     }
     return null;
+  }
+
+  private static BatchWriteRoutingTarget findBatchWriteRoutingTarget(
+      BatchWriteItemRequest request) {
+    if (request.requestItems() == null || request.requestItems().isEmpty()) {
+      return null;
+    }
+
+    for (Map.Entry<String, List<WriteRequest>> entry : request.requestItems().entrySet()) {
+      List<WriteRequest> writes = entry.getValue();
+      if (writes == null) {
+        continue;
+      }
+      for (WriteRequest write : writes) {
+        if (write.putRequest() != null) {
+          return new BatchWriteRoutingTarget(entry.getKey(), write.putRequest().item());
+        }
+        if (write.deleteRequest() != null) {
+          return new BatchWriteRoutingTarget(entry.getKey(), write.deleteRequest().key());
+        }
+      }
+    }
+    return null;
+  }
+
+  private static final class BatchWriteRoutingTarget {
+    private final String tableName;
+    private final Map<String, AttributeValue> key;
+
+    private BatchWriteRoutingTarget(String tableName, Map<String, AttributeValue> key) {
+      this.tableName = tableName;
+      this.key = key;
+    }
   }
 }

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinity.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinity.java
@@ -28,8 +28,8 @@ public enum KeyRouteAffinity {
    *   <li>DeleteItem with ConditionExpression, Expected, or non-NONE ReturnValues
    * </ul>
    *
-   * <p>Note: BatchWriteItem is intentionally excluded because it does not support conditional
-   * expressions and would require single-table batch handling for proper affinity routing.
+   * <p>Note: BatchWriteItem is intentionally excluded because it is write-only and does not use LWT
+   * in {@code only_rmw_uses_lwt} mode.
    */
   RMW,
 

--- a/src/test/java/com/scylladb/alternator/AffinityQueryPlanInterceptorTest.java
+++ b/src/test/java/com/scylladb/alternator/AffinityQueryPlanInterceptorTest.java
@@ -1509,7 +1509,7 @@ public class AffinityQueryPlanInterceptorTest {
   // --- BatchWriteItem ---
 
   @Test
-  public void testBatchWriteItem_AnyWrite_RoundRobin() {
+  public void testBatchWriteItem_AnyWrite_Affinity() {
     DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
     try {
       Map<String, List<WriteRequest>> requestItems = new HashMap<>();
@@ -1518,7 +1518,7 @@ public class AffinityQueryPlanInterceptorTest {
           WriteRequest.builder().putRequest(PutRequest.builder().item(makeItem()).build()).build());
       requestItems.put(TABLE_NAME, writes);
 
-      assertRoundRobinRouting(
+      assertAffinityRouting(
           () ->
               client.batchWriteItem(
                   BatchWriteItemRequest.builder().requestItems(requestItems).build()));
@@ -1568,7 +1568,7 @@ public class AffinityQueryPlanInterceptorTest {
   // --- BatchWriteItem with DeleteRequest ---
 
   @Test
-  public void testBatchWriteItemDelete_AnyWrite_RoundRobin() {
+  public void testBatchWriteItemDelete_AnyWrite_Affinity() {
     DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
     try {
       Map<String, List<WriteRequest>> requestItems = new HashMap<>();
@@ -1579,7 +1579,7 @@ public class AffinityQueryPlanInterceptorTest {
               .build());
       requestItems.put(TABLE_NAME, writes);
 
-      assertRoundRobinRouting(
+      assertAffinityRouting(
           () ->
               client.batchWriteItem(
                   BatchWriteItemRequest.builder().requestItems(requestItems).build()));

--- a/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
@@ -320,9 +320,17 @@ public class KeyAffinityRequestClassifierTest {
 
   @Test
   public void testRmwModeBatchWriteItem() {
-    // BatchWriteItem is not supported for key route affinity because it can contain
-    // items for multiple tables with different partition keys
-    BatchWriteItemRequest request = BatchWriteItemRequest.builder().build();
+    BatchWriteItemRequest request =
+        BatchWriteItemRequest.builder()
+            .requestItems(
+                Collections.singletonMap(
+                    "test",
+                    Collections.singletonList(
+                        WriteRequest.builder()
+                            .putRequest(
+                                PutRequest.builder().item(createItem("pk", "value")).build())
+                            .build())))
+            .build();
     assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.RMW, request));
   }
 
@@ -354,8 +362,22 @@ public class KeyAffinityRequestClassifierTest {
 
   @Test
   public void testAnyWriteModeBatchWriteItem() {
-    // BatchWriteItem is not supported for key route affinity because it can contain
-    // items for multiple tables with different partition keys
+    BatchWriteItemRequest request =
+        BatchWriteItemRequest.builder()
+            .requestItems(
+                Collections.singletonMap(
+                    "test",
+                    Collections.singletonList(
+                        WriteRequest.builder()
+                            .putRequest(
+                                PutRequest.builder().item(createItem("pk", "value")).build())
+                            .build())))
+            .build();
+    assertTrue(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
+  }
+
+  @Test
+  public void testAnyWriteModeEmptyBatchWriteItem() {
     BatchWriteItemRequest request = BatchWriteItemRequest.builder().build();
     assertFalse(KeyAffinityRequestClassifier.shouldApply(KeyRouteAffinity.ANY_WRITE, request));
   }
@@ -420,6 +442,22 @@ public class KeyAffinityRequestClassifierTest {
 
   @Test
   public void testExtractTableNameFromBatchWriteItem() {
+    BatchWriteItemRequest request =
+        BatchWriteItemRequest.builder()
+            .requestItems(
+                Collections.singletonMap(
+                    "orders",
+                    Collections.singletonList(
+                        WriteRequest.builder()
+                            .putRequest(
+                                PutRequest.builder().item(createItem("order_id", "o456")).build())
+                            .build())))
+            .build();
+    assertEquals("orders", KeyAffinityRequestClassifier.extractTableName(request));
+  }
+
+  @Test
+  public void testExtractTableNameFromEmptyBatchWriteItem() {
     BatchWriteItemRequest request = BatchWriteItemRequest.builder().build();
     assertNull(KeyAffinityRequestClassifier.extractTableName(request));
   }
@@ -464,6 +502,46 @@ public class KeyAffinityRequestClassifierTest {
     AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "product_id");
     assertNotNull(pk);
     assertEquals("p012", pk.s());
+  }
+
+  @Test
+  public void testExtractPartitionKeyFromBatchWriteItemPutRequest() {
+    BatchWriteItemRequest request =
+        BatchWriteItemRequest.builder()
+            .requestItems(
+                Collections.singletonMap(
+                    "orders",
+                    Collections.singletonList(
+                        WriteRequest.builder()
+                            .putRequest(
+                                PutRequest.builder().item(createItem("order_id", "o456")).build())
+                            .build())))
+            .build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "order_id");
+    assertNotNull(pk);
+    assertEquals("o456", pk.s());
+  }
+
+  @Test
+  public void testExtractPartitionKeyFromBatchWriteItemDeleteRequest() {
+    BatchWriteItemRequest request =
+        BatchWriteItemRequest.builder()
+            .requestItems(
+                Collections.singletonMap(
+                    "sessions",
+                    Collections.singletonList(
+                        WriteRequest.builder()
+                            .deleteRequest(
+                                DeleteRequest.builder()
+                                    .key(createKey("session_id", "s789"))
+                                    .build())
+                            .build())))
+            .build();
+
+    AttributeValue pk = KeyAffinityRequestClassifier.extractPartitionKey(request, "session_id");
+    assertNotNull(pk);
+    assertEquals("s789", pk.s());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Route `BatchWriteItem` through key affinity in `ANY_WRITE` mode using the first concrete put/delete request in the batch as the routing target.
- Keep `BatchWriteItem` excluded from `RMW` mode because it is a write-only API and does not use LWT in `only_rmw_uses_lwt` mode.
- Add classifier and interceptor coverage for batch put/delete affinity, plus empty-batch fallback behavior.

Fixes #92

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH make lint-fix`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH mvn -q -Dtest='KeyAffinityRequestClassifierTest,AffinityQueryPlanInterceptorTest' test`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH make lint`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH make test-unit`