### PR TITLE
DRIVER-560: report Alternator Java client in user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,8 +488,9 @@ When headers optimization is enabled, only the following headers are preserved b
 - `Content-Encoding` - For request compression (when enabled)
 - `Authorization` - AWS SigV4 signature (when authentication is enabled)
 - `X-Amz-Date` - Timestamp for AWS signature (when authentication is enabled)
+- `User-Agent` - Reports the AWS SDK and ScyllaDB Alternator client versions
 
-All other headers (such as `User-Agent`, `X-Amz-Sdk-Invocation-Id`, `amz-sdk-request`, `X-Amz-Content-Sha256`) are removed.
+All other headers (such as `X-Amz-Sdk-Invocation-Id`, `amz-sdk-request`, `X-Amz-Content-Sha256`) are removed.
 
 #### Custom headers whitelist
 
@@ -504,13 +505,13 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .withOptimizeHeaders(true)
     .withHeadersWhitelist(Arrays.asList(
         "Host", "X-Amz-Target", "Content-Type", "Content-Length",
-        "Authorization", "X-Amz-Date", "X-Custom-Header"))
+        "Authorization", "X-Amz-Date", "User-Agent", "X-Custom-Header"))
     .build();
 ```
 
 **Important:** When using a custom whitelist, make sure to include all headers required for
-authentication (`Authorization`, `X-Amz-Date`) and operation (`Host`, `X-Amz-Target`,
-`Content-Type`, `Content-Length`).
+authentication (`Authorization`, `X-Amz-Date`), operation (`Host`, `X-Amz-Target`,
+`Content-Type`, `Content-Length`), and client reporting (`User-Agent`).
 
 #### Combining with compression
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,48 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
 authentication (`Authorization`, `X-Amz-Date`), operation (`Host`, `X-Amz-Target`,
 `Content-Type`, `Content-Length`), and client reporting (`User-Agent`).
 
+#### User-Agent customization
+
+By default, the library appends the ScyllaDB Alternator client identity to the AWS SDK user-agent:
+
+```text
+<AWS SDK User-Agent> scylladb-alternator-client-java/<version>
+```
+
+You can replace it completely:
+
+```java
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://127.0.0.1:8043"))
+    .credentialsProvider(myCredentials)
+    .withUserAgent("my-client/1.2.3")
+    .build();
+```
+
+You can transform the generated value. The function receives the AWS SDK user-agent with the
+default ScyllaDB Alternator token already appended:
+
+```java
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://127.0.0.1:8043"))
+    .credentialsProvider(myCredentials)
+    .withUserAgent(userAgent -> userAgent + " my-app/4.5.6")
+    .build();
+```
+
+You can also remove the header entirely:
+
+```java
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://127.0.0.1:8043"))
+    .credentialsProvider(myCredentials)
+    .withoutUserAgent()
+    .build();
+```
+
+When `withoutUserAgent()` is used with headers optimization, `User-Agent` is removed from the
+effective required whitelist as well.
+
 #### Combining with compression
 
 Headers optimization can be combined with request compression for maximum bandwidth savings:

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
@@ -482,7 +482,7 @@ public class AlternatorDynamoDbAsyncClientIT {
           }
         };
 
-    // Custom whitelist that includes User-Agent but excludes some default headers
+    // Custom whitelist that keeps User-Agent while filtering non-required SDK metadata
     Set<String> customWhitelist =
         new HashSet<>(
             java.util.Arrays.asList(

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
@@ -472,7 +472,7 @@ public class AlternatorDynamoDbClientIT {
           }
         };
 
-    // Custom whitelist that includes User-Agent but excludes some default headers
+    // Custom whitelist that keeps User-Agent while filtering non-required SDK metadata
     Set<String> customWhitelist =
         new HashSet<>(
             java.util.Arrays.asList(

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -129,6 +129,7 @@ public class AlternatorConfig {
    *   <li>{@code Content-Length} - Required for request body
    *   <li>{@code Accept-Encoding} - For response compression negotiation
    *   <li>{@code Connection} - HTTP keep-alive for connection reuse
+   *   <li>{@code User-Agent} - Reports the AWS SDK and ScyllaDB Alternator client versions
    * </ul>
    *
    * @since 2.0.0
@@ -142,7 +143,8 @@ public class AlternatorConfig {
                   "Content-Type",
                   "Content-Length",
                   "Accept-Encoding",
-                  "Connection")));
+                  "Connection",
+                  "User-Agent")));
 
   /**
    * HTTP headers required when compression is enabled.

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -129,7 +129,6 @@ public class AlternatorConfig {
    *   <li>{@code Content-Length} - Required for request body
    *   <li>{@code Accept-Encoding} - For response compression negotiation
    *   <li>{@code Connection} - HTTP keep-alive for connection reuse
-   *   <li>{@code User-Agent} - Reports the AWS SDK and ScyllaDB Alternator client versions
    * </ul>
    *
    * @since 2.0.0
@@ -143,8 +142,19 @@ public class AlternatorConfig {
                   "Content-Type",
                   "Content-Length",
                   "Accept-Encoding",
-                  "Connection",
-                  "User-Agent")));
+                  "Connection")));
+
+  /**
+   * HTTP headers required when user-agent reporting is enabled.
+   *
+   * <ul>
+   *   <li>{@code User-Agent} - Reports the AWS SDK and ScyllaDB Alternator client versions
+   * </ul>
+   *
+   * @since 2.0.5
+   */
+  public static final Set<String> USER_AGENT_HEADERS =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("User-Agent")));
 
   /**
    * HTTP headers required when compression is enabled.
@@ -179,6 +189,7 @@ public class AlternatorConfig {
   private final int minCompressionSizeBytes;
   private final boolean optimizeHeaders;
   private final Set<String> headersWhitelist;
+  private final boolean userAgentEnabled;
   private final boolean authenticationEnabled;
   private final TlsSessionCacheConfig tlsSessionCacheConfig;
   private final TlsConfig tlsConfig;
@@ -202,6 +213,7 @@ public class AlternatorConfig {
    * @param minCompressionSizeBytes minimum request size in bytes to trigger compression
    * @param optimizeHeaders whether to enable HTTP header optimization
    * @param headersWhitelist the set of headers to preserve when optimization is enabled
+   * @param userAgentEnabled whether user-agent reporting is enabled
    * @param authenticationEnabled whether authentication is enabled
    * @param tlsSessionCacheConfig the TLS session cache configuration for quick TLS renegotiation
    * @param tlsConfig the TLS configuration including CA certificates and verification settings
@@ -226,6 +238,7 @@ public class AlternatorConfig {
       int minCompressionSizeBytes,
       boolean optimizeHeaders,
       Set<String> headersWhitelist,
+      boolean userAgentEnabled,
       boolean authenticationEnabled,
       TlsSessionCacheConfig tlsSessionCacheConfig,
       TlsConfig tlsConfig,
@@ -249,6 +262,7 @@ public class AlternatorConfig {
     this.minCompressionSizeBytes =
         minCompressionSizeBytes >= 0 ? minCompressionSizeBytes : DEFAULT_MIN_COMPRESSION_SIZE_BYTES;
     this.optimizeHeaders = optimizeHeaders;
+    this.userAgentEnabled = userAgentEnabled;
     this.authenticationEnabled = authenticationEnabled;
 
     // Compute default whitelist based on configuration if not provided
@@ -378,6 +392,20 @@ public class AlternatorConfig {
    */
   public Set<String> getHeadersWhitelist() {
     return headersWhitelist;
+  }
+
+  /**
+   * Checks if user-agent reporting is enabled.
+   *
+   * <p>When enabled, the client sends a {@code User-Agent} header that includes AWS SDK metadata
+   * and the ScyllaDB Alternator client version. When disabled, optimized header whitelists do not
+   * require {@code User-Agent}.
+   *
+   * @return true if user-agent reporting is enabled, false otherwise
+   * @since 2.0.5
+   */
+  public boolean isUserAgentEnabled() {
+    return userAgentEnabled;
   }
 
   /**
@@ -544,6 +572,9 @@ public class AlternatorConfig {
     if (compressionAlgorithm != null && compressionAlgorithm != RequestCompressionAlgorithm.NONE) {
       required.addAll(COMPRESSION_HEADERS);
     }
+    if (userAgentEnabled) {
+      required.addAll(USER_AGENT_HEADERS);
+    }
     if (authenticationEnabled) {
       required.addAll(AUTHENTICATION_HEADERS);
     }
@@ -569,6 +600,7 @@ public class AlternatorConfig {
     private boolean optimizeHeaders = false;
     private Set<String> headersWhitelist = null; // null means use default based on config
     private boolean headersWhitelistWasSet = false;
+    private boolean userAgentEnabled = true;
     private boolean authenticationEnabled = true;
     private TlsSessionCacheConfig tlsSessionCacheConfig = null; // null means use default
     private TlsConfig tlsConfig = null; // null means use default (trust-all for backwards compat)
@@ -594,6 +626,11 @@ public class AlternatorConfig {
      */
     Builder authenticationEnabled(boolean authenticationEnabled) {
       this.authenticationEnabled = authenticationEnabled;
+      return this;
+    }
+
+    Builder withUserAgentEnabled(boolean userAgentEnabled) {
+      this.userAgentEnabled = userAgentEnabled;
       return this;
     }
 
@@ -699,6 +736,9 @@ public class AlternatorConfig {
       Set<String> required = new HashSet<>(BASE_REQUIRED_HEADERS);
       if (compressionAlgorithm != null && compressionAlgorithm.isEnabled()) {
         required.addAll(COMPRESSION_HEADERS);
+      }
+      if (userAgentEnabled) {
+        required.addAll(USER_AGENT_HEADERS);
       }
       if (authenticationEnabled) {
         required.addAll(AUTHENTICATION_HEADERS);
@@ -1223,6 +1263,7 @@ public class AlternatorConfig {
           minCompressionSizeBytes,
           optimizeHeaders,
           headersWhitelist,
+          userAgentEnabled,
           authenticationEnabled,
           tlsSessionCacheConfig,
           effectiveTlsConfig,

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointMode;
@@ -95,9 +96,13 @@ public class AlternatorDynamoDbAsyncClient {
     private boolean disableCertificateChecks = false;
     private boolean httpClientSet = false;
     private boolean credentialsProviderSet = false;
+    private SdkAsyncHttpClient customHttpClient;
+    private SdkAsyncHttpClient.Builder customHttpClientBuilder;
     private Consumer<NettyNioAsyncHttpClient.Builder> nettyCustomizer;
     private Consumer<AwsCrtAsyncHttpClient.Builder> crtAsyncCustomizer;
     private HttpClientType httpClientType;
+    private UnaryOperator<String> userAgentTransformer;
+    private boolean defaultUserAgentSuffixEnabled = true;
 
     private AlternatorDynamoDbAsyncClientBuilder() {
       this.delegate = DynamoDbAsyncClient.builder();
@@ -161,6 +166,57 @@ public class AlternatorDynamoDbAsyncClient {
      */
     public AlternatorDynamoDbAsyncClientBuilder withHeadersWhitelist(Collection<String> headers) {
       configBuilder.withHeadersWhitelist(headers);
+      return this;
+    }
+
+    /**
+     * Replaces the final {@code User-Agent} header with the provided value.
+     *
+     * @param userAgent the exact user-agent value to send
+     * @return this builder instance
+     * @throws IllegalArgumentException if userAgent is null or blank
+     * @since 2.0.5
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withUserAgent(String userAgent) {
+      this.userAgentTransformer = AlternatorUserAgent.replaceWith(userAgent);
+      this.defaultUserAgentSuffixEnabled = false;
+      configBuilder.withUserAgentEnabled(true);
+      return this;
+    }
+
+    /**
+     * Transforms the final {@code User-Agent} header before the request is sent.
+     *
+     * <p>The function receives the AWS SDK user-agent with the default ScyllaDB Alternator client
+     * token appended. Returning null or blank removes the {@code User-Agent} header.
+     *
+     * @param userAgentTransformer function that maps the generated user-agent to the value to send
+     * @return this builder instance
+     * @throws IllegalArgumentException if userAgentTransformer is null
+     * @since 2.0.5
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withUserAgent(
+        UnaryOperator<String> userAgentTransformer) {
+      this.userAgentTransformer =
+          AlternatorUserAgent.requireUserAgentTransformer(userAgentTransformer);
+      this.defaultUserAgentSuffixEnabled = true;
+      configBuilder.withUserAgentEnabled(true);
+      return this;
+    }
+
+    /**
+     * Removes the {@code User-Agent} header from outgoing requests.
+     *
+     * <p>When header optimization is enabled, {@code User-Agent} is also removed from the required
+     * optimized header whitelist.
+     *
+     * @return this builder instance
+     * @since 2.0.5
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withoutUserAgent() {
+      this.userAgentTransformer = AlternatorUserAgent.disable();
+      this.defaultUserAgentSuffixEnabled = false;
+      configBuilder.withUserAgentEnabled(false);
       return this;
     }
 
@@ -320,6 +376,7 @@ public class AlternatorDynamoDbAsyncClient {
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
         configBuilder.withOptimizeHeaders(config.isOptimizeHeaders());
         configBuilder.withHeadersWhitelist(config.getHeadersWhitelist());
+        configBuilder.withUserAgentEnabled(config.isUserAgentEnabled());
         configBuilder.withTlsConfig(config.getTlsConfig());
         configBuilder.withTlsSessionCacheConfig(config.getTlsSessionCacheConfig());
         configBuilder.withKeyRouteAffinity(config.getKeyRouteAffinityConfig());
@@ -449,7 +506,8 @@ public class AlternatorDynamoDbAsyncClient {
     @Override
     public AlternatorDynamoDbAsyncClientBuilder httpClient(SdkAsyncHttpClient httpClient) {
       this.httpClientSet = true;
-      delegate.httpClient(httpClient);
+      this.customHttpClient = httpClient;
+      this.customHttpClientBuilder = null;
       return this;
     }
 
@@ -458,7 +516,8 @@ public class AlternatorDynamoDbAsyncClient {
     public AlternatorDynamoDbAsyncClientBuilder httpClientBuilder(
         SdkAsyncHttpClient.Builder httpClientBuilder) {
       this.httpClientSet = true;
-      delegate.httpClientBuilder(httpClientBuilder);
+      this.customHttpClient = null;
+      this.customHttpClientBuilder = httpClientBuilder;
       return this;
     }
 
@@ -596,19 +655,12 @@ public class AlternatorDynamoDbAsyncClient {
       }
 
       TlsConfig tlsConfig = alternatorConfig.getTlsConfig();
-      boolean optimizeHeaders = alternatorConfig.isOptimizeHeaders();
-
       if (!httpClientSet) {
         SdkAsyncHttpClient mainClient =
             createMainAsyncClient(asyncType, alternatorConfig, tlsConfig);
-
-        if (optimizeHeaders) {
-          delegate.httpClient(
-              new HeadersFilteringSdkAsyncHttpClient(
-                  mainClient, alternatorConfig.getHeadersWhitelist()));
-        } else {
-          delegate.httpClient(mainClient);
-        }
+        delegate.httpClient(configureMainAsyncClient(mainClient, alternatorConfig));
+      } else {
+        configureCustomAsyncClient(alternatorConfig);
       }
 
       SyncClientDetector.SyncClientType syncType = SyncClientDetector.detect();
@@ -631,7 +683,9 @@ public class AlternatorDynamoDbAsyncClient {
       } else {
         overrideBuilder.addExecutionInterceptor(new BasicQueryPlanInterceptor(liveNodes));
       }
-      AlternatorUserAgent.applyTo(overrideBuilder);
+      if (defaultUserAgentSuffixEnabled) {
+        AlternatorUserAgent.applyDefaultSuffixTo(overrideBuilder);
+      }
       delegate.overrideConfiguration(overrideBuilder.build());
 
       delegate.endpointOverride(seedUri);
@@ -726,6 +780,42 @@ public class AlternatorDynamoDbAsyncClient {
         default:
           throw new IllegalStateException("Unknown async client type: " + asyncType);
       }
+    }
+
+    private SdkAsyncHttpClient configureMainAsyncClient(
+        SdkAsyncHttpClient mainClient, AlternatorConfig alternatorConfig) {
+      SdkAsyncHttpClient configuredClient = mainClient;
+      if (userAgentTransformer != null) {
+        configuredClient = new UserAgentSdkAsyncHttpClient(configuredClient, userAgentTransformer);
+      }
+      if (alternatorConfig.isOptimizeHeaders()) {
+        configuredClient =
+            new HeadersFilteringSdkAsyncHttpClient(
+                configuredClient, alternatorConfig.getHeadersWhitelist());
+      }
+      return configuredClient;
+    }
+
+    private void configureCustomAsyncClient(AlternatorConfig alternatorConfig) {
+      if (customHttpClient != null) {
+        delegate.httpClient(configureMainAsyncClient(customHttpClient, alternatorConfig));
+        return;
+      }
+
+      if (customHttpClientBuilder == null) {
+        return;
+      }
+
+      if (needsHttpClientWrapper(alternatorConfig)) {
+        delegate.httpClient(
+            configureMainAsyncClient(customHttpClientBuilder.build(), alternatorConfig));
+      } else {
+        delegate.httpClientBuilder(customHttpClientBuilder);
+      }
+    }
+
+    private boolean needsHttpClientWrapper(AlternatorConfig alternatorConfig) {
+      return userAgentTransformer != null || alternatorConfig.isOptimizeHeaders();
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -631,6 +631,7 @@ public class AlternatorDynamoDbAsyncClient {
       } else {
         overrideBuilder.addExecutionInterceptor(new BasicQueryPlanInterceptor(liveNodes));
       }
+      AlternatorUserAgent.applyTo(overrideBuilder);
       delegate.overrideConfiguration(overrideBuilder.build());
 
       delegate.endpointOverride(seedUri);

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.endpoints.AccountIdEndpointMode;
@@ -95,9 +96,13 @@ public class AlternatorDynamoDbClient {
     private boolean disableCertificateChecks = false;
     private boolean httpClientSet = false;
     private boolean credentialsProviderSet = false;
+    private SdkHttpClient customHttpClient;
+    private SdkHttpClient.Builder customHttpClientBuilder;
     private Consumer<ApacheHttpClient.Builder> apacheCustomizer;
     private Consumer<AwsCrtHttpClient.Builder> crtCustomizer;
     private HttpClientType httpClientType;
+    private UnaryOperator<String> userAgentTransformer;
+    private boolean defaultUserAgentSuffixEnabled = true;
 
     private AlternatorDynamoDbClientBuilder() {
       this.delegate = DynamoDbClient.builder();
@@ -185,6 +190,57 @@ public class AlternatorDynamoDbClient {
      */
     public AlternatorDynamoDbClientBuilder withHeadersWhitelist(Collection<String> headers) {
       configBuilder.withHeadersWhitelist(headers);
+      return this;
+    }
+
+    /**
+     * Replaces the final {@code User-Agent} header with the provided value.
+     *
+     * @param userAgent the exact user-agent value to send
+     * @return this builder instance
+     * @throws IllegalArgumentException if userAgent is null or blank
+     * @since 2.0.5
+     */
+    public AlternatorDynamoDbClientBuilder withUserAgent(String userAgent) {
+      this.userAgentTransformer = AlternatorUserAgent.replaceWith(userAgent);
+      this.defaultUserAgentSuffixEnabled = false;
+      configBuilder.withUserAgentEnabled(true);
+      return this;
+    }
+
+    /**
+     * Transforms the final {@code User-Agent} header before the request is sent.
+     *
+     * <p>The function receives the AWS SDK user-agent with the default ScyllaDB Alternator client
+     * token appended. Returning null or blank removes the {@code User-Agent} header.
+     *
+     * @param userAgentTransformer function that maps the generated user-agent to the value to send
+     * @return this builder instance
+     * @throws IllegalArgumentException if userAgentTransformer is null
+     * @since 2.0.5
+     */
+    public AlternatorDynamoDbClientBuilder withUserAgent(
+        UnaryOperator<String> userAgentTransformer) {
+      this.userAgentTransformer =
+          AlternatorUserAgent.requireUserAgentTransformer(userAgentTransformer);
+      this.defaultUserAgentSuffixEnabled = true;
+      configBuilder.withUserAgentEnabled(true);
+      return this;
+    }
+
+    /**
+     * Removes the {@code User-Agent} header from outgoing requests.
+     *
+     * <p>When header optimization is enabled, {@code User-Agent} is also removed from the required
+     * optimized header whitelist.
+     *
+     * @return this builder instance
+     * @since 2.0.5
+     */
+    public AlternatorDynamoDbClientBuilder withoutUserAgent() {
+      this.userAgentTransformer = AlternatorUserAgent.disable();
+      this.defaultUserAgentSuffixEnabled = false;
+      configBuilder.withUserAgentEnabled(false);
       return this;
     }
 
@@ -357,6 +413,7 @@ public class AlternatorDynamoDbClient {
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
         configBuilder.withOptimizeHeaders(config.isOptimizeHeaders());
         configBuilder.withHeadersWhitelist(config.getHeadersWhitelist());
+        configBuilder.withUserAgentEnabled(config.isUserAgentEnabled());
         configBuilder.withTlsConfig(config.getTlsConfig());
         configBuilder.withTlsSessionCacheConfig(config.getTlsSessionCacheConfig());
         configBuilder.withKeyRouteAffinity(config.getKeyRouteAffinityConfig());
@@ -486,7 +543,8 @@ public class AlternatorDynamoDbClient {
     @Override
     public AlternatorDynamoDbClientBuilder httpClient(SdkHttpClient httpClient) {
       this.httpClientSet = true;
-      delegate.httpClient(httpClient);
+      this.customHttpClient = httpClient;
+      this.customHttpClientBuilder = null;
       return this;
     }
 
@@ -495,7 +553,8 @@ public class AlternatorDynamoDbClient {
     public AlternatorDynamoDbClientBuilder httpClientBuilder(
         SdkHttpClient.Builder httpClientBuilder) {
       this.httpClientSet = true;
-      delegate.httpClientBuilder(httpClientBuilder);
+      this.customHttpClient = null;
+      this.customHttpClientBuilder = httpClientBuilder;
       return this;
     }
 
@@ -617,22 +676,14 @@ public class AlternatorDynamoDbClient {
       }
 
       TlsConfig tlsConfig = alternatorConfig.getTlsConfig();
-      boolean optimizeHeaders = alternatorConfig.isOptimizeHeaders();
-
       SdkHttpClient pollingClient = null;
       if (!httpClientSet) {
         SdkHttpClient mainClient = createMainSyncClient(clientType, alternatorConfig, tlsConfig);
-
-        if (optimizeHeaders) {
-          delegate.httpClient(
-              new HeadersFilteringSdkHttpClient(
-                  mainClient, alternatorConfig.getHeadersWhitelist()));
-        } else {
-          delegate.httpClient(mainClient);
-        }
+        delegate.httpClient(configureMainSyncClient(mainClient, alternatorConfig));
 
         pollingClient = SyncClientDetector.createPollingClient(clientType, tlsConfig);
       } else {
+        configureCustomSyncClient(alternatorConfig);
         SyncClientDetector.SyncClientType pollingType = SyncClientDetector.detect();
         pollingClient = SyncClientDetector.createPollingClient(pollingType, tlsConfig);
       }
@@ -655,7 +706,9 @@ public class AlternatorDynamoDbClient {
       } else {
         overrideBuilder.addExecutionInterceptor(new BasicQueryPlanInterceptor(liveNodes));
       }
-      AlternatorUserAgent.applyTo(overrideBuilder);
+      if (defaultUserAgentSuffixEnabled) {
+        AlternatorUserAgent.applyDefaultSuffixTo(overrideBuilder);
+      }
       delegate.overrideConfiguration(overrideBuilder.build());
 
       delegate.endpointOverride(seedUri);
@@ -749,6 +802,42 @@ public class AlternatorDynamoDbClient {
         default:
           throw new IllegalStateException("Unknown sync client type: " + clientType);
       }
+    }
+
+    private SdkHttpClient configureMainSyncClient(
+        SdkHttpClient mainClient, AlternatorConfig alternatorConfig) {
+      SdkHttpClient configuredClient = mainClient;
+      if (userAgentTransformer != null) {
+        configuredClient = new UserAgentSdkHttpClient(configuredClient, userAgentTransformer);
+      }
+      if (alternatorConfig.isOptimizeHeaders()) {
+        configuredClient =
+            new HeadersFilteringSdkHttpClient(
+                configuredClient, alternatorConfig.getHeadersWhitelist());
+      }
+      return configuredClient;
+    }
+
+    private void configureCustomSyncClient(AlternatorConfig alternatorConfig) {
+      if (customHttpClient != null) {
+        delegate.httpClient(configureMainSyncClient(customHttpClient, alternatorConfig));
+        return;
+      }
+
+      if (customHttpClientBuilder == null) {
+        return;
+      }
+
+      if (needsHttpClientWrapper(alternatorConfig)) {
+        delegate.httpClient(
+            configureMainSyncClient(customHttpClientBuilder.build(), alternatorConfig));
+      } else {
+        delegate.httpClientBuilder(customHttpClientBuilder);
+      }
+    }
+
+    private boolean needsHttpClientWrapper(AlternatorConfig alternatorConfig) {
+      return userAgentTransformer != null || alternatorConfig.isOptimizeHeaders();
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -655,6 +655,7 @@ public class AlternatorDynamoDbClient {
       } else {
         overrideBuilder.addExecutionInterceptor(new BasicQueryPlanInterceptor(liveNodes));
       }
+      AlternatorUserAgent.applyTo(overrideBuilder);
       delegate.overrideConfiguration(overrideBuilder.build());
 
       delegate.endpointOverride(seedUri);

--- a/src/main/java/com/scylladb/alternator/AlternatorUserAgent.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorUserAgent.java
@@ -4,11 +4,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.function.UnaryOperator;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 /** Adds this Alternator wrapper's identity to AWS SDK user-agent strings. */
 final class AlternatorUserAgent {
+  static final String HEADER_NAME = "User-Agent";
   static final String PRODUCT_NAME = "scylladb-alternator-client-java";
   private static final String VERSION_RESOURCE =
       "META-INF/maven/com.scylladb.alternator/load-balancing/pom.properties";
@@ -17,7 +20,7 @@ final class AlternatorUserAgent {
 
   private AlternatorUserAgent() {}
 
-  static void applyTo(ClientOverrideConfiguration.Builder overrideBuilder) {
+  static void applyDefaultSuffixTo(ClientOverrideConfiguration.Builder overrideBuilder) {
     Objects.requireNonNull(overrideBuilder, "overrideBuilder");
 
     String existingSuffix =
@@ -30,6 +33,28 @@ final class AlternatorUserAgent {
     return USER_AGENT_TOKEN;
   }
 
+  static UnaryOperator<String> replaceWith(String userAgent) {
+    requireValidUserAgent(userAgent);
+    return current -> userAgent;
+  }
+
+  static UnaryOperator<String> disable() {
+    return current -> null;
+  }
+
+  static void requireValidUserAgent(String userAgent) {
+    if (userAgent == null || userAgent.trim().isEmpty()) {
+      throw new IllegalArgumentException("userAgent cannot be null or blank");
+    }
+  }
+
+  static <T> T requireUserAgentTransformer(T userAgentTransformer) {
+    if (userAgentTransformer == null) {
+      throw new IllegalArgumentException("userAgentTransformer cannot be null");
+    }
+    return userAgentTransformer;
+  }
+
   static String appendToken(String existingSuffix, String token) {
     if (existingSuffix == null || existingSuffix.trim().isEmpty()) {
       return token;
@@ -40,6 +65,27 @@ final class AlternatorUserAgent {
       return trimmed;
     }
     return trimmed + " " + token;
+  }
+
+  static SdkHttpRequest transform(SdkHttpRequest request, UnaryOperator<String> transformer) {
+    String currentUserAgent = request.firstMatchingHeader(HEADER_NAME).orElse("");
+    String replacement = transformer.apply(currentUserAgent);
+
+    SdkHttpRequest.Builder requestBuilder = request.toBuilder();
+    requestBuilder.clearHeaders();
+    request
+        .headers()
+        .forEach(
+            (headerName, values) -> {
+              if (!HEADER_NAME.equalsIgnoreCase(headerName)) {
+                values.forEach(value -> requestBuilder.appendHeader(headerName, value));
+              }
+            });
+
+    if (replacement != null && !replacement.trim().isEmpty()) {
+      requestBuilder.appendHeader(HEADER_NAME, replacement);
+    }
+    return requestBuilder.build();
   }
 
   private static String resolveVersion() {

--- a/src/main/java/com/scylladb/alternator/AlternatorUserAgent.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorUserAgent.java
@@ -1,0 +1,69 @@
+package com.scylladb.alternator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+
+/** Adds this Alternator wrapper's identity to AWS SDK user-agent strings. */
+final class AlternatorUserAgent {
+  static final String PRODUCT_NAME = "scylladb-alternator-client-java";
+  private static final String VERSION_RESOURCE =
+      "META-INF/maven/com.scylladb.alternator/load-balancing/pom.properties";
+  private static final String UNKNOWN_VERSION = "unknown";
+  private static final String USER_AGENT_TOKEN = PRODUCT_NAME + "/" + resolveVersion();
+
+  private AlternatorUserAgent() {}
+
+  static void applyTo(ClientOverrideConfiguration.Builder overrideBuilder) {
+    Objects.requireNonNull(overrideBuilder, "overrideBuilder");
+
+    String existingSuffix =
+        overrideBuilder.advancedOptions().get(SdkAdvancedClientOption.USER_AGENT_SUFFIX);
+    overrideBuilder.putAdvancedOption(
+        SdkAdvancedClientOption.USER_AGENT_SUFFIX, appendToken(existingSuffix, USER_AGENT_TOKEN));
+  }
+
+  static String userAgentToken() {
+    return USER_AGENT_TOKEN;
+  }
+
+  static String appendToken(String existingSuffix, String token) {
+    if (existingSuffix == null || existingSuffix.trim().isEmpty()) {
+      return token;
+    }
+
+    String trimmed = existingSuffix.trim();
+    if (trimmed.contains(token)) {
+      return trimmed;
+    }
+    return trimmed + " " + token;
+  }
+
+  private static String resolveVersion() {
+    String version = AlternatorUserAgent.class.getPackage().getImplementationVersion();
+    if (version == null || version.trim().isEmpty()) {
+      version = loadVersionFromPomProperties();
+    }
+    if (version == null || version.trim().isEmpty()) {
+      version = UNKNOWN_VERSION;
+    }
+    return version.trim().replaceAll("\\s+", "_");
+  }
+
+  private static String loadVersionFromPomProperties() {
+    try (InputStream input =
+        AlternatorUserAgent.class.getClassLoader().getResourceAsStream(VERSION_RESOURCE)) {
+      if (input == null) {
+        return null;
+      }
+      Properties properties = new Properties();
+      properties.load(input);
+      return properties.getProperty("version");
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClient.java
+++ b/src/main/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClient.java
@@ -12,8 +12,8 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
  * A wrapper around SdkAsyncHttpClient that filters HTTP headers to a specified whitelist.
  *
  * <p>This wrapper intercepts requests before they are executed and removes headers not in the
- * configured whitelist. This runs after all AWS SDK processing, ensuring complete header filtering
- * including SDK-internal headers like User-Agent and amz-sdk-request.
+ * configured whitelist. This runs after all AWS SDK processing, ensuring complete filtering of
+ * SDK-internal headers like amz-sdk-request.
  *
  * @author dmitry.kropachev
  * @since 2.0.0

--- a/src/main/java/com/scylladb/alternator/HeadersFilteringSdkHttpClient.java
+++ b/src/main/java/com/scylladb/alternator/HeadersFilteringSdkHttpClient.java
@@ -12,8 +12,8 @@ import software.amazon.awssdk.http.SdkHttpRequest;
  * A wrapper around SdkHttpClient that filters HTTP headers to a specified whitelist.
  *
  * <p>This wrapper intercepts requests before they are executed and removes headers not in the
- * configured whitelist. This runs after all AWS SDK processing, ensuring complete header filtering
- * including SDK-internal headers like User-Agent and amz-sdk-request.
+ * configured whitelist. This runs after all AWS SDK processing, ensuring complete filtering of
+ * SDK-internal headers like amz-sdk-request.
  *
  * @author dmitry.kropachev
  * @since 2.0.0

--- a/src/main/java/com/scylladb/alternator/UserAgentSdkAsyncHttpClient.java
+++ b/src/main/java/com/scylladb/alternator/UserAgentSdkAsyncHttpClient.java
@@ -1,0 +1,46 @@
+package com.scylladb.alternator;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.UnaryOperator;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+
+/** A wrapper around SdkAsyncHttpClient that rewrites or removes the User-Agent header. */
+class UserAgentSdkAsyncHttpClient implements SdkAsyncHttpClient {
+  private final SdkAsyncHttpClient delegate;
+  private final UnaryOperator<String> userAgentTransformer;
+
+  UserAgentSdkAsyncHttpClient(
+      SdkAsyncHttpClient delegate, UnaryOperator<String> userAgentTransformer) {
+    this.delegate = delegate;
+    this.userAgentTransformer = userAgentTransformer;
+  }
+
+  @Override
+  public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
+    SdkHttpRequest transformedRequest =
+        AlternatorUserAgent.transform(request.request(), userAgentTransformer);
+
+    AsyncExecuteRequest transformedExecuteRequest =
+        AsyncExecuteRequest.builder()
+            .request(transformedRequest)
+            .requestContentPublisher(request.requestContentPublisher())
+            .responseHandler(request.responseHandler())
+            .fullDuplex(request.fullDuplex())
+            .metricCollector(request.metricCollector().orElse(null))
+            .build();
+
+    return delegate.execute(transformedExecuteRequest);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public String clientName() {
+    return delegate.clientName();
+  }
+}

--- a/src/main/java/com/scylladb/alternator/UserAgentSdkHttpClient.java
+++ b/src/main/java/com/scylladb/alternator/UserAgentSdkHttpClient.java
@@ -1,0 +1,42 @@
+package com.scylladb.alternator;
+
+import java.util.function.UnaryOperator;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+/** A wrapper around SdkHttpClient that rewrites or removes the User-Agent header. */
+class UserAgentSdkHttpClient implements SdkHttpClient {
+  private final SdkHttpClient delegate;
+  private final UnaryOperator<String> userAgentTransformer;
+
+  UserAgentSdkHttpClient(SdkHttpClient delegate, UnaryOperator<String> userAgentTransformer) {
+    this.delegate = delegate;
+    this.userAgentTransformer = userAgentTransformer;
+  }
+
+  @Override
+  public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+    SdkHttpRequest transformedRequest =
+        AlternatorUserAgent.transform(request.httpRequest(), userAgentTransformer);
+
+    HttpExecuteRequest transformedExecuteRequest =
+        HttpExecuteRequest.builder()
+            .request(transformedRequest)
+            .contentStreamProvider(request.contentStreamProvider().orElse(null))
+            .build();
+
+    return delegate.prepareRequest(transformedExecuteRequest);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public String clientName() {
+    return delegate.clientName();
+  }
+}

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
@@ -157,6 +157,36 @@ public class AlternatorConfigHeadersTest {
   }
 
   @Test
+  public void testUserAgentDisabledRemovesUserAgentFromRequiredHeaders() {
+    AlternatorConfig config =
+        AlternatorConfig.builder().withOptimizeHeaders(true).withUserAgentEnabled(false).build();
+
+    assertFalse(config.isUserAgentEnabled());
+    assertFalse(config.getRequiredHeaders().contains("User-Agent"));
+    assertFalse(config.getHeadersWhitelist().contains("User-Agent"));
+  }
+
+  @Test
+  public void testCustomWhitelistWithoutUserAgentSucceedsWhenUserAgentDisabled() {
+    AlternatorConfig.Builder builder =
+        AlternatorConfig.builder().withOptimizeHeaders(true).withUserAgentEnabled(false);
+    Set<String> whitelist = new HashSet<>(builder.getRequiredHeaders());
+
+    AlternatorConfig config = builder.withHeadersWhitelist(whitelist).build();
+
+    assertFalse(config.getHeadersWhitelist().contains("User-Agent"));
+    assertEquals(whitelist, config.getHeadersWhitelist());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCustomWhitelistWithoutUserAgentFailsWhenUserAgentEnabled() {
+    Set<String> whitelist = new HashSet<>(AlternatorConfig.builder().getRequiredHeaders());
+    whitelist.remove("User-Agent");
+
+    AlternatorConfig.builder().withOptimizeHeaders(true).withHeadersWhitelist(whitelist).build();
+  }
+
+  @Test
   public void testRequiredHeadersIsImmutable() {
     AlternatorConfig config = AlternatorConfig.builder().build();
     try {

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
@@ -152,7 +152,8 @@ public class AlternatorConfigHeadersTest {
     assertTrue(headers.contains("Authorization"));
     assertTrue(headers.contains("X-Amz-Date"));
     assertTrue(headers.contains("Connection"));
-    assertEquals(9, headers.size());
+    assertTrue(headers.contains("User-Agent"));
+    assertEquals(10, headers.size());
   }
 
   @Test
@@ -196,6 +197,7 @@ public class AlternatorConfigHeadersTest {
     assertFalse(whitelist.contains("X-Amz-Date"));
     // Without compression enabled, Content-Encoding is not included
     assertFalse(whitelist.contains("Content-Encoding"));
+    assertTrue(whitelist.contains("User-Agent"));
     assertEquals(config.getRequiredHeaders(), whitelist);
   }
 
@@ -237,7 +239,8 @@ public class AlternatorConfigHeadersTest {
     assertFalse(noAuthHeaders.contains("Authorization"));
     assertFalse(noAuthHeaders.contains("X-Amz-Date"));
     assertTrue(noAuthHeaders.contains("Connection"));
-    assertEquals(7, noAuthHeaders.size());
+    assertTrue(noAuthHeaders.contains("User-Agent"));
+    assertEquals(8, noAuthHeaders.size());
   }
 
   @Test
@@ -248,16 +251,17 @@ public class AlternatorConfigHeadersTest {
             .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
             .authenticationEnabled(false)
             .build();
-    assertEquals(6, noCompressionNoAuth.getRequiredHeaders().size());
+    assertEquals(7, noCompressionNoAuth.getRequiredHeaders().size());
     assertFalse(noCompressionNoAuth.getRequiredHeaders().contains("Content-Encoding"));
     assertFalse(noCompressionNoAuth.getRequiredHeaders().contains("Authorization"));
+    assertTrue(noCompressionNoAuth.getRequiredHeaders().contains("User-Agent"));
 
     AlternatorConfig withCompressionNoAuth =
         AlternatorConfig.builder()
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
             .authenticationEnabled(false)
             .build();
-    assertEquals(7, withCompressionNoAuth.getRequiredHeaders().size());
+    assertEquals(8, withCompressionNoAuth.getRequiredHeaders().size());
     assertTrue(withCompressionNoAuth.getRequiredHeaders().contains("Content-Encoding"));
     assertFalse(withCompressionNoAuth.getRequiredHeaders().contains("Authorization"));
 
@@ -266,7 +270,7 @@ public class AlternatorConfigHeadersTest {
             .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
             .authenticationEnabled(true)
             .build();
-    assertEquals(8, noCompressionWithAuth.getRequiredHeaders().size());
+    assertEquals(9, noCompressionWithAuth.getRequiredHeaders().size());
     assertFalse(noCompressionWithAuth.getRequiredHeaders().contains("Content-Encoding"));
     assertTrue(noCompressionWithAuth.getRequiredHeaders().contains("Authorization"));
 
@@ -275,7 +279,7 @@ public class AlternatorConfigHeadersTest {
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
             .authenticationEnabled(true)
             .build();
-    assertEquals(9, withCompressionWithAuth.getRequiredHeaders().size());
+    assertEquals(10, withCompressionWithAuth.getRequiredHeaders().size());
     assertTrue(withCompressionWithAuth.getRequiredHeaders().contains("Content-Encoding"));
     assertTrue(withCompressionWithAuth.getRequiredHeaders().contains("Authorization"));
   }
@@ -286,20 +290,21 @@ public class AlternatorConfigHeadersTest {
     AlternatorConfig.Builder builder = AlternatorConfig.builder();
     Set<String> defaultRequired = builder.getRequiredHeaders();
     // Default is no compression, with auth
-    assertEquals(8, defaultRequired.size());
+    assertEquals(9, defaultRequired.size());
     assertFalse(defaultRequired.contains("Content-Encoding"));
     assertTrue(defaultRequired.contains("Authorization"));
+    assertTrue(defaultRequired.contains("User-Agent"));
 
     // Enable compression
     builder.withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP);
     Set<String> withCompression = builder.getRequiredHeaders();
-    assertEquals(9, withCompression.size());
+    assertEquals(10, withCompression.size());
     assertTrue(withCompression.contains("Content-Encoding"));
 
     // Disable auth
     builder.authenticationEnabled(false);
     Set<String> noAuth = builder.getRequiredHeaders();
-    assertEquals(7, noAuth.size());
+    assertEquals(8, noAuth.size());
     assertTrue(noAuth.contains("Content-Encoding"));
     assertFalse(noAuth.contains("Authorization"));
   }
@@ -313,9 +318,10 @@ public class AlternatorConfigHeadersTest {
             .build();
 
     Set<String> required = config.getRequiredHeaders();
-    assertEquals(9, required.size());
+    assertEquals(10, required.size());
     assertTrue(required.contains("Content-Encoding"));
     assertTrue(required.contains("Authorization"));
+    assertTrue(required.contains("User-Agent"));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.AsyncClientDetector;
 import java.net.URI;
+import java.util.function.UnaryOperator;
 import org.junit.Test;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
@@ -157,6 +158,33 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
             .endpointOverride(SEED_URI)
             .withHttpClientType(HttpClientType.NETTY);
     assertNotNull("Builder should return itself for chaining", builder);
+  }
+
+  @Test
+  public void testUserAgentBuilderMethodsReturnThis() {
+    AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder =
+        AlternatorDynamoDbAsyncClient.builder().endpointOverride(SEED_URI);
+
+    assertSame(builder, builder.withUserAgent("custom/1"));
+    assertSame(builder, builder.withUserAgent(userAgent -> userAgent + " app/1"));
+    assertSame(builder, builder.withoutUserAgent());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithUserAgentRejectsNullString() {
+    AlternatorDynamoDbAsyncClient.builder().endpointOverride(SEED_URI).withUserAgent((String) null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithUserAgentRejectsBlankString() {
+    AlternatorDynamoDbAsyncClient.builder().endpointOverride(SEED_URI).withUserAgent(" ");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithUserAgentRejectsNullTransformer() {
+    AlternatorDynamoDbAsyncClient.builder()
+        .endpointOverride(SEED_URI)
+        .withUserAgent((UnaryOperator<String>) null);
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.SyncClientDetector;
 import java.net.URI;
+import java.util.function.UnaryOperator;
 import org.junit.Test;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -157,6 +158,33 @@ public class AlternatorDynamoDbClientCustomizerTest {
             .endpointOverride(SEED_URI)
             .withHttpClientType(HttpClientType.APACHE);
     assertNotNull("Builder should return itself for chaining", builder);
+  }
+
+  @Test
+  public void testUserAgentBuilderMethodsReturnThis() {
+    AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder =
+        AlternatorDynamoDbClient.builder().endpointOverride(SEED_URI);
+
+    assertSame(builder, builder.withUserAgent("custom/1"));
+    assertSame(builder, builder.withUserAgent(userAgent -> userAgent + " app/1"));
+    assertSame(builder, builder.withoutUserAgent());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithUserAgentRejectsNullString() {
+    AlternatorDynamoDbClient.builder().endpointOverride(SEED_URI).withUserAgent((String) null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithUserAgentRejectsBlankString() {
+    AlternatorDynamoDbClient.builder().endpointOverride(SEED_URI).withUserAgent(" ");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testWithUserAgentRejectsNullTransformer() {
+    AlternatorDynamoDbClient.builder()
+        .endpointOverride(SEED_URI)
+        .withUserAgent((UnaryOperator<String>) null);
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClientTest.java
@@ -168,7 +168,7 @@ public class HeadersFilteringSdkAsyncHttpClientTest {
   }
 
   @Test
-  public void testFiltersAllSdkMetadataHeaders() {
+  public void testFiltersSdkMetadataHeadersExceptUserAgent() {
     // Use the default required headers whitelist
     AlternatorConfig config = AlternatorConfig.builder().authenticationEnabled(true).build();
     Set<String> whitelist = config.getRequiredHeaders();
@@ -188,8 +188,8 @@ public class HeadersFilteringSdkAsyncHttpClientTest {
             .appendHeader("Authorization", "AWS4-HMAC-SHA256...")
             .appendHeader("X-Amz-Date", "20240101T000000Z")
             .appendHeader("Accept-Encoding", "gzip")
-            // SDK metadata headers that should be filtered
             .appendHeader("User-Agent", "aws-sdk-java/2.x")
+            // SDK metadata headers that should be filtered
             .appendHeader("X-Amz-Sdk-Invocation-Id", "some-id")
             .appendHeader("amz-sdk-request", "attempt=1")
             .build();
@@ -205,8 +205,10 @@ public class HeadersFilteringSdkAsyncHttpClientTest {
     assertTrue(mockClient.capturedRequest.headers().containsKey("X-Amz-Date"));
     assertTrue(mockClient.capturedRequest.headers().containsKey("Accept-Encoding"));
 
-    // SDK metadata headers should be filtered
-    assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    // User-Agent should be preserved for driver reporting; other SDK metadata is filtered
+    assertTrue(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    assertEquals(
+        "aws-sdk-java/2.x", mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
     assertFalse(mockClient.capturedRequest.headers().containsKey("X-Amz-Sdk-Invocation-Id"));
     assertFalse(mockClient.capturedRequest.headers().containsKey("amz-sdk-request"));
   }

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;
@@ -168,7 +170,7 @@ public class HeadersFilteringSdkHttpClientTest {
   }
 
   @Test
-  public void testFiltersAllSdkMetadataHeaders() {
+  public void testFiltersSdkMetadataHeadersExceptUserAgent() {
     // Use the default required headers whitelist
     AlternatorConfig config = AlternatorConfig.builder().authenticationEnabled(true).build();
     Set<String> whitelist = config.getRequiredHeaders();
@@ -188,8 +190,8 @@ public class HeadersFilteringSdkHttpClientTest {
             .appendHeader("Authorization", "AWS4-HMAC-SHA256...")
             .appendHeader("X-Amz-Date", "20240101T000000Z")
             .appendHeader("Accept-Encoding", "gzip")
-            // SDK metadata headers that should be filtered
             .appendHeader("User-Agent", "aws-sdk-java/2.x")
+            // SDK metadata headers that should be filtered
             .appendHeader("X-Amz-Sdk-Invocation-Id", "some-id")
             .appendHeader("amz-sdk-request", "attempt=1")
             .build();
@@ -208,10 +210,33 @@ public class HeadersFilteringSdkHttpClientTest {
     assertTrue(mockClient.capturedRequest.headers().containsKey("X-Amz-Date"));
     assertTrue(mockClient.capturedRequest.headers().containsKey("Accept-Encoding"));
 
-    // SDK metadata headers should be filtered
-    assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    // User-Agent should be preserved for driver reporting; other SDK metadata is filtered
+    assertTrue(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    assertEquals(
+        "aws-sdk-java/2.x", mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
     assertFalse(mockClient.capturedRequest.headers().containsKey("X-Amz-Sdk-Invocation-Id"));
     assertFalse(mockClient.capturedRequest.headers().containsKey("amz-sdk-request"));
+  }
+
+  @Test
+  public void testAlternatorUserAgentSuffixIsAddedToOverrideConfiguration() {
+    ClientOverrideConfiguration.Builder overrideBuilder = ClientOverrideConfiguration.builder();
+
+    AlternatorUserAgent.applyTo(overrideBuilder);
+
+    String suffix =
+        overrideBuilder
+            .build()
+            .advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX)
+            .get();
+    assertEquals(AlternatorUserAgent.userAgentToken(), suffix);
+  }
+
+  @Test
+  public void testAlternatorUserAgentSuffixPreservesExistingSuffix() {
+    assertEquals(
+        "custom/1 " + AlternatorUserAgent.userAgentToken(),
+        AlternatorUserAgent.appendToken("custom/1", AlternatorUserAgent.userAgentToken()));
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
@@ -222,13 +222,10 @@ public class HeadersFilteringSdkHttpClientTest {
   public void testAlternatorUserAgentSuffixIsAddedToOverrideConfiguration() {
     ClientOverrideConfiguration.Builder overrideBuilder = ClientOverrideConfiguration.builder();
 
-    AlternatorUserAgent.applyTo(overrideBuilder);
+    AlternatorUserAgent.applyDefaultSuffixTo(overrideBuilder);
 
     String suffix =
-        overrideBuilder
-            .build()
-            .advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX)
-            .get();
+        overrideBuilder.build().advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX).get();
     assertEquals(AlternatorUserAgent.userAgentToken(), suffix);
   }
 

--- a/src/test/java/com/scylladb/alternator/UserAgentSdkAsyncHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/UserAgentSdkAsyncHttpClientTest.java
@@ -1,0 +1,153 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+/** Unit tests for UserAgentSdkAsyncHttpClient. */
+public class UserAgentSdkAsyncHttpClientTest {
+  private static class MockSdkAsyncHttpClient implements SdkAsyncHttpClient {
+    SdkHttpRequest capturedRequest;
+    AsyncExecuteRequest capturedExecuteRequest;
+    boolean closeCalled;
+
+    @Override
+    public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
+      this.capturedRequest = request.request();
+      this.capturedExecuteRequest = request;
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {
+      closeCalled = true;
+    }
+
+    @Override
+    public String clientName() {
+      return "mock";
+    }
+  }
+
+  private static class MockResponseHandler implements SdkAsyncHttpResponseHandler {
+    @Override
+    public void onHeaders(SdkHttpResponse response) {}
+
+    @Override
+    public void onStream(Publisher<ByteBuffer> stream) {}
+
+    @Override
+    public void onError(Throwable error) {}
+  }
+
+  @Test
+  public void testReplacesUserAgent() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    UserAgentSdkAsyncHttpClient client =
+        new UserAgentSdkAsyncHttpClient(mockClient, AlternatorUserAgent.replaceWith("custom/1"));
+
+    client.execute(createRequest(request("aws-sdk-java/2.x")));
+
+    assertEquals("custom/1", mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+    assertEquals("localhost:8043", mockClient.capturedRequest.firstMatchingHeader("Host").get());
+  }
+
+  @Test
+  public void testTransformsUserAgent() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    UserAgentSdkAsyncHttpClient client =
+        new UserAgentSdkAsyncHttpClient(mockClient, userAgent -> userAgent + " app/2");
+
+    client.execute(createRequest(request("aws-sdk-java/2.x")));
+
+    assertEquals(
+        "aws-sdk-java/2.x app/2",
+        mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+  }
+
+  @Test
+  public void testRemovesUserAgentWhenTransformerReturnsNull() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    UserAgentSdkAsyncHttpClient client =
+        new UserAgentSdkAsyncHttpClient(mockClient, AlternatorUserAgent.disable());
+
+    client.execute(createRequest(request("aws-sdk-java/2.x")));
+
+    assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    assertEquals("localhost:8043", mockClient.capturedRequest.firstMatchingHeader("Host").get());
+  }
+
+  @Test
+  public void testPreservesAsyncExecuteRequestFields() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    UserAgentSdkAsyncHttpClient client =
+        new UserAgentSdkAsyncHttpClient(mockClient, AlternatorUserAgent.replaceWith("custom/1"));
+    MockResponseHandler handler = new MockResponseHandler();
+    MetricCollector metricCollector = MetricCollector.create("test");
+    SdkHttpContentPublisher publisher =
+        new SdkHttpContentPublisher() {
+          @Override
+          public Optional<Long> contentLength() {
+            return Optional.of(4L);
+          }
+
+          @Override
+          public void subscribe(Subscriber<? super ByteBuffer> subscriber) {}
+        };
+
+    client.execute(
+        AsyncExecuteRequest.builder()
+            .request(request("aws-sdk-java/2.x"))
+            .responseHandler(handler)
+            .requestContentPublisher(publisher)
+            .metricCollector(metricCollector)
+            .fullDuplex(true)
+            .build());
+
+    assertSame(handler, mockClient.capturedExecuteRequest.responseHandler());
+    assertSame(publisher, mockClient.capturedExecuteRequest.requestContentPublisher());
+    assertEquals(metricCollector, mockClient.capturedExecuteRequest.metricCollector().get());
+    assertTrue(mockClient.capturedExecuteRequest.fullDuplex());
+  }
+
+  @Test
+  public void testCloseDelegates() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    UserAgentSdkAsyncHttpClient client =
+        new UserAgentSdkAsyncHttpClient(mockClient, AlternatorUserAgent.replaceWith("custom/1"));
+
+    client.close();
+
+    assertTrue(mockClient.closeCalled);
+  }
+
+  private AsyncExecuteRequest createRequest(SdkHttpRequest request) {
+    return AsyncExecuteRequest.builder()
+        .request(request)
+        .responseHandler(new MockResponseHandler())
+        .build();
+  }
+
+  private SdkHttpRequest request(String userAgent) {
+    return SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://localhost:8043"))
+        .appendHeader("Host", "localhost:8043")
+        .appendHeader("User-Agent", userAgent)
+        .build();
+  }
+}

--- a/src/test/java/com/scylladb/alternator/UserAgentSdkHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/UserAgentSdkHttpClientTest.java
@@ -1,0 +1,125 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import org.junit.Test;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+/** Unit tests for UserAgentSdkHttpClient. */
+public class UserAgentSdkHttpClientTest {
+  private static class MockSdkHttpClient implements SdkHttpClient {
+    SdkHttpRequest capturedRequest;
+    HttpExecuteRequest capturedExecuteRequest;
+    boolean closeCalled;
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      this.capturedRequest = request.httpRequest();
+      this.capturedExecuteRequest = request;
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() {
+          return null;
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    @Override
+    public void close() {
+      closeCalled = true;
+    }
+
+    @Override
+    public String clientName() {
+      return "mock";
+    }
+  }
+
+  @Test
+  public void testReplacesUserAgent() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    UserAgentSdkHttpClient client =
+        new UserAgentSdkHttpClient(mockClient, AlternatorUserAgent.replaceWith("custom/1"));
+
+    client.prepareRequest(
+        HttpExecuteRequest.builder().request(request("aws-sdk-java/2.x")).build());
+
+    assertEquals("custom/1", mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+    assertEquals("localhost:8043", mockClient.capturedRequest.firstMatchingHeader("Host").get());
+  }
+
+  @Test
+  public void testTransformsUserAgent() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    UserAgentSdkHttpClient client =
+        new UserAgentSdkHttpClient(mockClient, userAgent -> "prefix " + userAgent + " suffix");
+
+    client.prepareRequest(
+        HttpExecuteRequest.builder().request(request("aws-sdk-java/2.x")).build());
+
+    assertEquals(
+        "prefix aws-sdk-java/2.x suffix",
+        mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+  }
+
+  @Test
+  public void testRemovesUserAgentWhenTransformerReturnsNull() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    UserAgentSdkHttpClient client =
+        new UserAgentSdkHttpClient(mockClient, AlternatorUserAgent.disable());
+
+    client.prepareRequest(
+        HttpExecuteRequest.builder().request(request("aws-sdk-java/2.x")).build());
+
+    assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    assertEquals("localhost:8043", mockClient.capturedRequest.firstMatchingHeader("Host").get());
+  }
+
+  @Test
+  public void testPreservesContentStreamProvider() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    UserAgentSdkHttpClient client =
+        new UserAgentSdkHttpClient(mockClient, AlternatorUserAgent.replaceWith("custom/1"));
+    ContentStreamProvider contentProvider = () -> new ByteArrayInputStream("test".getBytes());
+
+    client.prepareRequest(
+        HttpExecuteRequest.builder()
+            .request(request("aws-sdk-java/2.x"))
+            .contentStreamProvider(contentProvider)
+            .build());
+
+    assertTrue(mockClient.capturedExecuteRequest.contentStreamProvider().isPresent());
+    assertSame(contentProvider, mockClient.capturedExecuteRequest.contentStreamProvider().get());
+  }
+
+  @Test
+  public void testCloseDelegates() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    UserAgentSdkHttpClient client =
+        new UserAgentSdkHttpClient(mockClient, AlternatorUserAgent.replaceWith("custom/1"));
+
+    client.close();
+
+    assertTrue(mockClient.closeCalled);
+  }
+
+  private SdkHttpRequest request(String userAgent) {
+    return SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://localhost:8043"))
+        .appendHeader("Host", "localhost:8043")
+        .appendHeader("User-Agent", userAgent)
+        .build();
+  }
+}


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-560
Related: https://scylladb.atlassian.net/browse/DRIVER-290

## Summary
- Append `scylladb-alternator-client-java/<version>` to the AWS SDK v2 `User-Agent` for sync and async Alternator client builders by default.
- Preserve `User-Agent` in the default optimized header whitelist so header optimization still reports the client identity.
- Add user-agent configuration APIs for exact replacement, functional transformation/wrapping, and complete removal.
- Remove `User-Agent` from the required/effective optimized-header whitelist when `.withoutUserAgent()` is used.
- Update docs and tests for default reporting, header optimization, replacement, transformation, removal, and validation cases.

## User-Agent API
- Default: `<AWS SDK User-Agent> scylladb-alternator-client-java/<version>`.
- Replace: `.withUserAgent("my-client/1.2.3")` sends exactly `my-client/1.2.3`.
- Transform/wrap: `.withUserAgent(userAgent -> userAgent + " my-app/4.5.6")` receives the generated AWS SDK user-agent with the default Alternator token already appended.
- Disable: `.withoutUserAgent()` sends no `User-Agent`; with header optimization enabled, `User-Agent` is not required or preserved.

For the current build, the default added token resolves to `scylladb-alternator-client-java/2.0.5-SNAPSHOT`.

## Verification
- `git diff --check`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH make lint`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q test`
