### PR TITLE
Stop live-node polling before closing clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ DOCKER_COMPOSE_VERSION := 2.34.0
 
 MAVEN_GPG_PASSPHRASE ?=
 MAVEN_OPTS ?=
+FMT_MAVEN_PLUGIN := com.spotify.fmt:fmt-maven-plugin:2.25
 
 SONATYPE_TOKEN_USERNAME ?=
 SONATYPE_TOKEN_PASSWORD ?=
@@ -50,7 +51,7 @@ verify:
 	${mvn} verify
 
 lint:
-	${mvn} com.spotify.fmt:fmt-maven-plugin:check
+	${mvn} ${FMT_MAVEN_PLUGIN}:check
 	${mvn} checkstyle:check
 	${mvn} compile test-compile
 	$(MAKE) lint-docs
@@ -60,7 +61,7 @@ lint-docs:
 	${mvn} javadoc:jar javadoc:aggregate javadoc:aggregate-jar javadoc:resource-bundle
 
 lint-fix:
-	${mvn} com.spotify.fmt:fmt-maven-plugin:format
+	${mvn} ${FMT_MAVEN_PLUGIN}:format
 
 compile:
 	${mvn} compile

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
@@ -145,16 +145,14 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
    * <p>This includes:
    *
    * <ul>
-   *   <li>Interrupting the LiveNodes background thread
+   *   <li>Stopping the LiveNodes background thread
    *   <li>Closing the polling HTTP client
    *   <li>Closing the underlying async DynamoDB client
    * </ul>
    */
   @Override
   public void close() {
-    // Interrupt the LiveNodes thread to stop polling
-    liveNodes.interrupt();
-    // Close the polling HTTP client
+    liveNodes.shutdownAndWait();
     if (pollingHttpClient != null) {
       pollingHttpClient.close();
     }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapper.java
@@ -173,7 +173,7 @@ public class AlternatorDynamoDbClientWrapper implements AutoCloseable {
    * <ul>
    *   <li>Shutting down the partition key resolver's discovery executor if key route affinity is
    *       enabled
-   *   <li>Interrupting the LiveNodes background thread
+   *   <li>Stopping the LiveNodes background thread
    *   <li>Closing the polling HTTP client
    *   <li>Closing the underlying DynamoDB client
    * </ul>
@@ -183,9 +183,7 @@ public class AlternatorDynamoDbClientWrapper implements AutoCloseable {
     if (affinityInterceptor != null) {
       affinityInterceptor.getPartitionKeyResolver().shutdown();
     }
-    // Interrupt the LiveNodes thread to stop polling
-    liveNodes.interrupt();
-    // Close the polling HTTP client
+    liveNodes.shutdownAndWait();
     if (pollingHttpClient != null) {
       pollingHttpClient.close();
     }

--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -37,6 +37,8 @@ import software.amazon.awssdk.http.SdkHttpRequest;
  * @author dmitry.kropachev
  */
 public class AlternatorLiveNodes extends Thread {
+  private static final long DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
+
   private final String alternatorScheme;
   private final int alternatorPort;
   private final AtomicReference<List<URI>> liveNodes;
@@ -61,7 +63,17 @@ public class AlternatorLiveNodes extends Thread {
         try {
           updateLiveNodes();
         } catch (IOException e) {
+          if (shutdownRequested.get()) {
+            logger.log(Level.FINE, "AlternatorLiveNodes polling stopped during shutdown", e);
+            return;
+          }
           logger.log(Level.SEVERE, "AlternatorLiveNodes failed to sync nodes list", e);
+        } catch (RuntimeException e) {
+          if (shutdownRequested.get()) {
+            logger.log(Level.FINE, "AlternatorLiveNodes polling stopped during shutdown", e);
+            return;
+          }
+          throw e;
         }
         try {
           Thread.sleep(getRefreshInterval());
@@ -96,6 +108,40 @@ public class AlternatorLiveNodes extends Thread {
   public void shutdown() {
     shutdownRequested.set(true);
     this.interrupt();
+  }
+
+  /**
+   * Initiates shutdown and waits for the background thread to stop.
+   *
+   * @return true if the thread stopped before the default timeout, false otherwise
+   * @since 2.0.5
+   */
+  public boolean shutdownAndWait() {
+    return shutdownAndWait(DEFAULT_SHUTDOWN_TIMEOUT_MS);
+  }
+
+  /**
+   * Initiates shutdown and waits up to the requested timeout for the background thread to stop.
+   *
+   * @param timeoutMs maximum time to wait in milliseconds
+   * @return true if the thread stopped before the timeout, false otherwise
+   * @since 2.0.5
+   */
+  public boolean shutdownAndWait(long timeoutMs) {
+    shutdown();
+    if (Thread.currentThread() == this) {
+      return false;
+    }
+    if (timeoutMs <= 0) {
+      return !isAlive();
+    }
+    try {
+      join(timeoutMs);
+      return !isAlive();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
   }
 
   /**

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapperShutdownTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapperShutdownTest.java
@@ -1,0 +1,120 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class AlternatorDynamoDbClientWrapperShutdownTest {
+
+  @Test
+  public void testSyncWrapperStopsLiveNodesBeforeClosingClients() throws Exception {
+    List<String> events = new ArrayList<>();
+    TrackingLiveNodes liveNodes = new TrackingLiveNodes(events);
+    TrackingPollingClient pollingClient = new TrackingPollingClient(events);
+    DynamoDbClient client = mock(DynamoDbClient.class);
+    doAnswer(
+            invocation -> {
+              events.add("client");
+              return null;
+            })
+        .when(client)
+        .close();
+
+    AlternatorDynamoDbClientWrapper wrapper =
+        new AlternatorDynamoDbClientWrapper(client, liveNodes, null, null, pollingClient);
+
+    wrapper.close();
+
+    assertEquals(Arrays.asList("live-nodes", "polling-client", "client"), events);
+  }
+
+  @Test
+  public void testAsyncWrapperStopsLiveNodesBeforeClosingClients() throws Exception {
+    List<String> events = new ArrayList<>();
+    TrackingLiveNodes liveNodes = new TrackingLiveNodes(events);
+    TrackingPollingClient pollingClient = new TrackingPollingClient(events);
+    DynamoDbAsyncClient client = mock(DynamoDbAsyncClient.class);
+    doAnswer(
+            invocation -> {
+              events.add("client");
+              return null;
+            })
+        .when(client)
+        .close();
+
+    AlternatorDynamoDbAsyncClientWrapper wrapper =
+        new AlternatorDynamoDbAsyncClientWrapper(client, liveNodes, null, pollingClient);
+
+    wrapper.close();
+
+    assertEquals(Arrays.asList("live-nodes", "polling-client", "client"), events);
+  }
+
+  private static final class TrackingLiveNodes extends AlternatorLiveNodes {
+    private final List<String> events;
+
+    private TrackingLiveNodes(List<String> events) {
+      super(
+          AlternatorConfig.builder().withSeedNode(URI.create("http://127.0.0.1:8000")).build(),
+          new NoopPollingClient());
+      this.events = events;
+    }
+
+    @Override
+    public boolean shutdownAndWait() {
+      events.add("live-nodes");
+      return true;
+    }
+  }
+
+  private static final class NoopPollingClient implements SdkHttpClient {
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "noop";
+    }
+  }
+
+  private static final class TrackingPollingClient implements SdkHttpClient {
+    private final List<String> events;
+
+    private TrackingPollingClient(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+      events.add("polling-client");
+    }
+
+    @Override
+    public String clientName() {
+      return "tracking";
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesShutdownTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesShutdownTest.java
@@ -1,0 +1,71 @@
+package com.scylladb.alternator.internal;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.scylladb.alternator.AlternatorConfig;
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+
+public class AlternatorLiveNodesShutdownTest {
+
+  @Test
+  public void testShutdownPathPollingFailureDoesNotEscapeThread() throws Exception {
+    BlockingShutdownHttpClient client = new BlockingShutdownHttpClient();
+    AlternatorConfig config =
+        AlternatorConfig.builder().withSeedNode(URI.create("http://127.0.0.1:8000")).build();
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, client);
+    AtomicReference<Throwable> uncaught = new AtomicReference<>();
+    liveNodes.setUncaughtExceptionHandler((thread, throwable) -> uncaught.set(throwable));
+
+    liveNodes.start();
+    assertTrue("polling request should start", client.callStarted.await(5, TimeUnit.SECONDS));
+
+    liveNodes.shutdown();
+    client.releaseCall.countDown();
+
+    assertTrue("live-node thread should stop", liveNodes.shutdownAndWait(5_000));
+    assertNull("shutdown-path polling exception should not escape", uncaught.get());
+  }
+
+  private static final class BlockingShutdownHttpClient implements SdkHttpClient {
+    private final CountDownLatch callStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseCall = new CountDownLatch(1);
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() {
+          callStarted.countDown();
+          while (releaseCall.getCount() > 0) {
+            try {
+              releaseCall.await(100, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+          throw new IllegalStateException("Connection pool shut down");
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "blocking-shutdown";
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- stop the live-node polling thread before closing polling and DynamoDB clients
- suppress shutdown-path polling exceptions once live-node shutdown has been requested
- add shutdown ordering and shutdown-path failure tests
- pin the formatter plugin used by lint to a Java 11 compatible version without changing workflow Java versions

## Testing
- `JAVA_HOME=$HOME/.sdkman/candidates/java/11.0.29-tem PATH=$HOME/.sdkman/candidates/java/11.0.29-tem/bin:$PATH mvn -q -Dtest=AlternatorLiveNodesShutdownTest,AlternatorDynamoDbClientWrapperShutdownTest test`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/11.0.29-tem PATH=$HOME/.sdkman/candidates/java/11.0.29-tem/bin:$PATH make lint`