### PR TITLE
Align BatchWrite affinity selection across languages

### DIFF
--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
@@ -1,7 +1,11 @@
 package com.scylladb.alternator.keyrouting;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -130,7 +134,8 @@ public final class KeyAffinityRequestClassifier {
 
   private static boolean shouldApplyBatchWriteItem(
       KeyRouteAffinity mode, BatchWriteItemRequest request) {
-    return mode == KeyRouteAffinity.ANY_WRITE && findBatchWriteRoutingTarget(request) != null;
+    return mode == KeyRouteAffinity.ANY_WRITE
+        && !extractBatchWriteRoutingTargets(request).isEmpty();
   }
 
   /**
@@ -194,8 +199,13 @@ public final class KeyAffinityRequestClassifier {
     } else if (request instanceof GetItemRequest) {
       key = ((GetItemRequest) request).key();
     } else if (request instanceof BatchWriteItemRequest) {
-      BatchWriteRoutingTarget target = findBatchWriteRoutingTarget((BatchWriteItemRequest) request);
-      key = target == null ? null : target.key;
+      for (BatchWriteRoutingTarget target :
+          extractBatchWriteRoutingTargets((BatchWriteItemRequest) request)) {
+        AttributeValue pk = target.partitionKeyValue(pkAttributeName);
+        if (pk != null) {
+          return pk;
+        }
+      }
     }
 
     if (key != null && pkAttributeName != null) {
@@ -206,10 +216,29 @@ public final class KeyAffinityRequestClassifier {
 
   private static BatchWriteRoutingTarget findBatchWriteRoutingTarget(
       BatchWriteItemRequest request) {
+    List<BatchWriteRoutingTarget> candidates = extractBatchWriteRoutingTargets(request);
+    return candidates.isEmpty() ? null : candidates.get(0);
+  }
+
+  /**
+   * Extracts BatchWriteItem routing targets in a deterministic cross-language order.
+   *
+   * <p>The ordering key is {@code (tableName, canonicalAttributes, operation)}, where
+   * canonicalAttributes is a no-whitespace JSON representation with sorted map keys. This matches
+   * the Rust and Go implementations so the same positive BatchWriteItem workload selects the same
+   * partition key before hashing.
+   *
+   * @param request the BatchWriteItem request
+   * @return deterministic routing candidates; empty when the request has no
+   *     PutRequest/DeleteRequest
+   */
+  public static List<BatchWriteRoutingTarget> extractBatchWriteRoutingTargets(
+      BatchWriteItemRequest request) {
     if (request.requestItems() == null || request.requestItems().isEmpty()) {
-      return null;
+      return Collections.emptyList();
     }
 
+    List<BatchWriteRoutingTarget> candidates = new ArrayList<>();
     for (Map.Entry<String, List<WriteRequest>> entry : request.requestItems().entrySet()) {
       List<WriteRequest> writes = entry.getValue();
       if (writes == null) {
@@ -217,23 +246,270 @@ public final class KeyAffinityRequestClassifier {
       }
       for (WriteRequest write : writes) {
         if (write.putRequest() != null) {
-          return new BatchWriteRoutingTarget(entry.getKey(), write.putRequest().item());
+          candidates.add(
+              new BatchWriteRoutingTarget(
+                  entry.getKey(),
+                  write.putRequest().item(),
+                  "PutRequest",
+                  canonicalAttributeValues(write.putRequest().item())));
         }
         if (write.deleteRequest() != null) {
-          return new BatchWriteRoutingTarget(entry.getKey(), write.deleteRequest().key());
+          candidates.add(
+              new BatchWriteRoutingTarget(
+                  entry.getKey(),
+                  write.deleteRequest().key(),
+                  "DeleteRequest",
+                  canonicalAttributeValues(write.deleteRequest().key())));
         }
       }
     }
-    return null;
+
+    if (candidates.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    candidates.sort(
+        Comparator.comparing((BatchWriteRoutingTarget target) -> target.tableName)
+            .thenComparing(target -> target.canonicalAttributes)
+            .thenComparing(target -> target.operation));
+    return Collections.unmodifiableList(candidates);
   }
 
-  private static final class BatchWriteRoutingTarget {
-    private final String tableName;
-    private final Map<String, AttributeValue> key;
+  private static String canonicalAttributeValues(Map<String, AttributeValue> values) {
+    if (values == null || values.isEmpty()) {
+      return "{}";
+    }
 
-    private BatchWriteRoutingTarget(String tableName, Map<String, AttributeValue> key) {
+    List<String> keys = new ArrayList<>(values.keySet());
+    Collections.sort(keys);
+
+    StringBuilder builder = new StringBuilder();
+    builder.append('{');
+    for (int i = 0; i < keys.size(); i++) {
+      if (i > 0) {
+        builder.append(',');
+      }
+      String key = keys.get(i);
+      builder.append(quote(key));
+      builder.append(':');
+      appendCanonicalAttributeValue(builder, values.get(key));
+    }
+    builder.append('}');
+    return builder.toString();
+  }
+
+  private static void appendCanonicalAttributeValue(StringBuilder builder, AttributeValue value) {
+    if (value == null) {
+      builder.append("{\"UNKNOWN\":true}");
+      return;
+    }
+    if (value.s() != null) {
+      appendTaggedJsonString(builder, "S", value.s());
+      return;
+    }
+    if (value.n() != null) {
+      appendTaggedJsonString(builder, "N", value.n());
+      return;
+    }
+    if (value.b() != null) {
+      builder.append("{\"B\":{\"__bytes__\":\"");
+      appendHex(builder, value.b().asByteArray());
+      builder.append("\"}}");
+      return;
+    }
+    if (value.bool() != null) {
+      builder.append("{\"BOOL\":").append(value.bool() ? "true" : "false").append('}');
+      return;
+    }
+    if (value.nul() != null) {
+      builder.append("{\"NULL\":").append(value.nul() ? "true" : "false").append('}');
+      return;
+    }
+    if (value.hasSs()) {
+      appendTaggedJsonStringList(builder, "SS", value.ss());
+      return;
+    }
+    if (value.hasNs()) {
+      appendTaggedJsonStringList(builder, "NS", value.ns());
+      return;
+    }
+    if (value.hasBs()) {
+      builder.append("{\"BS\":[");
+      int i = 0;
+      for (SdkBytes bytes : value.bs()) {
+        if (i > 0) {
+          builder.append(',');
+        }
+        builder.append("{\"__bytes__\":\"");
+        appendHex(builder, bytes.asByteArray());
+        builder.append("\"}");
+        i++;
+      }
+      builder.append("]}");
+      return;
+    }
+    if (value.hasL()) {
+      builder.append("{\"L\":[");
+      int i = 0;
+      for (AttributeValue item : value.l()) {
+        if (i > 0) {
+          builder.append(',');
+        }
+        appendCanonicalAttributeValue(builder, item);
+        i++;
+      }
+      builder.append("]}");
+      return;
+    }
+    if (value.hasM()) {
+      builder.append("{\"M\":");
+      builder.append(canonicalAttributeValues(value.m()));
+      builder.append('}');
+      return;
+    }
+    builder.append("{\"UNKNOWN\":true}");
+  }
+
+  private static void appendTaggedJsonString(StringBuilder builder, String tag, String value) {
+    builder.append("{\"").append(tag).append("\":");
+    builder.append(quote(value));
+    builder.append('}');
+  }
+
+  private static void appendTaggedJsonStringList(
+      StringBuilder builder, String tag, List<String> values) {
+    builder.append("{\"").append(tag).append("\":[");
+    for (int i = 0; i < values.size(); i++) {
+      if (i > 0) {
+        builder.append(',');
+      }
+      builder.append(quote(values.get(i)));
+    }
+    builder.append("]}");
+  }
+
+  private static void appendHex(StringBuilder builder, byte[] bytes) {
+    final char[] hex = "0123456789abcdef".toCharArray();
+    for (byte value : bytes) {
+      builder.append(hex[(value >> 4) & 0x0f]);
+      builder.append(hex[value & 0x0f]);
+    }
+  }
+
+  private static String quote(String value) {
+    StringBuilder builder = new StringBuilder();
+    builder.append('"');
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\':
+          builder.append("\\\\");
+          break;
+        case '"':
+          builder.append("\\\"");
+          break;
+        case '\b':
+          builder.append("\\b");
+          break;
+        case '\f':
+          builder.append("\\f");
+          break;
+        case '\n':
+          builder.append("\\n");
+          break;
+        case '\r':
+          builder.append("\\r");
+          break;
+        case '\t':
+          builder.append("\\t");
+          break;
+        default:
+          if (c <= 0x1f) {
+            builder.append("\\u");
+            appendHex4(builder, c);
+          } else {
+            builder.append(c);
+          }
+          break;
+      }
+    }
+    builder.append('"');
+    return builder.toString();
+  }
+
+  private static void appendHex4(StringBuilder builder, char value) {
+    final char[] hex = "0123456789abcdef".toCharArray();
+    builder.append(hex[(value >> 12) & 0x0f]);
+    builder.append(hex[(value >> 8) & 0x0f]);
+    builder.append(hex[(value >> 4) & 0x0f]);
+    builder.append(hex[value & 0x0f]);
+  }
+
+  /** Deterministic BatchWriteItem routing candidate. */
+  public static final class BatchWriteRoutingTarget {
+    private final String tableName;
+    private final Map<String, AttributeValue> values;
+    private final String operation;
+    private final String canonicalAttributes;
+
+    private BatchWriteRoutingTarget(
+        String tableName,
+        Map<String, AttributeValue> values,
+        String operation,
+        String canonicalAttributes) {
       this.tableName = tableName;
-      this.key = key;
+      this.values = values;
+      this.operation = operation;
+      this.canonicalAttributes = canonicalAttributes;
+    }
+
+    /**
+     * Returns the table name that owns this BatchWriteItem write.
+     *
+     * @return the table name
+     */
+    public String tableName() {
+      return tableName;
+    }
+
+    /**
+     * Returns the PutRequest item or DeleteRequest key attributes for this write.
+     *
+     * @return the write attributes
+     */
+    public Map<String, AttributeValue> values() {
+      return values;
+    }
+
+    /**
+     * Returns the write operation name, either {@code PutRequest} or {@code DeleteRequest}.
+     *
+     * @return the operation name
+     */
+    public String operation() {
+      return operation;
+    }
+
+    /**
+     * Returns the canonical JSON attributes used for deterministic candidate ordering.
+     *
+     * @return the canonical JSON attributes
+     */
+    public String canonicalAttributes() {
+      return canonicalAttributes;
+    }
+
+    /**
+     * Returns the configured partition-key attribute value for this write, or null if absent.
+     *
+     * @param pkAttributeName the partition-key attribute name
+     * @return the partition-key attribute value, or null
+     */
+    public AttributeValue partitionKeyValue(String pkAttributeName) {
+      if (values == null || pkAttributeName == null) {
+        return null;
+      }
+      return values.get(pkAttributeName);
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/queryplan/AffinityQueryPlanInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/queryplan/AffinityQueryPlanInterceptor.java
@@ -4,6 +4,7 @@ import com.scylladb.alternator.internal.AlternatorLiveNodes;
 import com.scylladb.alternator.internal.LazyQueryPlan;
 import com.scylladb.alternator.keyrouting.AttributeValueHasher;
 import com.scylladb.alternator.keyrouting.KeyAffinityRequestClassifier;
+import com.scylladb.alternator.keyrouting.KeyAffinityRequestClassifier.BatchWriteRoutingTarget;
 import com.scylladb.alternator.keyrouting.KeyRouteAffinityConfig;
 import com.scylladb.alternator.keyrouting.PartitionKeyResolver;
 import software.amazon.awssdk.core.SdkRequest;
@@ -11,6 +12,7 @@ import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 
 /**
  * Execution interceptor that implements key-based route affinity.
@@ -92,6 +94,10 @@ public class AffinityQueryPlanInterceptor extends BasicQueryPlanInterceptor {
       return null;
     }
 
+    if (request instanceof BatchWriteItemRequest) {
+      return getBatchWriteQueryPlan((BatchWriteItemRequest) request);
+    }
+
     // Extract table name
     String tableName = KeyAffinityRequestClassifier.extractTableName(request);
     if (tableName == null) {
@@ -120,6 +126,33 @@ public class AffinityQueryPlanInterceptor extends BasicQueryPlanInterceptor {
     // Hash the partition key and create a deterministic query plan
     long hash = AttributeValueHasher.hash(pkValue);
     return new LazyQueryPlan(liveNodes, hash);
+  }
+
+  private LazyQueryPlan getBatchWriteQueryPlan(BatchWriteItemRequest request) {
+    for (BatchWriteRoutingTarget target :
+        KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request)) {
+      String tableName = target.tableName();
+      String pkName = pkResolver.getPartitionKeyName(tableName);
+      if (pkName == null) {
+        if (clientForDiscovery != null) {
+          pkResolver.triggerDiscovery(tableName, clientForDiscovery);
+        }
+        return null;
+      }
+
+      AttributeValue pkValue = target.partitionKeyValue(pkName);
+      if (pkValue == null) {
+        continue;
+      }
+
+      try {
+        long hash = AttributeValueHasher.hash(pkValue);
+        return new LazyQueryPlan(liveNodes, hash);
+      } catch (IllegalArgumentException e) {
+        // Unsupported partition-key shapes cannot be routed by key affinity.
+      }
+    }
+    return null;
   }
 
   @Override

--- a/src/test/java/com/scylladb/alternator/AffinityQueryPlanInterceptorTest.java
+++ b/src/test/java/com/scylladb/alternator/AffinityQueryPlanInterceptorTest.java
@@ -3,6 +3,8 @@ package com.scylladb.alternator;
 import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.internal.LazyQueryPlan;
+import com.scylladb.alternator.keyrouting.AttributeValueHasher;
 import com.scylladb.alternator.keyrouting.KeyRouteAffinity;
 import com.scylladb.alternator.keyrouting.KeyRouteAffinityConfig;
 import com.scylladb.alternator.queryplan.AffinityQueryPlanInterceptor;
@@ -140,10 +142,39 @@ public class AffinityQueryPlanInterceptorTest {
   }
 
   private Map<String, AttributeValue> makeItem() {
+    return makeItem(PK_VALUE);
+  }
+
+  private Map<String, AttributeValue> makeItem(String pkValue) {
     Map<String, AttributeValue> item = new HashMap<>();
-    item.put(PK_NAME, AttributeValue.builder().s(PK_VALUE).build());
+    item.put(PK_NAME, AttributeValue.builder().s(pkValue).build());
     item.put("data", AttributeValue.builder().s("value").build());
     return item;
+  }
+
+  private URI firstAffinityRouteForPk(String pkValue) {
+    long hash = AttributeValueHasher.hash(AttributeValue.builder().s(pkValue).build());
+    LazyQueryPlan plan = new LazyQueryPlan(new MockAlternatorLiveNodes(testNodeUris), hash);
+    return plan.next();
+  }
+
+  private String findPkValueWithDifferentRoute(String prefix, String otherPkValue) {
+    URI otherRoute = firstAffinityRouteForPk(otherPkValue);
+    for (int i = 0; i < 100; i++) {
+      String candidate = prefix + i;
+      if (!firstAffinityRouteForPk(candidate).equals(otherRoute)) {
+        return candidate;
+      }
+    }
+    fail("Could not find test partition key with a different affinity route");
+    return null;
+  }
+
+  private void assertSameRoute(String message, URI expected, URI actual) {
+    assertNotNull(message + ": actual route should not be null", actual);
+    assertEquals(message + ": scheme", expected.getScheme(), actual.getScheme());
+    assertEquals(message + ": host", expected.getHost(), actual.getHost());
+    assertEquals(message + ": port", expected.getPort(), actual.getPort());
   }
 
   // ========== PutItem variants ==========
@@ -1583,6 +1614,59 @@ public class AffinityQueryPlanInterceptorTest {
           () ->
               client.batchWriteItem(
                   BatchWriteItemRequest.builder().requestItems(requestItems).build()));
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testBatchWriteItemReorderedWritesRouteDeterministically() {
+    String selectedPk = "a-route";
+    String otherPk = findPkValueWithDifferentRoute("z-route-", selectedPk);
+    DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
+    try {
+      Map<String, List<WriteRequest>> firstRequestItems = new HashMap<>();
+      firstRequestItems.put(
+          TABLE_NAME,
+          Arrays.asList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(otherPk)).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(selectedPk)).build())
+                  .build()));
+
+      Map<String, List<WriteRequest>> secondRequestItems = new HashMap<>();
+      secondRequestItems.put(
+          TABLE_NAME,
+          Arrays.asList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(selectedPk)).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(otherPk)).build())
+                  .build()));
+
+      URI expectedRoute = firstAffinityRouteForPk(selectedPk);
+
+      mockHttpClient.clearCapturedRequests();
+      client.batchWriteItem(
+          BatchWriteItemRequest.builder().requestItems(firstRequestItems).build());
+      URI firstRoute = mockHttpClient.getLastRequestUri();
+
+      mockHttpClient.clearCapturedRequests();
+      client.batchWriteItem(
+          BatchWriteItemRequest.builder().requestItems(secondRequestItems).build());
+      URI secondRoute = mockHttpClient.getLastRequestUri();
+
+      assertSameRoute(
+          "First request should route by deterministic BatchWrite target",
+          expectedRoute,
+          firstRoute);
+      assertSameRoute(
+          "Second request should route by deterministic BatchWrite target",
+          expectedRoute,
+          secondRoute);
     } finally {
       client.close();
     }

--- a/src/test/java/com/scylladb/alternator/keyrouting/BatchWriteItemKeyRouteAffinityCrossLanguageTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/BatchWriteItemKeyRouteAffinityCrossLanguageTest.java
@@ -1,0 +1,276 @@
+package com.scylladb.alternator.keyrouting;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.internal.LazyQueryPlan;
+import com.scylladb.alternator.keyrouting.KeyAffinityRequestClassifier.BatchWriteRoutingTarget;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
+
+/** Cross-language BatchWriteItem route-affinity vectors shared with Rust and Go. */
+public class BatchWriteItemKeyRouteAffinityCrossLanguageTest {
+
+  @Test
+  public void testBatchWriteItemKeyRouteAffinityCrossLanguageVectors() throws URISyntaxException {
+    for (BatchWriteVector vector : vectors()) {
+      List<BatchWriteRoutingTarget> targets =
+          KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(vector.request);
+      assertFalse(vector.name, targets.isEmpty());
+
+      BatchWriteRoutingTarget target = targets.get(0);
+      assertEquals(vector.name, vector.tableName, target.tableName());
+      assertEquals(vector.name, vector.operation, target.operation());
+      assertEquals(vector.name, vector.canonical, target.canonicalAttributes());
+
+      String pkName = vector.pkInfo.get(target.tableName());
+      AttributeValue pkValue = target.partitionKeyValue(pkName);
+      assertEquals(vector.name, vector.pkLabel, attributeLabel(pkValue));
+
+      long hash = batchWriteHash(vector.request, vector.pkInfo);
+      assertEquals(vector.name, vector.hashSigned, hash);
+      assertEquals(vector.name, vector.hashUnsigned, Long.toUnsignedString(hash));
+      assertEquals(vector.name, vector.firstSixNodes, nodeSequence(hash, 6));
+    }
+  }
+
+  private static List<BatchWriteVector> vectors() {
+    return Arrays.asList(
+        new BatchWriteVector(
+            "same_table_write_order",
+            batchWrite(
+                table("orders", put(attrs("pk", s("order456"))), put(attrs("pk", s("order123"))))),
+            pkInfo("orders", "pk"),
+            "orders",
+            "PutRequest",
+            "S:order123",
+            "{\"pk\":{\"S\":\"order123\"}}",
+            -2126891002421145093L,
+            "16319853071288406523",
+            Arrays.asList("node9", "node2", "node10", "node8", "node7", "node5")),
+        new BatchWriteVector(
+            "multi_table_order",
+            batchWrite(
+                table("sessions", delete(attrs("pk", s("session123")))),
+                table(
+                    "orders",
+                    put(attrs("data", s("value"), "pk", s("order456"))),
+                    put(attrs("pk", s("order123"), "data", s("value"))))),
+            pkInfo("orders", "pk", "sessions", "pk"),
+            "orders",
+            "PutRequest",
+            "S:order123",
+            "{\"data\":{\"S\":\"value\"},\"pk\":{\"S\":\"order123\"}}",
+            -2126891002421145093L,
+            "16319853071288406523",
+            Arrays.asList("node9", "node2", "node10", "node8", "node7", "node5")),
+        new BatchWriteVector(
+            "delete_put_same_attributes",
+            batchWrite(
+                table("orders", put(attrs("pk", s("same"))), delete(attrs("pk", s("same"))))),
+            pkInfo("orders", "pk"),
+            "orders",
+            "DeleteRequest",
+            "S:same",
+            "{\"pk\":{\"S\":\"same\"}}",
+            -4879317772220196571L,
+            "13567426301489355045",
+            Arrays.asList("node1", "node3", "node10", "node7", "node4", "node5")),
+        new BatchWriteVector(
+            "number_partition_key",
+            batchWrite(table("accounts", put(attrs("pk", n("7"))), put(attrs("pk", n("42"))))),
+            pkInfo("accounts", "pk"),
+            "accounts",
+            "PutRequest",
+            "N:42",
+            "{\"pk\":{\"N\":\"42\"}}",
+            -5061732451827723051L,
+            "13385011621881828565",
+            Arrays.asList("node3", "node7", "node1", "node10", "node2", "node5")),
+        new BatchWriteVector(
+            "binary_partition_key",
+            batchWrite(
+                table(
+                    "blobs",
+                    put(attrs("pk", b(0x01, 0x02, 0x03))),
+                    delete(attrs("pk", b(0x00, 0xff))))),
+            pkInfo("blobs", "pk"),
+            "blobs",
+            "DeleteRequest",
+            "B:00ff",
+            "{\"pk\":{\"B\":{\"__bytes__\":\"00ff\"}}}",
+            -4376945693382523102L,
+            "14069798380327028514",
+            Arrays.asList("node7", "node2", "node5", "node1", "node6", "node9")));
+  }
+
+  @SafeVarargs
+  private static BatchWriteItemRequest batchWrite(Map.Entry<String, List<WriteRequest>>... tables) {
+    Map<String, List<WriteRequest>> requestItems = new LinkedHashMap<>();
+    for (Map.Entry<String, List<WriteRequest>> table : tables) {
+      requestItems.put(table.getKey(), table.getValue());
+    }
+    return BatchWriteItemRequest.builder().requestItems(requestItems).build();
+  }
+
+  private static Map.Entry<String, List<WriteRequest>> table(
+      String tableName, WriteRequest... writes) {
+    return new AbstractMap.SimpleImmutableEntry<>(tableName, Arrays.asList(writes));
+  }
+
+  private static WriteRequest put(Map<String, AttributeValue> item) {
+    return WriteRequest.builder().putRequest(PutRequest.builder().item(item).build()).build();
+  }
+
+  private static WriteRequest delete(Map<String, AttributeValue> key) {
+    return WriteRequest.builder().deleteRequest(DeleteRequest.builder().key(key).build()).build();
+  }
+
+  private static Map<String, AttributeValue> attrs(Object... keyValues) {
+    Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      attrs.put((String) keyValues[i], (AttributeValue) keyValues[i + 1]);
+    }
+    return attrs;
+  }
+
+  private static Map<String, String> pkInfo(String tableName, String pkName, String... rest) {
+    Map<String, String> pkInfo = new LinkedHashMap<>();
+    pkInfo.put(tableName, pkName);
+    for (int i = 0; i < rest.length; i += 2) {
+      pkInfo.put(rest[i], rest[i + 1]);
+    }
+    return pkInfo;
+  }
+
+  private static AttributeValue s(String value) {
+    return AttributeValue.builder().s(value).build();
+  }
+
+  private static AttributeValue n(String value) {
+    return AttributeValue.builder().n(value).build();
+  }
+
+  private static AttributeValue b(int... values) {
+    byte[] bytes = new byte[values.length];
+    for (int i = 0; i < values.length; i++) {
+      bytes[i] = (byte) values[i];
+    }
+    return AttributeValue.builder().b(SdkBytes.fromByteArray(bytes)).build();
+  }
+
+  private static long batchWriteHash(BatchWriteItemRequest request, Map<String, String> pkInfo) {
+    for (BatchWriteRoutingTarget target :
+        KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request)) {
+      String pkName = pkInfo.get(target.tableName());
+      if (pkName == null) {
+        throw new AssertionError("missing partition key info for table " + target.tableName());
+      }
+
+      AttributeValue pkValue = target.partitionKeyValue(pkName);
+      if (pkValue == null) {
+        continue;
+      }
+
+      try {
+        return AttributeValueHasher.hash(pkValue);
+      } catch (IllegalArgumentException e) {
+        // Try the next deterministic candidate.
+      }
+    }
+    throw new AssertionError("batch write request does not have a usable partition key value");
+  }
+
+  private static String attributeLabel(AttributeValue value) {
+    if (value.s() != null) {
+      return "S:" + value.s();
+    }
+    if (value.n() != null) {
+      return "N:" + value.n();
+    }
+    if (value.b() != null) {
+      return "B:" + hex(value.b().asByteArray());
+    }
+    return String.valueOf(value);
+  }
+
+  private static List<String> nodeSequence(long seed, int count) throws URISyntaxException {
+    List<URI> nodes = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      nodes.add(new URI("http", null, "node" + i + ".example.com", 8000, null, null, null));
+    }
+
+    LazyQueryPlan plan =
+        new LazyQueryPlan(new AlternatorLiveNodes(nodes, "http", 8000, "", ""), seed);
+    List<String> result = new ArrayList<>();
+    for (int i = 0; i < count && plan.hasNext(); i++) {
+      result.add(nodeShortName(plan.next()));
+    }
+    return result;
+  }
+
+  private static String nodeShortName(URI uri) {
+    String host = uri.getHost();
+    return host.substring(0, host.indexOf(".example.com"));
+  }
+
+  private static String hex(byte[] bytes) {
+    final char[] hex = "0123456789abcdef".toCharArray();
+    StringBuilder builder = new StringBuilder(bytes.length * 2);
+    for (byte value : bytes) {
+      builder.append(hex[(value >> 4) & 0x0f]);
+      builder.append(hex[value & 0x0f]);
+    }
+    return builder.toString();
+  }
+
+  private static final class BatchWriteVector {
+    private final String name;
+    private final BatchWriteItemRequest request;
+    private final Map<String, String> pkInfo;
+    private final String tableName;
+    private final String operation;
+    private final String pkLabel;
+    private final String canonical;
+    private final long hashSigned;
+    private final String hashUnsigned;
+    private final List<String> firstSixNodes;
+
+    private BatchWriteVector(
+        String name,
+        BatchWriteItemRequest request,
+        Map<String, String> pkInfo,
+        String tableName,
+        String operation,
+        String pkLabel,
+        String canonical,
+        long hashSigned,
+        String hashUnsigned,
+        List<String> firstSixNodes) {
+      this.name = name;
+      this.request = request;
+      this.pkInfo = pkInfo;
+      this.tableName = tableName;
+      this.operation = operation;
+      this.pkLabel = pkLabel;
+      this.canonical = canonical;
+      this.hashSigned = hashSigned;
+      this.hashUnsigned = hashUnsigned;
+      this.firstSixNodes = firstSixNodes;
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
@@ -2,8 +2,11 @@ package com.scylladb.alternator.keyrouting;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import software.amazon.awssdk.services.dynamodb.model.*;
@@ -545,6 +548,45 @@ public class KeyAffinityRequestClassifierTest {
   }
 
   @Test
+  public void testBatchWriteItemExtractionIsTableOrderIndependent() {
+    BatchWriteItemRequest first = batchWriteRequest("orders", "z-order", "audit", "a-audit");
+    BatchWriteItemRequest second = batchWriteRequest("audit", "a-audit", "orders", "z-order");
+
+    assertEquals("audit", KeyAffinityRequestClassifier.extractTableName(first));
+    assertEquals("audit", KeyAffinityRequestClassifier.extractTableName(second));
+
+    AttributeValue firstPk = KeyAffinityRequestClassifier.extractPartitionKey(first, "pk");
+    AttributeValue secondPk = KeyAffinityRequestClassifier.extractPartitionKey(second, "pk");
+    assertNotNull(firstPk);
+    assertNotNull(secondPk);
+    assertEquals("a-audit", firstPk.s());
+    assertEquals("a-audit", secondPk.s());
+  }
+
+  @Test
+  public void testBatchWriteItemExtractionIsWriteOrderIndependent() {
+    BatchWriteItemRequest first =
+        BatchWriteItemRequest.builder()
+            .requestItems(
+                Collections.singletonMap(
+                    "orders", Arrays.asList(batchPut("z-route"), batchPut("a-route"))))
+            .build();
+    BatchWriteItemRequest second =
+        BatchWriteItemRequest.builder()
+            .requestItems(
+                Collections.singletonMap(
+                    "orders", Arrays.asList(batchPut("a-route"), batchPut("z-route"))))
+            .build();
+
+    AttributeValue firstPk = KeyAffinityRequestClassifier.extractPartitionKey(first, "pk");
+    AttributeValue secondPk = KeyAffinityRequestClassifier.extractPartitionKey(second, "pk");
+    assertNotNull(firstPk);
+    assertNotNull(secondPk);
+    assertEquals("a-route", firstPk.s());
+    assertEquals("a-route", secondPk.s());
+  }
+
+  @Test
   public void testExtractPartitionKeyWithWrongKeyName() {
     Map<String, AttributeValue> key = createKey("user_id", "u123");
     UpdateItemRequest request = UpdateItemRequest.builder().tableName("users").key(key).build();
@@ -575,5 +617,19 @@ public class KeyAffinityRequestClassifierTest {
     item.put(keyName, AttributeValue.builder().s(keyValue).build());
     item.put("data", AttributeValue.builder().s("some data").build());
     return item;
+  }
+
+  private BatchWriteItemRequest batchWriteRequest(
+      String firstTable, String firstPk, String secondTable, String secondPk) {
+    Map<String, List<WriteRequest>> requestItems = new LinkedHashMap<>();
+    requestItems.put(firstTable, Collections.singletonList(batchPut(firstPk)));
+    requestItems.put(secondTable, Collections.singletonList(batchPut(secondPk)));
+    return BatchWriteItemRequest.builder().requestItems(requestItems).build();
+  }
+
+  private WriteRequest batchPut(String pk) {
+    return WriteRequest.builder()
+        .putRequest(PutRequest.builder().item(createItem("pk", pk)).build())
+        .build();
   }
 }


### PR DESCRIPTION
## Summary
- Align Java BatchWriteItem key-affinity target selection with the Rust and Go implementations.
- Sort BatchWrite routing candidates by `(tableName, canonicalAttributes, operation)` where `canonicalAttributes` is no-whitespace canonical JSON with sorted map keys.
- Canonicalize binary attributes as `{ "__bytes__": "hex" }` inside the DynamoDB attribute wrapper, matching the shared cross-language vectors.
- Route BatchWriteItem through the sorted candidate list so Java skips candidates without the configured partition key, or with an unsupported partition-key shape, and hashes the same selected key as Rust and Go.
- Add positive BatchWriteItem cross-language vectors covering selected table/operation, canonical attributes, signed and unsigned hash values, and first-six seeded node sequences.

Fixes #94
Closes #96

## Cross-Language Contract
For positive BatchWriteItem key-affinity cases:

1. Build one routing candidate for each `PutRequest.Item` and each `DeleteRequest.Key`.
2. Set the candidate operation to exactly `PutRequest` or `DeleteRequest`.
3. Canonicalize candidate attributes as stable JSON:
   - object/map keys sorted lexicographically
   - no whitespace
   - lists and set arrays preserve SDK/request order
   - binary scalar: `{ "B": { "__bytes__": "<lowercase hex>" } }`
   - binary set entries: `{ "__bytes__": "<lowercase hex>" }`
4. Sort candidates by `(tableName, canonicalAttributes, operation)`.
5. Walk sorted candidates, resolve that candidate table's configured partition key, and hash the first usable partition-key value with the shared `AttributeValueHasher`.
6. Seed `LazyQueryPlan` with that hash, preserving the existing Go-compatible PRNG and pick-and-remove node ordering.

## Covered Vectors
- `same_table_write_order`: selects `orders` / `PutRequest` / `S:order123`, hash `-2126891002421145093`, nodes `node9,node2,node10,node8,node7,node5`.
- `multi_table_order`: selects `orders` / `PutRequest` / `S:order123`, hash `-2126891002421145093`, nodes `node9,node2,node10,node8,node7,node5`.
- `delete_put_same_attributes`: selects `orders` / `DeleteRequest` / `S:same`, hash `-4879317772220196571`, nodes `node1,node3,node10,node7,node4,node5`.
- `number_partition_key`: selects `accounts` / `PutRequest` / `N:42`, hash `-5061732451827723051`, nodes `node3,node7,node1,node10,node2,node5`.
- `binary_partition_key`: selects `blobs` / `DeleteRequest` / `B:00ff`, hash `-4376945693382523102`, nodes `node7,node2,node5,node1,node6,node9`.

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH mvn test -Dtest=KeyAffinityRequestClassifierTest,BatchWriteItemKeyRouteAffinityCrossLanguageTest,AffinityQueryPlanInterceptorTest,LazyQueryPlanCrossLanguageTest,AttributeValueHasherCrossLanguageTest`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH make test-unit` (661 tests)
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH make lint`