### PR TITLE
DRIVER-560: remove AWS SDK user agent from reported value

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ When headers optimization is enabled, only the following headers are preserved b
 - `Content-Encoding` - For request compression (when enabled)
 - `Authorization` - AWS SigV4 signature (when authentication is enabled)
 - `X-Amz-Date` - Timestamp for AWS signature (when authentication is enabled)
-- `User-Agent` - Reports the AWS SDK and ScyllaDB Alternator client versions
+- `User-Agent` - Reports the ScyllaDB Alternator client version
 
 All other headers (such as `X-Amz-Sdk-Invocation-Id`, `amz-sdk-request`, `X-Amz-Content-Sha256`) are removed.
 
@@ -515,10 +515,10 @@ authentication (`Authorization`, `X-Amz-Date`), operation (`Host`, `X-Amz-Target
 
 #### User-Agent customization
 
-By default, the library appends the ScyllaDB Alternator client identity to the AWS SDK user-agent:
+By default, the library sends only the ScyllaDB Alternator client identity:
 
 ```text
-<AWS SDK User-Agent> scylladb-alternator-client-java/<version>
+scylladb-alternator-client-java/<version>
 ```
 
 You can replace it completely:
@@ -531,8 +531,8 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .build();
 ```
 
-You can transform the generated value. The function receives the AWS SDK user-agent with the
-default ScyllaDB Alternator token already appended:
+You can transform the generated value. The function receives the default ScyllaDB Alternator
+user-agent:
 
 ```java
 DynamoDbClient client = AlternatorDynamoDbClient.builder()

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -148,7 +148,7 @@ public class AlternatorConfig {
    * HTTP headers required when user-agent reporting is enabled.
    *
    * <ul>
-   *   <li>{@code User-Agent} - Reports the AWS SDK and ScyllaDB Alternator client versions
+   *   <li>{@code User-Agent} - Reports the ScyllaDB Alternator client version
    * </ul>
    *
    * @since 2.0.5
@@ -397,9 +397,9 @@ public class AlternatorConfig {
   /**
    * Checks if user-agent reporting is enabled.
    *
-   * <p>When enabled, the client sends a {@code User-Agent} header that includes AWS SDK metadata
-   * and the ScyllaDB Alternator client version. When disabled, optimized header whitelists do not
-   * require {@code User-Agent}.
+   * <p>When enabled, the client sends a {@code User-Agent} header that includes the ScyllaDB
+   * Alternator client version. When disabled, optimized header whitelists do not require {@code
+   * User-Agent}.
    *
    * @return true if user-agent reporting is enabled, false otherwise
    * @since 2.0.5

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -101,8 +101,7 @@ public class AlternatorDynamoDbAsyncClient {
     private Consumer<NettyNioAsyncHttpClient.Builder> nettyCustomizer;
     private Consumer<AwsCrtAsyncHttpClient.Builder> crtAsyncCustomizer;
     private HttpClientType httpClientType;
-    private UnaryOperator<String> userAgentTransformer;
-    private boolean defaultUserAgentSuffixEnabled = true;
+    private UnaryOperator<String> userAgentTransformer = AlternatorUserAgent.defaultUserAgent();
 
     private AlternatorDynamoDbAsyncClientBuilder() {
       this.delegate = DynamoDbAsyncClient.builder();
@@ -179,7 +178,6 @@ public class AlternatorDynamoDbAsyncClient {
      */
     public AlternatorDynamoDbAsyncClientBuilder withUserAgent(String userAgent) {
       this.userAgentTransformer = AlternatorUserAgent.replaceWith(userAgent);
-      this.defaultUserAgentSuffixEnabled = false;
       configBuilder.withUserAgentEnabled(true);
       return this;
     }
@@ -187,8 +185,8 @@ public class AlternatorDynamoDbAsyncClient {
     /**
      * Transforms the final {@code User-Agent} header before the request is sent.
      *
-     * <p>The function receives the AWS SDK user-agent with the default ScyllaDB Alternator client
-     * token appended. Returning null or blank removes the {@code User-Agent} header.
+     * <p>The function receives the default ScyllaDB Alternator client user-agent. Returning null or
+     * blank removes the {@code User-Agent} header.
      *
      * @param userAgentTransformer function that maps the generated user-agent to the value to send
      * @return this builder instance
@@ -197,9 +195,7 @@ public class AlternatorDynamoDbAsyncClient {
      */
     public AlternatorDynamoDbAsyncClientBuilder withUserAgent(
         UnaryOperator<String> userAgentTransformer) {
-      this.userAgentTransformer =
-          AlternatorUserAgent.requireUserAgentTransformer(userAgentTransformer);
-      this.defaultUserAgentSuffixEnabled = true;
+      this.userAgentTransformer = AlternatorUserAgent.transformDefault(userAgentTransformer);
       configBuilder.withUserAgentEnabled(true);
       return this;
     }
@@ -215,7 +211,6 @@ public class AlternatorDynamoDbAsyncClient {
      */
     public AlternatorDynamoDbAsyncClientBuilder withoutUserAgent() {
       this.userAgentTransformer = AlternatorUserAgent.disable();
-      this.defaultUserAgentSuffixEnabled = false;
       configBuilder.withUserAgentEnabled(false);
       return this;
     }
@@ -682,9 +677,6 @@ public class AlternatorDynamoDbAsyncClient {
             new AffinityQueryPlanInterceptor(keyAffinityConfig, liveNodes));
       } else {
         overrideBuilder.addExecutionInterceptor(new BasicQueryPlanInterceptor(liveNodes));
-      }
-      if (defaultUserAgentSuffixEnabled) {
-        AlternatorUserAgent.applyDefaultSuffixTo(overrideBuilder);
       }
       delegate.overrideConfiguration(overrideBuilder.build());
 

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -101,8 +101,7 @@ public class AlternatorDynamoDbClient {
     private Consumer<ApacheHttpClient.Builder> apacheCustomizer;
     private Consumer<AwsCrtHttpClient.Builder> crtCustomizer;
     private HttpClientType httpClientType;
-    private UnaryOperator<String> userAgentTransformer;
-    private boolean defaultUserAgentSuffixEnabled = true;
+    private UnaryOperator<String> userAgentTransformer = AlternatorUserAgent.defaultUserAgent();
 
     private AlternatorDynamoDbClientBuilder() {
       this.delegate = DynamoDbClient.builder();
@@ -203,7 +202,6 @@ public class AlternatorDynamoDbClient {
      */
     public AlternatorDynamoDbClientBuilder withUserAgent(String userAgent) {
       this.userAgentTransformer = AlternatorUserAgent.replaceWith(userAgent);
-      this.defaultUserAgentSuffixEnabled = false;
       configBuilder.withUserAgentEnabled(true);
       return this;
     }
@@ -211,8 +209,8 @@ public class AlternatorDynamoDbClient {
     /**
      * Transforms the final {@code User-Agent} header before the request is sent.
      *
-     * <p>The function receives the AWS SDK user-agent with the default ScyllaDB Alternator client
-     * token appended. Returning null or blank removes the {@code User-Agent} header.
+     * <p>The function receives the default ScyllaDB Alternator client user-agent. Returning null or
+     * blank removes the {@code User-Agent} header.
      *
      * @param userAgentTransformer function that maps the generated user-agent to the value to send
      * @return this builder instance
@@ -221,9 +219,7 @@ public class AlternatorDynamoDbClient {
      */
     public AlternatorDynamoDbClientBuilder withUserAgent(
         UnaryOperator<String> userAgentTransformer) {
-      this.userAgentTransformer =
-          AlternatorUserAgent.requireUserAgentTransformer(userAgentTransformer);
-      this.defaultUserAgentSuffixEnabled = true;
+      this.userAgentTransformer = AlternatorUserAgent.transformDefault(userAgentTransformer);
       configBuilder.withUserAgentEnabled(true);
       return this;
     }
@@ -239,7 +235,6 @@ public class AlternatorDynamoDbClient {
      */
     public AlternatorDynamoDbClientBuilder withoutUserAgent() {
       this.userAgentTransformer = AlternatorUserAgent.disable();
-      this.defaultUserAgentSuffixEnabled = false;
       configBuilder.withUserAgentEnabled(false);
       return this;
     }
@@ -705,9 +700,6 @@ public class AlternatorDynamoDbClient {
         overrideBuilder.addExecutionInterceptor(affinityInterceptor);
       } else {
         overrideBuilder.addExecutionInterceptor(new BasicQueryPlanInterceptor(liveNodes));
-      }
-      if (defaultUserAgentSuffixEnabled) {
-        AlternatorUserAgent.applyDefaultSuffixTo(overrideBuilder);
       }
       delegate.overrideConfiguration(overrideBuilder.build());
 

--- a/src/main/java/com/scylladb/alternator/AlternatorUserAgent.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorUserAgent.java
@@ -2,14 +2,11 @@ package com.scylladb.alternator;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.function.UnaryOperator;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.http.SdkHttpRequest;
 
-/** Adds this Alternator wrapper's identity to AWS SDK user-agent strings. */
+/** Rewrites generated user-agent strings to this Alternator wrapper's identity. */
 final class AlternatorUserAgent {
   static final String HEADER_NAME = "User-Agent";
   static final String PRODUCT_NAME = "scylladb-alternator-client-java";
@@ -20,22 +17,22 @@ final class AlternatorUserAgent {
 
   private AlternatorUserAgent() {}
 
-  static void applyDefaultSuffixTo(ClientOverrideConfiguration.Builder overrideBuilder) {
-    Objects.requireNonNull(overrideBuilder, "overrideBuilder");
-
-    String existingSuffix =
-        overrideBuilder.advancedOptions().get(SdkAdvancedClientOption.USER_AGENT_SUFFIX);
-    overrideBuilder.putAdvancedOption(
-        SdkAdvancedClientOption.USER_AGENT_SUFFIX, appendToken(existingSuffix, USER_AGENT_TOKEN));
-  }
-
   static String userAgentToken() {
     return USER_AGENT_TOKEN;
+  }
+
+  static UnaryOperator<String> defaultUserAgent() {
+    return replaceWith(USER_AGENT_TOKEN);
   }
 
   static UnaryOperator<String> replaceWith(String userAgent) {
     requireValidUserAgent(userAgent);
     return current -> userAgent;
+  }
+
+  static UnaryOperator<String> transformDefault(UnaryOperator<String> userAgentTransformer) {
+    requireUserAgentTransformer(userAgentTransformer);
+    return current -> userAgentTransformer.apply(USER_AGENT_TOKEN);
   }
 
   static UnaryOperator<String> disable() {
@@ -53,18 +50,6 @@ final class AlternatorUserAgent {
       throw new IllegalArgumentException("userAgentTransformer cannot be null");
     }
     return userAgentTransformer;
-  }
-
-  static String appendToken(String existingSuffix, String token) {
-    if (existingSuffix == null || existingSuffix.trim().isEmpty()) {
-      return token;
-    }
-
-    String trimmed = existingSuffix.trim();
-    if (trimmed.contains(token)) {
-      return trimmed;
-    }
-    return trimmed + " " + token;
   }
 
   static SdkHttpRequest transform(SdkHttpRequest request, UnaryOperator<String> transformer) {

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
@@ -7,8 +7,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;
@@ -216,24 +214,6 @@ public class HeadersFilteringSdkHttpClientTest {
         "aws-sdk-java/2.x", mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
     assertFalse(mockClient.capturedRequest.headers().containsKey("X-Amz-Sdk-Invocation-Id"));
     assertFalse(mockClient.capturedRequest.headers().containsKey("amz-sdk-request"));
-  }
-
-  @Test
-  public void testAlternatorUserAgentSuffixIsAddedToOverrideConfiguration() {
-    ClientOverrideConfiguration.Builder overrideBuilder = ClientOverrideConfiguration.builder();
-
-    AlternatorUserAgent.applyDefaultSuffixTo(overrideBuilder);
-
-    String suffix =
-        overrideBuilder.build().advancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX).get();
-    assertEquals(AlternatorUserAgent.userAgentToken(), suffix);
-  }
-
-  @Test
-  public void testAlternatorUserAgentSuffixPreservesExistingSuffix() {
-    assertEquals(
-        "custom/1 " + AlternatorUserAgent.userAgentToken(),
-        AlternatorUserAgent.appendToken("custom/1", AlternatorUserAgent.userAgentToken()));
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/UserAgentSdkAsyncHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/UserAgentSdkAsyncHttpClientTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
@@ -55,6 +57,25 @@ public class UserAgentSdkAsyncHttpClientTest {
   }
 
   @Test
+  public void testDefaultUserAgentReplacesAwsSdkUserAgent() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    UserAgentSdkAsyncHttpClient client =
+        new UserAgentSdkAsyncHttpClient(mockClient, AlternatorUserAgent.defaultUserAgent());
+
+    client.execute(createRequest(request("aws-sdk-java/2.x")));
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+    assertFalse(
+        mockClient
+            .capturedRequest
+            .firstMatchingHeader("User-Agent")
+            .get()
+            .contains("aws-sdk-java"));
+  }
+
+  @Test
   public void testReplacesUserAgent() {
     MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
     UserAgentSdkAsyncHttpClient client =
@@ -70,12 +91,13 @@ public class UserAgentSdkAsyncHttpClientTest {
   public void testTransformsUserAgent() {
     MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
     UserAgentSdkAsyncHttpClient client =
-        new UserAgentSdkAsyncHttpClient(mockClient, userAgent -> userAgent + " app/2");
+        new UserAgentSdkAsyncHttpClient(
+            mockClient, AlternatorUserAgent.transformDefault(userAgent -> userAgent + " app/2"));
 
     client.execute(createRequest(request("aws-sdk-java/2.x")));
 
     assertEquals(
-        "aws-sdk-java/2.x app/2",
+        AlternatorUserAgent.userAgentToken() + " app/2",
         mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
   }
 
@@ -89,6 +111,38 @@ public class UserAgentSdkAsyncHttpClientTest {
 
     assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
     assertEquals("localhost:8043", mockClient.capturedRequest.firstMatchingHeader("Host").get());
+  }
+
+  @Test
+  public void testDefaultUserAgentWithHeaderOptimizationReplacesAwsSdkUserAgent() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    Set<String> whitelist = AlternatorConfig.builder().getRequiredHeaders();
+    SdkAsyncHttpClient client =
+        new HeadersFilteringSdkAsyncHttpClient(
+            new UserAgentSdkAsyncHttpClient(mockClient, AlternatorUserAgent.defaultUserAgent()),
+            whitelist);
+
+    client.execute(createRequest(requestWithSdkMetadata("aws-sdk-java/2.x")));
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+    assertFalse(mockClient.capturedRequest.headers().containsKey("X-Amz-Sdk-Invocation-Id"));
+  }
+
+  @Test
+  public void testDisabledUserAgentWithHeaderOptimizationRemovesAwsSdkUserAgent() {
+    MockSdkAsyncHttpClient mockClient = new MockSdkAsyncHttpClient();
+    Set<String> whitelist =
+        new HashSet<>(AlternatorConfig.builder().withUserAgentEnabled(false).getRequiredHeaders());
+    SdkAsyncHttpClient client =
+        new HeadersFilteringSdkAsyncHttpClient(
+            new UserAgentSdkAsyncHttpClient(mockClient, AlternatorUserAgent.disable()), whitelist);
+
+    client.execute(createRequest(requestWithSdkMetadata("aws-sdk-java/2.x")));
+
+    assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    assertFalse(mockClient.capturedRequest.headers().containsKey("X-Amz-Sdk-Invocation-Id"));
   }
 
   @Test
@@ -148,6 +202,20 @@ public class UserAgentSdkAsyncHttpClientTest {
         .uri(URI.create("https://localhost:8043"))
         .appendHeader("Host", "localhost:8043")
         .appendHeader("User-Agent", userAgent)
+        .build();
+  }
+
+  private SdkHttpRequest requestWithSdkMetadata(String userAgent) {
+    return SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://localhost:8043"))
+        .appendHeader("Host", "localhost:8043")
+        .appendHeader("X-Amz-Target", "DynamoDB_20120810.GetItem")
+        .appendHeader("Content-Type", "application/x-amz-json-1.0")
+        .appendHeader("Content-Length", "123")
+        .appendHeader("Accept-Encoding", "gzip")
+        .appendHeader("User-Agent", userAgent)
+        .appendHeader("X-Amz-Sdk-Invocation-Id", "some-id")
         .build();
   }
 }

--- a/src/test/java/com/scylladb/alternator/UserAgentSdkHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/UserAgentSdkHttpClientTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Test;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
@@ -47,6 +49,26 @@ public class UserAgentSdkHttpClientTest {
   }
 
   @Test
+  public void testDefaultUserAgentReplacesAwsSdkUserAgent() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    UserAgentSdkHttpClient client =
+        new UserAgentSdkHttpClient(mockClient, AlternatorUserAgent.defaultUserAgent());
+
+    client.prepareRequest(
+        HttpExecuteRequest.builder().request(request("aws-sdk-java/2.x")).build());
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+    assertFalse(
+        mockClient
+            .capturedRequest
+            .firstMatchingHeader("User-Agent")
+            .get()
+            .contains("aws-sdk-java"));
+  }
+
+  @Test
   public void testReplacesUserAgent() {
     MockSdkHttpClient mockClient = new MockSdkHttpClient();
     UserAgentSdkHttpClient client =
@@ -63,13 +85,15 @@ public class UserAgentSdkHttpClientTest {
   public void testTransformsUserAgent() {
     MockSdkHttpClient mockClient = new MockSdkHttpClient();
     UserAgentSdkHttpClient client =
-        new UserAgentSdkHttpClient(mockClient, userAgent -> "prefix " + userAgent + " suffix");
+        new UserAgentSdkHttpClient(
+            mockClient,
+            AlternatorUserAgent.transformDefault(userAgent -> "prefix " + userAgent + " suffix"));
 
     client.prepareRequest(
         HttpExecuteRequest.builder().request(request("aws-sdk-java/2.x")).build());
 
     assertEquals(
-        "prefix aws-sdk-java/2.x suffix",
+        "prefix " + AlternatorUserAgent.userAgentToken() + " suffix",
         mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
   }
 
@@ -84,6 +108,40 @@ public class UserAgentSdkHttpClientTest {
 
     assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
     assertEquals("localhost:8043", mockClient.capturedRequest.firstMatchingHeader("Host").get());
+  }
+
+  @Test
+  public void testDefaultUserAgentWithHeaderOptimizationReplacesAwsSdkUserAgent() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    Set<String> whitelist = AlternatorConfig.builder().getRequiredHeaders();
+    SdkHttpClient client =
+        new HeadersFilteringSdkHttpClient(
+            new UserAgentSdkHttpClient(mockClient, AlternatorUserAgent.defaultUserAgent()),
+            whitelist);
+
+    client.prepareRequest(
+        HttpExecuteRequest.builder().request(requestWithSdkMetadata("aws-sdk-java/2.x")).build());
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        mockClient.capturedRequest.firstMatchingHeader("User-Agent").get());
+    assertFalse(mockClient.capturedRequest.headers().containsKey("X-Amz-Sdk-Invocation-Id"));
+  }
+
+  @Test
+  public void testDisabledUserAgentWithHeaderOptimizationRemovesAwsSdkUserAgent() {
+    MockSdkHttpClient mockClient = new MockSdkHttpClient();
+    Set<String> whitelist =
+        new HashSet<>(AlternatorConfig.builder().withUserAgentEnabled(false).getRequiredHeaders());
+    SdkHttpClient client =
+        new HeadersFilteringSdkHttpClient(
+            new UserAgentSdkHttpClient(mockClient, AlternatorUserAgent.disable()), whitelist);
+
+    client.prepareRequest(
+        HttpExecuteRequest.builder().request(requestWithSdkMetadata("aws-sdk-java/2.x")).build());
+
+    assertFalse(mockClient.capturedRequest.headers().containsKey("User-Agent"));
+    assertFalse(mockClient.capturedRequest.headers().containsKey("X-Amz-Sdk-Invocation-Id"));
   }
 
   @Test
@@ -120,6 +178,20 @@ public class UserAgentSdkHttpClientTest {
         .uri(URI.create("https://localhost:8043"))
         .appendHeader("Host", "localhost:8043")
         .appendHeader("User-Agent", userAgent)
+        .build();
+  }
+
+  private SdkHttpRequest requestWithSdkMetadata(String userAgent) {
+    return SdkHttpRequest.builder()
+        .method(SdkHttpMethod.POST)
+        .uri(URI.create("https://localhost:8043"))
+        .appendHeader("Host", "localhost:8043")
+        .appendHeader("X-Amz-Target", "DynamoDB_20120810.GetItem")
+        .appendHeader("Content-Type", "application/x-amz-json-1.0")
+        .appendHeader("Content-Length", "123")
+        .appendHeader("Accept-Encoding", "gzip")
+        .appendHeader("User-Agent", userAgent)
+        .appendHeader("X-Amz-Sdk-Invocation-Id", "some-id")
         .build();
   }
 }


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-560
Follow-up to: https://github.com/scylladb/alternator-client-java/pull/97

## Summary
- Stop appending the Alternator token via AWS SDK `USER_AGENT_SUFFIX`.
- Replace the final SDK-generated `User-Agent` by default with only `scylladb-alternator-client-java/<version>`.
- Make `.withUserAgent(userAgent -> ...)` receive the default Alternator-only value, not the AWS SDK user-agent.
- Keep `.withUserAgent("...")` as an exact replacement and `.withoutUserAgent()` as complete removal.
- Add sync and async tests proving the AWS SDK user-agent does not leak through with or without header optimization.

## User-Agent Behavior
- Default: `scylladb-alternator-client-java/<version>`
- Replace: `.withUserAgent("my-client/1.2.3")` sends exactly `my-client/1.2.3`
- Transform: `.withUserAgent(userAgent -> userAgent + " my-app/4.5.6")` starts from the default Alternator-only value
- Disable: `.withoutUserAgent()` sends no `User-Agent`; with header optimization, it remains removed from the effective required whitelist

## Verification
- `git diff --check`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH mvn -q com.spotify.fmt:fmt-maven-plugin:format`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q -Dtest=UserAgentSdkHttpClientTest,UserAgentSdkAsyncHttpClientTest,AlternatorConfigHeadersTest,HeadersFilteringSdkHttpClientTest,HeadersFilteringSdkAsyncHttpClientTest,AlternatorDynamoDbClientCustomizerTest,AlternatorDynamoDbAsyncClientCustomizerTest test`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH make lint`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q test`
