### PR TITLE
Align BatchWrite key-route affinity routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ DOCKER_COMPOSE_VERSION := 2.34.0
 
 MAVEN_GPG_PASSPHRASE ?=
 MAVEN_OPTS ?=
+FMT_MAVEN_PLUGIN := com.spotify.fmt:fmt-maven-plugin:2.25
 
 SONATYPE_TOKEN_USERNAME ?=
 SONATYPE_TOKEN_PASSWORD ?=
@@ -50,7 +51,7 @@ verify:
 	${mvn} verify
 
 lint:
-	${mvn} com.spotify.fmt:fmt-maven-plugin:check
+	${mvn} ${FMT_MAVEN_PLUGIN}:check
 	${mvn} checkstyle:check
 	${mvn} compile test-compile
 	$(MAKE) lint-docs
@@ -60,7 +61,7 @@ lint-docs:
 	${mvn} javadoc:jar javadoc:aggregate javadoc:aggregate-jar javadoc:resource-bundle
 
 lint-fix:
-	${mvn} com.spotify.fmt:fmt-maven-plugin:format
+	${mvn} ${FMT_MAVEN_PLUGIN}:format
 
 compile:
 	${mvn} compile

--- a/README.md
+++ b/README.md
@@ -755,9 +755,9 @@ Key route affinity is an optimization for Lightweight Transactions (LWT) that us
 consensus. By routing all requests with the same partition key to the same coordinator node,
 it reduces Paxos round-trips and improves latency for conditional writes.
 
-**Note:** Key route affinity only works reliably with synchronous DynamoDB clients
-(`DynamoDbClient`). Do not use it with `DynamoDbAsyncClient` due to cross-thread
-execution limitations.
+**Note:** Synchronous clients automatically discover missing partition-key names via
+`DescribeTable`. Async clients can use key route affinity with pre-configured partition-key
+names; requests for tables without pre-configured metadata fall back to round-robin routing.
 
 #### Quick start
 
@@ -784,8 +784,9 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
 
 #### Pre-configuring partition key names
 
-By default, the library auto-discovers partition key names via `DescribeTable` on first
-use of each table. To avoid this initial lookup, you can pre-configure them:
+For synchronous clients, the library auto-discovers partition key names via `DescribeTable`
+on first use of each table. To avoid this initial lookup, or when using an async client,
+pre-configure them:
 
 ```java
 import com.scylladb.alternator.keyrouting.KeyRouteAffinityConfig;
@@ -806,10 +807,12 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
 #### How it works
 
 1. The `AffinityQueryPlanInterceptor` intercepts each DynamoDB request
-2. For qualifying operations, it extracts the partition key value from the request
+2. For qualifying single-item operations, it extracts the partition key value from the request
 3. A deterministic hash (MurmurHash3) of the partition key selects a consistent node
-4. All requests for the same partition key are routed to the same Alternator node
-5. Non-qualifying operations continue to use round-robin load balancing
+4. For `BatchWriteItem`, each usable write votes for its preferred node; voted nodes are tried by
+   vote count, then by node URL
+5. Non-qualifying operations and requests without usable partition keys continue to use
+   round-robin load balancing
 
 #### When to use key route affinity
 
@@ -821,4 +824,4 @@ Key route affinity is recommended for:
 Key route affinity may not be beneficial for:
 - Read-heavy workloads (reads don't use Paxos)
 - Workloads with uniformly distributed writes across many keys
-- Async clients (use sync clients only)
+- Async clients where partition-key names cannot be pre-configured

--- a/src/main/java/com/scylladb/alternator/internal/LazyQueryPlan.java
+++ b/src/main/java/com/scylladb/alternator/internal/LazyQueryPlan.java
@@ -2,6 +2,7 @@ package com.scylladb.alternator.internal;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -54,6 +55,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
   private final AlternatorLiveNodes liveNodes;
   private final GoRand goRand;
+  private final List<URI> preferredNodes;
 
   /**
    * Mutable list of remaining nodes for pick-and-remove. Initialized lazily on first access when
@@ -82,6 +84,7 @@ public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
     }
     this.liveNodes = liveNodes;
     this.goRand = null;
+    this.preferredNodes = null;
     this.usedNodes = new java.util.HashSet<>();
   }
 
@@ -99,6 +102,26 @@ public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
     }
     this.liveNodes = liveNodes;
     this.goRand = new GoRand(seed);
+    this.preferredNodes = null;
+  }
+
+  /**
+   * Creates a LazyQueryPlan that tries the given preferred nodes first, then the remaining live
+   * nodes in canonical affinity order.
+   *
+   * @param liveNodes the {@link AlternatorLiveNodes} instance to pull nodes from
+   * @param preferredNodes nodes to try first, in preference order
+   */
+  public LazyQueryPlan(AlternatorLiveNodes liveNodes, List<URI> preferredNodes) {
+    if (liveNodes == null) {
+      throw new IllegalArgumentException("liveNodes cannot be null");
+    }
+    if (preferredNodes == null) {
+      throw new IllegalArgumentException("preferredNodes cannot be null");
+    }
+    this.liveNodes = liveNodes;
+    this.goRand = null;
+    this.preferredNodes = new ArrayList<>(preferredNodes);
   }
 
   /**
@@ -107,9 +130,56 @@ public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
    */
   private void ensureInitialized() {
     if (!initialized) {
-      remaining = new ArrayList<>(liveNodes.getLiveNodesInternal());
+      remaining = sortedAffinityNodes(liveNodes);
+      if (preferredNodes != null) {
+        remaining = orderPreferredNodesFirst(remaining, preferredNodes);
+      }
       initialized = true;
     }
+  }
+
+  /**
+   * Returns the current live nodes in the canonical order used by affinity routing.
+   *
+   * @param liveNodes the live nodes manager
+   * @return a sorted copy of current live nodes
+   */
+  public static List<URI> sortedAffinityNodes(AlternatorLiveNodes liveNodes) {
+    if (liveNodes == null) {
+      throw new IllegalArgumentException("liveNodes cannot be null");
+    }
+    List<URI> nodes = new ArrayList<>(liveNodes.getLiveNodesInternal());
+    nodes.sort(Comparator.comparing(URI::toString));
+    return nodes;
+  }
+
+  /**
+   * Returns the first node selected by the seeded affinity plan without consuming a full query
+   * plan.
+   *
+   * @param liveNodes the live nodes manager
+   * @param seed deterministic seed
+   * @return the preferred node, or null when no live nodes exist
+   */
+  public static URI preferredNodeForHash(AlternatorLiveNodes liveNodes, long seed) {
+    List<URI> nodes = sortedAffinityNodes(liveNodes);
+    if (nodes.isEmpty()) {
+      return null;
+    }
+    return nodes.get(new GoRand(seed).intn(nodes.size()));
+  }
+
+  private static List<URI> orderPreferredNodesFirst(List<URI> sortedNodes, List<URI> preferred) {
+    List<URI> ordered = new ArrayList<>(sortedNodes.size());
+    List<URI> remainingNodes = new ArrayList<>(sortedNodes);
+    for (URI preferredNode : preferred) {
+      int index = remainingNodes.indexOf(preferredNode);
+      if (index >= 0) {
+        ordered.add(remainingNodes.remove(index));
+      }
+    }
+    ordered.addAll(remainingNodes);
+    return ordered;
   }
 
   /**
@@ -160,7 +230,7 @@ public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
 
   @Override
   public boolean hasNext() {
-    if (goRand != null) {
+    if (goRand != null || preferredNodes != null) {
       ensureInitialized();
       return !remaining.isEmpty();
     }
@@ -175,6 +245,14 @@ public class LazyQueryPlan implements Iterator<URI>, Iterable<URI> {
         throw new NoSuchElementException("No more nodes available in query plan");
       }
       return node;
+    }
+
+    if (preferredNodes != null) {
+      ensureInitialized();
+      if (remaining.isEmpty()) {
+        throw new NoSuchElementException("No more nodes available in query plan");
+      }
+      return remaining.remove(0);
     }
 
     URI node = computeNextNonSeeded();

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifier.java
@@ -2,10 +2,8 @@ package com.scylladb.alternator.keyrouting;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -221,16 +219,13 @@ public final class KeyAffinityRequestClassifier {
   }
 
   /**
-   * Extracts BatchWriteItem routing targets in a deterministic cross-language order.
+   * Extracts BatchWriteItem routing targets.
    *
-   * <p>The ordering key is {@code (tableName, canonicalAttributes, operation)}, where
-   * canonicalAttributes is a no-whitespace JSON representation with sorted map keys. This matches
-   * the Rust and Go implementations so the same positive BatchWriteItem workload selects the same
-   * partition key before hashing.
+   * <p>All usable targets contribute to BatchWriteItem affinity routing. The routing decision must
+   * not depend on the order returned here, non-key attributes, or SDK map iteration order.
    *
    * @param request the BatchWriteItem request
-   * @return deterministic routing candidates; empty when the request has no
-   *     PutRequest/DeleteRequest
+   * @return routing candidates; empty when the request has no PutRequest/DeleteRequest
    */
   public static List<BatchWriteRoutingTarget> extractBatchWriteRoutingTargets(
       BatchWriteItemRequest request) {
@@ -247,19 +242,12 @@ public final class KeyAffinityRequestClassifier {
       for (WriteRequest write : writes) {
         if (write.putRequest() != null) {
           candidates.add(
-              new BatchWriteRoutingTarget(
-                  entry.getKey(),
-                  write.putRequest().item(),
-                  "PutRequest",
-                  canonicalAttributeValues(write.putRequest().item())));
+              new BatchWriteRoutingTarget(entry.getKey(), write.putRequest().item(), "PutRequest"));
         }
         if (write.deleteRequest() != null) {
           candidates.add(
               new BatchWriteRoutingTarget(
-                  entry.getKey(),
-                  write.deleteRequest().key(),
-                  "DeleteRequest",
-                  canonicalAttributeValues(write.deleteRequest().key())));
+                  entry.getKey(), write.deleteRequest().key(), "DeleteRequest"));
         }
       }
     }
@@ -267,182 +255,7 @@ public final class KeyAffinityRequestClassifier {
     if (candidates.isEmpty()) {
       return Collections.emptyList();
     }
-
-    candidates.sort(
-        Comparator.comparing((BatchWriteRoutingTarget target) -> target.tableName)
-            .thenComparing(target -> target.canonicalAttributes)
-            .thenComparing(target -> target.operation));
     return Collections.unmodifiableList(candidates);
-  }
-
-  private static String canonicalAttributeValues(Map<String, AttributeValue> values) {
-    if (values == null || values.isEmpty()) {
-      return "{}";
-    }
-
-    List<String> keys = new ArrayList<>(values.keySet());
-    Collections.sort(keys);
-
-    StringBuilder builder = new StringBuilder();
-    builder.append('{');
-    for (int i = 0; i < keys.size(); i++) {
-      if (i > 0) {
-        builder.append(',');
-      }
-      String key = keys.get(i);
-      builder.append(quote(key));
-      builder.append(':');
-      appendCanonicalAttributeValue(builder, values.get(key));
-    }
-    builder.append('}');
-    return builder.toString();
-  }
-
-  private static void appendCanonicalAttributeValue(StringBuilder builder, AttributeValue value) {
-    if (value == null) {
-      builder.append("{\"UNKNOWN\":true}");
-      return;
-    }
-    if (value.s() != null) {
-      appendTaggedJsonString(builder, "S", value.s());
-      return;
-    }
-    if (value.n() != null) {
-      appendTaggedJsonString(builder, "N", value.n());
-      return;
-    }
-    if (value.b() != null) {
-      builder.append("{\"B\":{\"__bytes__\":\"");
-      appendHex(builder, value.b().asByteArray());
-      builder.append("\"}}");
-      return;
-    }
-    if (value.bool() != null) {
-      builder.append("{\"BOOL\":").append(value.bool() ? "true" : "false").append('}');
-      return;
-    }
-    if (value.nul() != null) {
-      builder.append("{\"NULL\":").append(value.nul() ? "true" : "false").append('}');
-      return;
-    }
-    if (value.hasSs()) {
-      appendTaggedJsonStringList(builder, "SS", value.ss());
-      return;
-    }
-    if (value.hasNs()) {
-      appendTaggedJsonStringList(builder, "NS", value.ns());
-      return;
-    }
-    if (value.hasBs()) {
-      builder.append("{\"BS\":[");
-      int i = 0;
-      for (SdkBytes bytes : value.bs()) {
-        if (i > 0) {
-          builder.append(',');
-        }
-        builder.append("{\"__bytes__\":\"");
-        appendHex(builder, bytes.asByteArray());
-        builder.append("\"}");
-        i++;
-      }
-      builder.append("]}");
-      return;
-    }
-    if (value.hasL()) {
-      builder.append("{\"L\":[");
-      int i = 0;
-      for (AttributeValue item : value.l()) {
-        if (i > 0) {
-          builder.append(',');
-        }
-        appendCanonicalAttributeValue(builder, item);
-        i++;
-      }
-      builder.append("]}");
-      return;
-    }
-    if (value.hasM()) {
-      builder.append("{\"M\":");
-      builder.append(canonicalAttributeValues(value.m()));
-      builder.append('}');
-      return;
-    }
-    builder.append("{\"UNKNOWN\":true}");
-  }
-
-  private static void appendTaggedJsonString(StringBuilder builder, String tag, String value) {
-    builder.append("{\"").append(tag).append("\":");
-    builder.append(quote(value));
-    builder.append('}');
-  }
-
-  private static void appendTaggedJsonStringList(
-      StringBuilder builder, String tag, List<String> values) {
-    builder.append("{\"").append(tag).append("\":[");
-    for (int i = 0; i < values.size(); i++) {
-      if (i > 0) {
-        builder.append(',');
-      }
-      builder.append(quote(values.get(i)));
-    }
-    builder.append("]}");
-  }
-
-  private static void appendHex(StringBuilder builder, byte[] bytes) {
-    final char[] hex = "0123456789abcdef".toCharArray();
-    for (byte value : bytes) {
-      builder.append(hex[(value >> 4) & 0x0f]);
-      builder.append(hex[value & 0x0f]);
-    }
-  }
-
-  private static String quote(String value) {
-    StringBuilder builder = new StringBuilder();
-    builder.append('"');
-    for (int i = 0; i < value.length(); i++) {
-      char c = value.charAt(i);
-      switch (c) {
-        case '\\':
-          builder.append("\\\\");
-          break;
-        case '"':
-          builder.append("\\\"");
-          break;
-        case '\b':
-          builder.append("\\b");
-          break;
-        case '\f':
-          builder.append("\\f");
-          break;
-        case '\n':
-          builder.append("\\n");
-          break;
-        case '\r':
-          builder.append("\\r");
-          break;
-        case '\t':
-          builder.append("\\t");
-          break;
-        default:
-          if (c <= 0x1f) {
-            builder.append("\\u");
-            appendHex4(builder, c);
-          } else {
-            builder.append(c);
-          }
-          break;
-      }
-    }
-    builder.append('"');
-    return builder.toString();
-  }
-
-  private static void appendHex4(StringBuilder builder, char value) {
-    final char[] hex = "0123456789abcdef".toCharArray();
-    builder.append(hex[(value >> 12) & 0x0f]);
-    builder.append(hex[(value >> 8) & 0x0f]);
-    builder.append(hex[(value >> 4) & 0x0f]);
-    builder.append(hex[value & 0x0f]);
   }
 
   /** Deterministic BatchWriteItem routing candidate. */
@@ -450,17 +263,12 @@ public final class KeyAffinityRequestClassifier {
     private final String tableName;
     private final Map<String, AttributeValue> values;
     private final String operation;
-    private final String canonicalAttributes;
 
     private BatchWriteRoutingTarget(
-        String tableName,
-        Map<String, AttributeValue> values,
-        String operation,
-        String canonicalAttributes) {
+        String tableName, Map<String, AttributeValue> values, String operation) {
       this.tableName = tableName;
       this.values = values;
       this.operation = operation;
-      this.canonicalAttributes = canonicalAttributes;
     }
 
     /**
@@ -488,15 +296,6 @@ public final class KeyAffinityRequestClassifier {
      */
     public String operation() {
       return operation;
-    }
-
-    /**
-     * Returns the canonical JSON attributes used for deterministic candidate ordering.
-     *
-     * @return the canonical JSON attributes
-     */
-    public String canonicalAttributes() {
-      return canonicalAttributes;
     }
 
     /**

--- a/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityConfig.java
+++ b/src/main/java/com/scylladb/alternator/keyrouting/KeyRouteAffinityConfig.java
@@ -11,10 +11,10 @@ import java.util.Map;
  * table. If partition key info is not provided for a table, it will be discovered automatically via
  * DescribeTable.
  *
- * <p><strong>Important:</strong> Key route affinity only works reliably with synchronous DynamoDB
- * clients ({@link software.amazon.awssdk.services.dynamodb.DynamoDbClient}). With async clients,
- * the ThreadLocal-based context passing mechanism may fail due to cross-thread execution. Do not
- * use key route affinity with {@link software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient}.
+ * <p><strong>Important:</strong> Automatic partition-key discovery uses a synchronous {@link
+ * software.amazon.awssdk.services.dynamodb.DynamoDbClient}. Synchronous Alternator clients wire
+ * discovery automatically. Async clients can use key route affinity when partition-key names are
+ * pre-configured via {@link Builder#withPkInfo(String, String)}.
  *
  * <p>Example usage:
  *

--- a/src/main/java/com/scylladb/alternator/queryplan/AffinityQueryPlanInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/queryplan/AffinityQueryPlanInterceptor.java
@@ -7,6 +7,12 @@ import com.scylladb.alternator.keyrouting.KeyAffinityRequestClassifier;
 import com.scylladb.alternator.keyrouting.KeyAffinityRequestClassifier.BatchWriteRoutingTarget;
 import com.scylladb.alternator.keyrouting.KeyRouteAffinityConfig;
 import com.scylladb.alternator.keyrouting.PartitionKeyResolver;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -124,11 +130,17 @@ public class AffinityQueryPlanInterceptor extends BasicQueryPlanInterceptor {
     }
 
     // Hash the partition key and create a deterministic query plan
-    long hash = AttributeValueHasher.hash(pkValue);
-    return new LazyQueryPlan(liveNodes, hash);
+    try {
+      long hash = AttributeValueHasher.hash(pkValue);
+      return new LazyQueryPlan(liveNodes, hash);
+    } catch (IllegalArgumentException e) {
+      // Unsupported partition-key shapes cannot be routed by key affinity.
+      return null;
+    }
   }
 
   private LazyQueryPlan getBatchWriteQueryPlan(BatchWriteItemRequest request) {
+    Map<URI, Integer> votes = new HashMap<>();
     for (BatchWriteRoutingTarget target :
         KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request)) {
       String tableName = target.tableName();
@@ -137,7 +149,7 @@ public class AffinityQueryPlanInterceptor extends BasicQueryPlanInterceptor {
         if (clientForDiscovery != null) {
           pkResolver.triggerDiscovery(tableName, clientForDiscovery);
         }
-        return null;
+        continue;
       }
 
       AttributeValue pkValue = target.partitionKeyValue(pkName);
@@ -147,12 +159,34 @@ public class AffinityQueryPlanInterceptor extends BasicQueryPlanInterceptor {
 
       try {
         long hash = AttributeValueHasher.hash(pkValue);
-        return new LazyQueryPlan(liveNodes, hash);
+        URI preferredNode = LazyQueryPlan.preferredNodeForHash(liveNodes, hash);
+        if (preferredNode == null) {
+          return null;
+        }
+        votes.merge(preferredNode, 1, Integer::sum);
       } catch (IllegalArgumentException e) {
         // Unsupported partition-key shapes cannot be routed by key affinity.
       }
     }
-    return null;
+    List<URI> preferredNodes = votePreferenceOrder(votes);
+    if (preferredNodes.isEmpty()) {
+      return null;
+    }
+    return new LazyQueryPlan(liveNodes, preferredNodes);
+  }
+
+  private static List<URI> votePreferenceOrder(Map<URI, Integer> votes) {
+    List<Map.Entry<URI, Integer>> votedNodes = new ArrayList<>(votes.entrySet());
+    votedNodes.sort(
+        Comparator.<Map.Entry<URI, Integer>, Integer>comparing(Map.Entry::getValue)
+            .reversed()
+            .thenComparing(entry -> entry.getKey().toString()));
+
+    List<URI> preferredNodes = new ArrayList<>(votedNodes.size());
+    for (Map.Entry<URI, Integer> entry : votedNodes) {
+      preferredNodes.add(entry.getKey());
+    }
+    return preferredNodes;
   }
 
   @Override

--- a/src/test/java/com/scylladb/alternator/AffinityQueryPlanInterceptorTest.java
+++ b/src/test/java/com/scylladb/alternator/AffinityQueryPlanInterceptorTest.java
@@ -1620,12 +1620,50 @@ public class AffinityQueryPlanInterceptorTest {
   }
 
   @Test
-  public void testBatchWriteItemReorderedWritesRouteDeterministically() {
-    String selectedPk = "a-route";
-    String otherPk = findPkValueWithDifferentRoute("z-route-", selectedPk);
+  public void testBatchWriteItemMajorityPreferredNodeWins() {
+    String majorityPk = PK_VALUE;
+    String otherPk = findPkValueWithDifferentRoute("other-route-", majorityPk);
     DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
     try {
-      Map<String, List<WriteRequest>> firstRequestItems = new HashMap<>();
+      Map<String, List<WriteRequest>> requestItems = new LinkedHashMap<>();
+      requestItems.put(
+          TABLE_NAME,
+          Arrays.asList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(otherPk)).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(majorityPk)).build())
+                  .build(),
+              WriteRequest.builder()
+                  .deleteRequest(DeleteRequest.builder().key(makeKey()).build())
+                  .build()));
+
+      URI expectedRoute = firstAffinityRouteForPk(majorityPk);
+
+      mockHttpClient.clearCapturedRequests();
+      client.batchWriteItem(BatchWriteItemRequest.builder().requestItems(requestItems).build());
+      URI actualRoute = mockHttpClient.getLastRequestUri();
+
+      assertSameRoute(
+          "BatchWrite should route to the majority preferred node", expectedRoute, actualRoute);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testBatchWriteItemNonKeyAttributesDoNotAffectRouting() {
+    String majorityPk = PK_VALUE;
+    String otherPk = findPkValueWithDifferentRoute("other-route-", majorityPk);
+    DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
+    try {
+      Map<String, AttributeValue> majorityA = makeItem(majorityPk);
+      majorityA.put("data", AttributeValue.builder().s("alpha").build());
+      Map<String, AttributeValue> majorityB = makeItem(majorityPk);
+      majorityB.put("data", AttributeValue.builder().s("zeta").build());
+
+      Map<String, List<WriteRequest>> firstRequestItems = new LinkedHashMap<>();
       firstRequestItems.put(
           TABLE_NAME,
           Arrays.asList(
@@ -1633,21 +1671,30 @@ public class AffinityQueryPlanInterceptorTest {
                   .putRequest(PutRequest.builder().item(makeItem(otherPk)).build())
                   .build(),
               WriteRequest.builder()
-                  .putRequest(PutRequest.builder().item(makeItem(selectedPk)).build())
+                  .putRequest(PutRequest.builder().item(majorityA).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(majorityB).build())
                   .build()));
 
-      Map<String, List<WriteRequest>> secondRequestItems = new HashMap<>();
+      Map<String, AttributeValue> majorityC = makeItem(majorityPk);
+      majorityC.put("data", AttributeValue.builder().s("middle").build());
+      Map<String, AttributeValue> majorityD = makeItem(majorityPk);
+      majorityD.put("data", AttributeValue.builder().s("beta").build());
+
+      Map<String, List<WriteRequest>> secondRequestItems = new LinkedHashMap<>();
       secondRequestItems.put(
           TABLE_NAME,
           Arrays.asList(
               WriteRequest.builder()
-                  .putRequest(PutRequest.builder().item(makeItem(selectedPk)).build())
+                  .putRequest(PutRequest.builder().item(majorityC).build())
                   .build(),
               WriteRequest.builder()
                   .putRequest(PutRequest.builder().item(makeItem(otherPk)).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(majorityD).build())
                   .build()));
-
-      URI expectedRoute = firstAffinityRouteForPk(selectedPk);
 
       mockHttpClient.clearCapturedRequests();
       client.batchWriteItem(
@@ -1659,14 +1706,152 @@ public class AffinityQueryPlanInterceptorTest {
           BatchWriteItemRequest.builder().requestItems(secondRequestItems).build());
       URI secondRoute = mockHttpClient.getLastRequestUri();
 
+      URI expectedRoute = firstAffinityRouteForPk(majorityPk);
       assertSameRoute(
-          "First request should route by deterministic BatchWrite target",
-          expectedRoute,
-          firstRoute);
+          "First request should route by partition-key votes", expectedRoute, firstRoute);
       assertSameRoute(
-          "Second request should route by deterministic BatchWrite target",
-          expectedRoute,
-          secondRoute);
+          "Second request should route by partition-key votes", expectedRoute, secondRoute);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testBatchWriteItemMissingMetadataContinuesWithUsableCandidate() {
+    KeyRouteAffinityConfig config =
+        KeyRouteAffinityConfig.builder()
+            .withType(KeyRouteAffinity.ANY_WRITE)
+            .withPkInfo(TABLE_NAME, PK_NAME)
+            .build();
+    DynamoDbClient client = createClient(config);
+    try {
+      Map<String, List<WriteRequest>> requestItems = new LinkedHashMap<>();
+      requestItems.put(
+          "unknown_table",
+          Collections.singletonList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem("unknown-pk")).build())
+                  .build()));
+      requestItems.put(
+          TABLE_NAME,
+          Collections.singletonList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(PK_VALUE)).build())
+                  .build()));
+
+      URI expectedRoute = firstAffinityRouteForPk(PK_VALUE);
+
+      mockHttpClient.clearCapturedRequests();
+      client.batchWriteItem(BatchWriteItemRequest.builder().requestItems(requestItems).build());
+      URI actualRoute = mockHttpClient.getLastRequestUri();
+
+      assertSameRoute(
+          "BatchWrite should continue after missing table metadata", expectedRoute, actualRoute);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testBatchWriteItemSkipsMissingAndUnsupportedPartitionKeys() {
+    DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
+    try {
+      Map<String, AttributeValue> missingPk = new HashMap<>();
+      missingPk.put("data", AttributeValue.builder().s("missing").build());
+      Map<String, AttributeValue> unsupportedPk = new HashMap<>();
+      unsupportedPk.put(PK_NAME, AttributeValue.builder().bool(true).build());
+
+      Map<String, List<WriteRequest>> requestItems = new LinkedHashMap<>();
+      requestItems.put(
+          TABLE_NAME,
+          Arrays.asList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(missingPk).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(unsupportedPk).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(PK_VALUE)).build())
+                  .build()));
+
+      URI expectedRoute = firstAffinityRouteForPk(PK_VALUE);
+
+      mockHttpClient.clearCapturedRequests();
+      client.batchWriteItem(BatchWriteItemRequest.builder().requestItems(requestItems).build());
+      URI actualRoute = mockHttpClient.getLastRequestUri();
+
+      assertSameRoute(
+          "BatchWrite should route by the supported candidate", expectedRoute, actualRoute);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testBatchWriteItemTieUsesLexicographicNodeOrder() {
+    String firstPk = PK_VALUE;
+    String secondPk = findPkValueWithDifferentRoute("tie-route-", firstPk);
+    URI firstRoute = firstAffinityRouteForPk(firstPk);
+    URI secondRoute = firstAffinityRouteForPk(secondPk);
+    URI expectedRoute =
+        firstRoute.toString().compareTo(secondRoute.toString()) <= 0 ? firstRoute : secondRoute;
+
+    DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
+    try {
+      Map<String, List<WriteRequest>> requestItems = new LinkedHashMap<>();
+      requestItems.put(
+          TABLE_NAME,
+          Arrays.asList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(firstPk)).build())
+                  .build(),
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(makeItem(secondPk)).build())
+                  .build()));
+
+      mockHttpClient.clearCapturedRequests();
+      client.batchWriteItem(BatchWriteItemRequest.builder().requestItems(requestItems).build());
+      URI actualRoute = mockHttpClient.getLastRequestUri();
+
+      assertSameRoute("Tied votes should use lexicographic node order", expectedRoute, actualRoute);
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testBatchWriteItemNoUsableCandidatesFallsBackToRoundRobin() {
+    DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
+    try {
+      Map<String, AttributeValue> unsupportedPk = new HashMap<>();
+      unsupportedPk.put(PK_NAME, AttributeValue.builder().bool(true).build());
+      Map<String, List<WriteRequest>> requestItems = new LinkedHashMap<>();
+      requestItems.put(
+          TABLE_NAME,
+          Collections.singletonList(
+              WriteRequest.builder()
+                  .putRequest(PutRequest.builder().item(unsupportedPk).build())
+                  .build()));
+
+      assertRoundRobinRouting(
+          () ->
+              client.batchWriteItem(
+                  BatchWriteItemRequest.builder().requestItems(requestItems).build()));
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testPutItemUnsupportedPartitionKeyTypeFallsBackToRoundRobin() {
+    DynamoDbClient client = createClient(buildConfig(KeyRouteAffinity.ANY_WRITE));
+    try {
+      Map<String, AttributeValue> item = new HashMap<>();
+      item.put(PK_NAME, AttributeValue.builder().bool(true).build());
+
+      assertRoundRobinRouting(
+          () -> client.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item).build()));
     } finally {
       client.close();
     }

--- a/src/test/java/com/scylladb/alternator/LazyQueryPlanCrossLanguageTest.java
+++ b/src/test/java/com/scylladb/alternator/LazyQueryPlanCrossLanguageTest.java
@@ -16,8 +16,8 @@ import org.junit.Test;
  * implementation for the same seed values. This is critical for key route affinity, where all
  * client implementations must route the same partition key to the same coordinator node.
  *
- * <p>Test vectors are generated from the Go implementation using Go's math/rand PRNG with
- * pick-and-remove selection.
+ * <p>Test vectors are generated using Go's math/rand PRNG with pick-and-remove selection over the
+ * canonical lexicographic live-node order.
  *
  * <p>Node naming convention: active nodes are node1.example.com:8043 through
  * node{N}.example.com:8043, quarantined nodes are quarantined1.example.com:8043 through
@@ -65,7 +65,7 @@ public class LazyQueryPlanCrossLanguageTest {
     AlternatorLiveNodes liveNodes = createLiveNodes(10, 0);
     LazyQueryPlan plan = new LazyQueryPlan(liveNodes, 42L);
     List<String> actual = getSequence(plan, 6);
-    assertEquals(Arrays.asList("node6", "node9", "node5", "node2", "node7", "node1"), actual);
+    assertEquals(Arrays.asList("node5", "node8", "node4", "node10", "node6", "node1"), actual);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class LazyQueryPlanCrossLanguageTest {
     AlternatorLiveNodes liveNodes = createLiveNodes(10, 0);
     LazyQueryPlan plan = new LazyQueryPlan(liveNodes, 123L);
     List<String> actual = getSequence(plan, 6);
-    assertEquals(Arrays.asList("node6", "node1", "node4", "node3", "node10", "node5"), actual);
+    assertEquals(Arrays.asList("node5", "node1", "node3", "node2", "node9", "node4"), actual);
   }
 
   @Test
@@ -81,7 +81,7 @@ public class LazyQueryPlanCrossLanguageTest {
     AlternatorLiveNodes liveNodes = createLiveNodes(10, 0);
     LazyQueryPlan plan = new LazyQueryPlan(liveNodes, 999L);
     List<String> actual = getSequence(plan, 6);
-    assertEquals(Arrays.asList("node5", "node10", "node4", "node1", "node2", "node3"), actual);
+    assertEquals(Arrays.asList("node4", "node9", "node3", "node1", "node10", "node2"), actual);
   }
 
   @Test
@@ -89,7 +89,7 @@ public class LazyQueryPlanCrossLanguageTest {
     AlternatorLiveNodes liveNodes = createLiveNodes(10, 0);
     LazyQueryPlan plan = new LazyQueryPlan(liveNodes, 0L);
     List<String> actual = getSequence(plan, 6);
-    assertEquals(Arrays.asList("node5", "node1", "node2", "node10", "node6", "node8"), actual);
+    assertEquals(Arrays.asList("node4", "node1", "node10", "node9", "node5", "node7"), actual);
   }
 
   @Test
@@ -97,7 +97,7 @@ public class LazyQueryPlanCrossLanguageTest {
     AlternatorLiveNodes liveNodes = createLiveNodes(10, 0);
     LazyQueryPlan plan = new LazyQueryPlan(liveNodes, -1L);
     List<String> actual = getSequence(plan, 6);
-    assertEquals(Arrays.asList("node2", "node5", "node1", "node3", "node6", "node10"), actual);
+    assertEquals(Arrays.asList("node10", "node4", "node1", "node2", "node5", "node9"), actual);
   }
 
   @Test
@@ -113,7 +113,7 @@ public class LazyQueryPlanCrossLanguageTest {
     AlternatorLiveNodes liveNodes = createLiveNodes(10, 0);
     LazyQueryPlan plan = new LazyQueryPlan(liveNodes, 12345L);
     List<String> actual = getSequence(plan, 6);
-    assertEquals(Arrays.asList("node4", "node5", "node1", "node7", "node6", "node8"), actual);
+    assertEquals(Arrays.asList("node3", "node4", "node1", "node6", "node5", "node7"), actual);
   }
 
   @Test
@@ -121,6 +121,6 @@ public class LazyQueryPlanCrossLanguageTest {
     AlternatorLiveNodes liveNodes = createLiveNodes(10, 0);
     LazyQueryPlan plan = new LazyQueryPlan(liveNodes, Long.MAX_VALUE);
     List<String> actual = getSequence(plan, 6);
-    assertEquals(Arrays.asList("node2", "node7", "node8", "node1", "node10", "node4"), actual);
+    assertEquals(Arrays.asList("node10", "node6", "node7", "node1", "node9", "node3"), actual);
   }
 }

--- a/src/test/java/com/scylladb/alternator/LazyQueryPlanTest.java
+++ b/src/test/java/com/scylladb/alternator/LazyQueryPlanTest.java
@@ -209,4 +209,50 @@ public class LazyQueryPlanTest {
     assertEquals("For-each should iterate all nodes", nodes.size(), collectedNodes.size());
     assertEquals("For-each should return all nodes", new HashSet<>(nodes), collectedNodes);
   }
+
+  @Test
+  public void testPreferredNodesAreReturnedBeforeSortedRemaining() {
+    LazyQueryPlan plan = new LazyQueryPlan(liveNodes, Arrays.asList(nodes.get(2), nodes.get(4)));
+
+    List<URI> actual = new ArrayList<>();
+    while (plan.hasNext()) {
+      actual.add(plan.next());
+    }
+
+    assertEquals(
+        Arrays.asList(nodes.get(2), nodes.get(4), nodes.get(0), nodes.get(1), nodes.get(3)),
+        actual);
+  }
+
+  @Test
+  public void testSeededAffinityUsesSortedNodeOrder() throws URISyntaxException {
+    List<URI> unsortedNodes =
+        Arrays.asList(
+            new URI("http", null, "node3.example.com", 8000, null, null, null),
+            new URI("http", null, "node1.example.com", 8000, null, null, null),
+            new URI("http", null, "node2.example.com", 8000, null, null, null));
+    AlternatorLiveNodes unsortedLiveNodes =
+        new AlternatorLiveNodes(unsortedNodes, "http", 8000, "", "");
+    AlternatorLiveNodes sortedLiveNodes =
+        new AlternatorLiveNodes(
+            Arrays.asList(unsortedNodes.get(1), unsortedNodes.get(2), unsortedNodes.get(0)),
+            "http",
+            8000,
+            "",
+            "");
+
+    LazyQueryPlan unsortedPlan = new LazyQueryPlan(unsortedLiveNodes, 42L);
+    LazyQueryPlan sortedPlan = new LazyQueryPlan(sortedLiveNodes, 42L);
+
+    List<URI> unsortedSequence = new ArrayList<>();
+    List<URI> sortedSequence = new ArrayList<>();
+    while (unsortedPlan.hasNext()) {
+      unsortedSequence.add(unsortedPlan.next());
+    }
+    while (sortedPlan.hasNext()) {
+      sortedSequence.add(sortedPlan.next());
+    }
+
+    assertEquals(sortedSequence, unsortedSequence);
+  }
 }

--- a/src/test/java/com/scylladb/alternator/keyrouting/BatchWriteItemKeyRouteAffinityCrossLanguageTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/BatchWriteItemKeyRouteAffinityCrossLanguageTest.java
@@ -1,7 +1,7 @@
 package com.scylladb.alternator.keyrouting;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.scylladb.alternator.internal.AlternatorLiveNodes;
 import com.scylladb.alternator.internal.LazyQueryPlan;
@@ -11,6 +11,7 @@ import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,100 +23,109 @@ import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutRequest;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
-/** Cross-language BatchWriteItem route-affinity vectors shared with Rust and Go. */
+/** BatchWriteItem route-affinity vectors for the shared vote-preference algorithm. */
 public class BatchWriteItemKeyRouteAffinityCrossLanguageTest {
 
   @Test
-  public void testBatchWriteItemKeyRouteAffinityCrossLanguageVectors() throws URISyntaxException {
-    for (BatchWriteVector vector : vectors()) {
-      List<BatchWriteRoutingTarget> targets =
-          KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(vector.request);
-      assertFalse(vector.name, targets.isEmpty());
+  public void testBatchWriteItemTargetsExposePutItemsAndDeleteKeys() {
+    BatchWriteItemRequest request =
+        batchWrite(
+            table(
+                "orders",
+                put(attrs("pk", s("put-key"), "data", s("value"))),
+                delete(attrs("pk", s("delete-key")))));
 
-      BatchWriteRoutingTarget target = targets.get(0);
-      assertEquals(vector.name, vector.tableName, target.tableName());
-      assertEquals(vector.name, vector.operation, target.operation());
-      assertEquals(vector.name, vector.canonical, target.canonicalAttributes());
+    List<BatchWriteRoutingTarget> targets =
+        KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request);
 
-      String pkName = vector.pkInfo.get(target.tableName());
-      AttributeValue pkValue = target.partitionKeyValue(pkName);
-      assertEquals(vector.name, vector.pkLabel, attributeLabel(pkValue));
-
-      long hash = batchWriteHash(vector.request, vector.pkInfo);
-      assertEquals(vector.name, vector.hashSigned, hash);
-      assertEquals(vector.name, vector.hashUnsigned, Long.toUnsignedString(hash));
-      assertEquals(vector.name, vector.firstSixNodes, nodeSequence(hash, 6));
-    }
+    assertEquals(2, targets.size());
+    assertEquals("orders", targets.get(0).tableName());
+    assertEquals("PutRequest", targets.get(0).operation());
+    assertEquals("put-key", targets.get(0).partitionKeyValue("pk").s());
+    assertEquals("orders", targets.get(1).tableName());
+    assertEquals("DeleteRequest", targets.get(1).operation());
+    assertEquals("delete-key", targets.get(1).partitionKeyValue("pk").s());
   }
 
-  private static List<BatchWriteVector> vectors() {
-    return Arrays.asList(
-        new BatchWriteVector(
-            "same_table_write_order",
-            batchWrite(
-                table("orders", put(attrs("pk", s("order456"))), put(attrs("pk", s("order123"))))),
-            pkInfo("orders", "pk"),
-            "orders",
-            "PutRequest",
-            "S:order123",
-            "{\"pk\":{\"S\":\"order123\"}}",
-            -2126891002421145093L,
-            "16319853071288406523",
-            Arrays.asList("node9", "node2", "node10", "node8", "node7", "node5")),
-        new BatchWriteVector(
-            "multi_table_order",
-            batchWrite(
-                table("sessions", delete(attrs("pk", s("session123")))),
-                table(
-                    "orders",
-                    put(attrs("data", s("value"), "pk", s("order456"))),
-                    put(attrs("pk", s("order123"), "data", s("value"))))),
-            pkInfo("orders", "pk", "sessions", "pk"),
-            "orders",
-            "PutRequest",
-            "S:order123",
-            "{\"data\":{\"S\":\"value\"},\"pk\":{\"S\":\"order123\"}}",
-            -2126891002421145093L,
-            "16319853071288406523",
-            Arrays.asList("node9", "node2", "node10", "node8", "node7", "node5")),
-        new BatchWriteVector(
-            "delete_put_same_attributes",
-            batchWrite(
-                table("orders", put(attrs("pk", s("same"))), delete(attrs("pk", s("same"))))),
-            pkInfo("orders", "pk"),
-            "orders",
-            "DeleteRequest",
-            "S:same",
-            "{\"pk\":{\"S\":\"same\"}}",
-            -4879317772220196571L,
-            "13567426301489355045",
-            Arrays.asList("node1", "node3", "node10", "node7", "node4", "node5")),
-        new BatchWriteVector(
-            "number_partition_key",
-            batchWrite(table("accounts", put(attrs("pk", n("7"))), put(attrs("pk", n("42"))))),
-            pkInfo("accounts", "pk"),
-            "accounts",
-            "PutRequest",
-            "N:42",
-            "{\"pk\":{\"N\":\"42\"}}",
-            -5061732451827723051L,
-            "13385011621881828565",
-            Arrays.asList("node3", "node7", "node1", "node10", "node2", "node5")),
-        new BatchWriteVector(
-            "binary_partition_key",
-            batchWrite(
-                table(
-                    "blobs",
-                    put(attrs("pk", b(0x01, 0x02, 0x03))),
-                    delete(attrs("pk", b(0x00, 0xff))))),
-            pkInfo("blobs", "pk"),
-            "blobs",
-            "DeleteRequest",
-            "B:00ff",
-            "{\"pk\":{\"B\":{\"__bytes__\":\"00ff\"}}}",
-            -4376945693382523102L,
-            "14069798380327028514",
-            Arrays.asList("node7", "node2", "node5", "node1", "node6", "node9")));
+  @Test
+  public void testVotePreferenceIgnoresNonKeyAttributes() throws URISyntaxException {
+    Map<String, String> pkInfo = pkInfo("orders", "pk");
+    BatchWriteItemRequest first =
+        batchWrite(
+            table(
+                "orders",
+                put(attrs("pk", s("A"), "data", s("a"))),
+                put(attrs("pk", s("B"), "data", s("x")))));
+    BatchWriteItemRequest second =
+        batchWrite(
+            table(
+                "orders",
+                put(attrs("pk", s("A"), "data", s("x"))),
+                put(attrs("pk", s("B"), "data", s("a")))));
+
+    assertEquals(votePreferenceOrder(first, pkInfo), votePreferenceOrder(second, pkInfo));
+  }
+
+  @Test
+  public void testVotePreferenceSkipsUnusableCandidates() throws URISyntaxException {
+    Map<String, String> pkInfo = pkInfo("orders", "pk");
+    BatchWriteItemRequest request =
+        batchWrite(
+            table(
+                "orders",
+                put(attrs("data", s("missing-pk"))),
+                put(attrs("pk", AttributeValue.builder().bool(true).build())),
+                put(attrs("pk", b(0x01, 0x02, 0x03)))));
+
+    List<String> preferenceOrder = votePreferenceOrder(request, pkInfo);
+
+    assertEquals(1, preferenceOrder.size());
+    assertTrue(preferenceOrder.get(0).startsWith("node"));
+  }
+
+  private static List<String> votePreferenceOrder(
+      BatchWriteItemRequest request, Map<String, String> pkInfo) throws URISyntaxException {
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(nodes(), "http", 8000, "", "");
+    Map<URI, Integer> votes = new HashMap<>();
+    for (BatchWriteRoutingTarget target :
+        KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request)) {
+      String pkName = pkInfo.get(target.tableName());
+      if (pkName == null) {
+        continue;
+      }
+      AttributeValue pkValue = target.partitionKeyValue(pkName);
+      if (pkValue == null) {
+        continue;
+      }
+      try {
+        long hash = AttributeValueHasher.hash(pkValue);
+        URI preferredNode = LazyQueryPlan.preferredNodeForHash(liveNodes, hash);
+        if (preferredNode != null) {
+          votes.merge(preferredNode, 1, Integer::sum);
+        }
+      } catch (IllegalArgumentException e) {
+        // Unsupported partition-key types do not contribute votes.
+      }
+    }
+
+    List<Map.Entry<URI, Integer>> ordered = new ArrayList<>(votes.entrySet());
+    ordered.sort(
+        java.util.Comparator.<Map.Entry<URI, Integer>, Integer>comparing(Map.Entry::getValue)
+            .reversed()
+            .thenComparing(entry -> entry.getKey().toString()));
+    List<String> result = new ArrayList<>();
+    for (Map.Entry<URI, Integer> entry : ordered) {
+      result.add(nodeShortName(entry.getKey()));
+    }
+    return result;
+  }
+
+  private static List<URI> nodes() throws URISyntaxException {
+    List<URI> nodes = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      nodes.add(new URI("http", null, "node" + i + ".example.com", 8000, null, null, null));
+    }
+    return nodes;
   }
 
   @SafeVarargs
@@ -148,21 +158,14 @@ public class BatchWriteItemKeyRouteAffinityCrossLanguageTest {
     return attrs;
   }
 
-  private static Map<String, String> pkInfo(String tableName, String pkName, String... rest) {
+  private static Map<String, String> pkInfo(String tableName, String pkName) {
     Map<String, String> pkInfo = new LinkedHashMap<>();
     pkInfo.put(tableName, pkName);
-    for (int i = 0; i < rest.length; i += 2) {
-      pkInfo.put(rest[i], rest[i + 1]);
-    }
     return pkInfo;
   }
 
   private static AttributeValue s(String value) {
     return AttributeValue.builder().s(value).build();
-  }
-
-  private static AttributeValue n(String value) {
-    return AttributeValue.builder().n(value).build();
   }
 
   private static AttributeValue b(int... values) {
@@ -173,104 +176,8 @@ public class BatchWriteItemKeyRouteAffinityCrossLanguageTest {
     return AttributeValue.builder().b(SdkBytes.fromByteArray(bytes)).build();
   }
 
-  private static long batchWriteHash(BatchWriteItemRequest request, Map<String, String> pkInfo) {
-    for (BatchWriteRoutingTarget target :
-        KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request)) {
-      String pkName = pkInfo.get(target.tableName());
-      if (pkName == null) {
-        throw new AssertionError("missing partition key info for table " + target.tableName());
-      }
-
-      AttributeValue pkValue = target.partitionKeyValue(pkName);
-      if (pkValue == null) {
-        continue;
-      }
-
-      try {
-        return AttributeValueHasher.hash(pkValue);
-      } catch (IllegalArgumentException e) {
-        // Try the next deterministic candidate.
-      }
-    }
-    throw new AssertionError("batch write request does not have a usable partition key value");
-  }
-
-  private static String attributeLabel(AttributeValue value) {
-    if (value.s() != null) {
-      return "S:" + value.s();
-    }
-    if (value.n() != null) {
-      return "N:" + value.n();
-    }
-    if (value.b() != null) {
-      return "B:" + hex(value.b().asByteArray());
-    }
-    return String.valueOf(value);
-  }
-
-  private static List<String> nodeSequence(long seed, int count) throws URISyntaxException {
-    List<URI> nodes = new ArrayList<>();
-    for (int i = 1; i <= 10; i++) {
-      nodes.add(new URI("http", null, "node" + i + ".example.com", 8000, null, null, null));
-    }
-
-    LazyQueryPlan plan =
-        new LazyQueryPlan(new AlternatorLiveNodes(nodes, "http", 8000, "", ""), seed);
-    List<String> result = new ArrayList<>();
-    for (int i = 0; i < count && plan.hasNext(); i++) {
-      result.add(nodeShortName(plan.next()));
-    }
-    return result;
-  }
-
   private static String nodeShortName(URI uri) {
     String host = uri.getHost();
     return host.substring(0, host.indexOf(".example.com"));
-  }
-
-  private static String hex(byte[] bytes) {
-    final char[] hex = "0123456789abcdef".toCharArray();
-    StringBuilder builder = new StringBuilder(bytes.length * 2);
-    for (byte value : bytes) {
-      builder.append(hex[(value >> 4) & 0x0f]);
-      builder.append(hex[value & 0x0f]);
-    }
-    return builder.toString();
-  }
-
-  private static final class BatchWriteVector {
-    private final String name;
-    private final BatchWriteItemRequest request;
-    private final Map<String, String> pkInfo;
-    private final String tableName;
-    private final String operation;
-    private final String pkLabel;
-    private final String canonical;
-    private final long hashSigned;
-    private final String hashUnsigned;
-    private final List<String> firstSixNodes;
-
-    private BatchWriteVector(
-        String name,
-        BatchWriteItemRequest request,
-        Map<String, String> pkInfo,
-        String tableName,
-        String operation,
-        String pkLabel,
-        String canonical,
-        long hashSigned,
-        String hashUnsigned,
-        List<String> firstSixNodes) {
-      this.name = name;
-      this.request = request;
-      this.pkInfo = pkInfo;
-      this.tableName = tableName;
-      this.operation = operation;
-      this.pkLabel = pkLabel;
-      this.canonical = canonical;
-      this.hashSigned = hashSigned;
-      this.hashUnsigned = hashUnsigned;
-      this.firstSixNodes = firstSixNodes;
-    }
   }
 }

--- a/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
+++ b/src/test/java/com/scylladb/alternator/keyrouting/KeyAffinityRequestClassifierTest.java
@@ -5,9 +5,11 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import software.amazon.awssdk.services.dynamodb.model.*;
 
@@ -548,42 +550,40 @@ public class KeyAffinityRequestClassifierTest {
   }
 
   @Test
-  public void testBatchWriteItemExtractionIsTableOrderIndependent() {
+  public void testBatchWriteItemExtractionIncludesMultipleTables() {
     BatchWriteItemRequest first = batchWriteRequest("orders", "z-order", "audit", "a-audit");
-    BatchWriteItemRequest second = batchWriteRequest("audit", "a-audit", "orders", "z-order");
 
-    assertEquals("audit", KeyAffinityRequestClassifier.extractTableName(first));
-    assertEquals("audit", KeyAffinityRequestClassifier.extractTableName(second));
+    List<KeyAffinityRequestClassifier.BatchWriteRoutingTarget> targets =
+        KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(first);
 
-    AttributeValue firstPk = KeyAffinityRequestClassifier.extractPartitionKey(first, "pk");
-    AttributeValue secondPk = KeyAffinityRequestClassifier.extractPartitionKey(second, "pk");
-    assertNotNull(firstPk);
-    assertNotNull(secondPk);
-    assertEquals("a-audit", firstPk.s());
-    assertEquals("a-audit", secondPk.s());
+    assertEquals(2, targets.size());
+    Set<String> tableAndPk = new HashSet<>();
+    for (KeyAffinityRequestClassifier.BatchWriteRoutingTarget target : targets) {
+      tableAndPk.add(target.tableName() + ":" + target.partitionKeyValue("pk").s());
+    }
+    assertTrue(tableAndPk.contains("orders:z-order"));
+    assertTrue(tableAndPk.contains("audit:a-audit"));
   }
 
   @Test
-  public void testBatchWriteItemExtractionIsWriteOrderIndependent() {
-    BatchWriteItemRequest first =
+  public void testBatchWriteItemExtractionIncludesMultipleWrites() {
+    BatchWriteItemRequest request =
         BatchWriteItemRequest.builder()
             .requestItems(
                 Collections.singletonMap(
                     "orders", Arrays.asList(batchPut("z-route"), batchPut("a-route"))))
             .build();
-    BatchWriteItemRequest second =
-        BatchWriteItemRequest.builder()
-            .requestItems(
-                Collections.singletonMap(
-                    "orders", Arrays.asList(batchPut("a-route"), batchPut("z-route"))))
-            .build();
 
-    AttributeValue firstPk = KeyAffinityRequestClassifier.extractPartitionKey(first, "pk");
-    AttributeValue secondPk = KeyAffinityRequestClassifier.extractPartitionKey(second, "pk");
-    assertNotNull(firstPk);
-    assertNotNull(secondPk);
-    assertEquals("a-route", firstPk.s());
-    assertEquals("a-route", secondPk.s());
+    List<KeyAffinityRequestClassifier.BatchWriteRoutingTarget> targets =
+        KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request);
+
+    assertEquals(2, targets.size());
+    Set<String> pkValues = new HashSet<>();
+    for (KeyAffinityRequestClassifier.BatchWriteRoutingTarget target : targets) {
+      pkValues.add(target.partitionKeyValue("pk").s());
+    }
+    assertTrue(pkValues.contains("z-route"));
+    assertTrue(pkValues.contains("a-route"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Route `BatchWriteItem` key affinity through vote-preference order across all usable partition keys.
- Use a canonical sorted live-node view for affinity selection and preferred-node batch plans.
- Fall back cleanly for missing metadata, missing keys, unsupported partition-key shapes, or no usable candidates.
- Update key-affinity docs and coverage for BatchWrite routing, fallback behavior, and async metadata requirements.

Closes #99

## Testing
- `JAVA_HOME=$HOME/.sdkman/candidates/java/11.0.29-tem PATH=$HOME/.sdkman/candidates/java/11.0.29-tem/bin:$PATH mvn -q -Dtest=AffinityQueryPlanInterceptorTest,LazyQueryPlanTest,LazyQueryPlanCrossLanguageTest,KeyAffinityRequestClassifierTest,BatchWriteItemKeyRouteAffinityCrossLanguageTest test`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/11.0.29-tem PATH=$HOME/.sdkman/candidates/java/11.0.29-tem/bin:$PATH mvn -q test`