### PR TITLE
Add TLS client certificate authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,40 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .build();
 ```
 
+### TLS Client Certificate Authentication
+
+Alternator clusters that require TLS client certificates can be used by configuring client key
+material in `TlsConfig`. The certificate file must be PEM-encoded and may contain the full
+certificate chain. The private key file must be an unencrypted PKCS#8 PEM key.
+
+```java
+import com.scylladb.alternator.AlternatorDynamoDbClient;
+import com.scylladb.alternator.HttpClientType;
+import com.scylladb.alternator.TlsConfig;
+import java.nio.file.Paths;
+
+TlsConfig tlsConfig = TlsConfig.builder()
+    .withCaCertPath(Paths.get("/path/to/ca.pem"))
+    .withTrustSystemCaCerts(false)
+    .withClientCertificate(
+        Paths.get("/path/to/client.crt"),
+        Paths.get("/path/to/client.key"))
+    .build();
+
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://localhost:8043"))
+    .withHttpClientType(HttpClientType.APACHE)
+    .withTlsConfig(tlsConfig)
+    .build();
+```
+
+For async clients, use `HttpClientType.NETTY`. The CRT HTTP client does not expose key-manager
+configuration in the AWS SDK, so client certificates are not supported with `HttpClientType.CRT`.
+
+When the cluster authenticates clients by TLS certificate and SigV4 signing is not needed, omit
+`credentialsProvider(...)`. The Alternator builders automatically use anonymous credentials and do
+not generate authentication headers in that mode.
+
 ### TLS Session Tickets
 
 The library supports TLS session tickets (RFC 5077) for quick TLS renegotiation when using HTTPS

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -442,8 +442,8 @@ public class AlternatorConfig {
   /**
    * Gets the TLS configuration.
    *
-   * <p>The TLS configuration controls certificate validation, custom CA certificates, hostname
-   * verification, and session caching settings.
+   * <p>The TLS configuration controls certificate validation, custom CA certificates, client TLS
+   * certificates, hostname verification, and session caching settings.
    *
    * @return the TLS configuration, never null
    * @since 1.0.9
@@ -948,6 +948,18 @@ public class AlternatorConfig {
      *     .withSeedNode(URI.create("https://localhost:8043"))
      *     .withTlsConfig(TlsConfig.builder()
      *         .withCaCertPath(Paths.get("/path/to/ca.pem"))
+     *         .withTrustSystemCaCerts(false)
+     *         .build())
+     *     .build();
+     *
+     * // Use mutual TLS client certificate authentication
+     * AlternatorConfig config = AlternatorConfig.builder()
+     *     .withSeedNode(URI.create("https://localhost:8043"))
+     *     .withTlsConfig(TlsConfig.builder()
+     *         .withCaCertPath(Paths.get("/path/to/ca.pem"))
+     *         .withClientCertificate(
+     *             Paths.get("/path/to/client.crt"),
+     *             Paths.get("/path/to/client.key"))
      *         .withTrustSystemCaCerts(false)
      *         .build())
      *     .build();

--- a/src/main/java/com/scylladb/alternator/HttpClientType.java
+++ b/src/main/java/com/scylladb/alternator/HttpClientType.java
@@ -14,11 +14,11 @@ import com.scylladb.alternator.internal.SyncClientDetector;
  *
  * <table>
  * <caption>HTTP client compatibility matrix</caption>
- * <tr><th>Type</th><th>Sync</th><th>Async</th><th>Custom CA certs</th><th>Connection TTL</th></tr>
- * <tr><td>{@link #APACHE}</td><td>Yes</td><td>No</td><td>Yes</td><td>Yes</td></tr>
- * <tr><td>{@link #NETTY}</td><td>No</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
- * <tr><td>{@link #CRT}</td><td>Yes</td><td>Yes</td><td>No</td><td>No</td></tr>
- * <tr><td>{@link #AUTO}</td><td>Yes</td><td>Yes</td><td>Depends</td><td>Depends</td></tr>
+ * <tr><th>Type</th><th>Sync</th><th>Async</th><th>Custom CA certs</th><th>Client certs</th><th>Connection TTL</th></tr>
+ * <tr><td>{@link #APACHE}</td><td>Yes</td><td>No</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+ * <tr><td>{@link #NETTY}</td><td>No</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+ * <tr><td>{@link #CRT}</td><td>Yes</td><td>Yes</td><td>No</td><td>No</td><td>No</td></tr>
+ * <tr><td>{@link #AUTO}</td><td>Yes</td><td>Yes</td><td>Depends</td><td>Depends</td><td>Depends</td></tr>
  * </table>
  *
  * <p>Example usage:
@@ -53,24 +53,26 @@ public enum HttpClientType {
   /**
    * Apache HTTP Client ({@code software.amazon.awssdk:apache-client}).
    *
-   * <p>Sync only. Supports custom CA certificates and connection time-to-live. Using this type on
-   * an async client builder will throw {@link IllegalStateException}.
+   * <p>Sync only. Supports custom CA certificates, client TLS certificates, and connection
+   * time-to-live. Using this type on an async client builder will throw {@link
+   * IllegalStateException}.
    */
   APACHE(true, false),
 
   /**
    * Netty NIO HTTP Client ({@code software.amazon.awssdk:netty-nio-client}).
    *
-   * <p>Async only. Supports custom CA certificates and connection time-to-live. Using this type on
-   * a sync client builder will throw {@link IllegalStateException}.
+   * <p>Async only. Supports custom CA certificates, client TLS certificates, and connection
+   * time-to-live. Using this type on a sync client builder will throw {@link
+   * IllegalStateException}.
    */
   NETTY(false, true),
 
   /**
    * AWS CRT HTTP Client ({@code software.amazon.awssdk:aws-crt-client}).
    *
-   * <p>Supports both sync and async clients. Does not support custom CA certificates or connection
-   * time-to-live.
+   * <p>Supports both sync and async clients. Does not support custom CA certificates, client TLS
+   * certificates, or connection time-to-live.
    */
   CRT(true, true);
 

--- a/src/main/java/com/scylladb/alternator/TlsConfig.java
+++ b/src/main/java/com/scylladb/alternator/TlsConfig.java
@@ -14,6 +14,7 @@ import java.util.Objects;
  *
  * <ul>
  *   <li>Custom CA certificates from file paths (PEM format)
+ *   <li>Client certificate and private key files for mutual TLS authentication
  *   <li>Option to trust system CA certificates
  *   <li>Trust-all mode for development/testing
  *   <li>Hostname verification control
@@ -38,6 +39,7 @@ import java.util.Objects;
  * // Combine custom CA with system CAs
  * TlsConfig config = TlsConfig.builder()
  *     .withCaCertPath(Paths.get("/path/to/ca.pem"))
+ *     .withClientCertificate(Paths.get("/path/to/client.crt"), Paths.get("/path/to/client.key"))
  *     .withTrustSystemCaCerts(true)
  *     .build();
  * }</pre>
@@ -49,13 +51,27 @@ public final class TlsConfig {
 
   private static final TlsConfig TRUST_ALL_INSTANCE =
       new TlsConfig(
-          Collections.<Path>emptyList(), false, true, false, TlsSessionCacheConfig.getDefault());
+          Collections.<Path>emptyList(),
+          null,
+          null,
+          false,
+          true,
+          false,
+          TlsSessionCacheConfig.getDefault());
 
   private static final TlsConfig SYSTEM_DEFAULT_INSTANCE =
       new TlsConfig(
-          Collections.<Path>emptyList(), true, false, true, TlsSessionCacheConfig.getDefault());
+          Collections.<Path>emptyList(),
+          null,
+          null,
+          true,
+          false,
+          true,
+          TlsSessionCacheConfig.getDefault());
 
   private final List<Path> customCaCertPaths;
+  private final Path clientCertificatePath;
+  private final Path clientPrivateKeyPath;
   private final boolean trustSystemCaCerts;
   private final boolean trustAllCertificates;
   private final boolean verifyHostname;
@@ -63,6 +79,8 @@ public final class TlsConfig {
 
   private TlsConfig(
       List<Path> customCaCertPaths,
+      Path clientCertificatePath,
+      Path clientPrivateKeyPath,
       boolean trustSystemCaCerts,
       boolean trustAllCertificates,
       boolean verifyHostname,
@@ -71,6 +89,8 @@ public final class TlsConfig {
         customCaCertPaths != null
             ? Collections.unmodifiableList(new ArrayList<>(customCaCertPaths))
             : Collections.<Path>emptyList();
+    this.clientCertificatePath = clientCertificatePath;
+    this.clientPrivateKeyPath = clientPrivateKeyPath;
     this.trustSystemCaCerts = trustSystemCaCerts;
     this.trustAllCertificates = trustAllCertificates;
     this.verifyHostname = verifyHostname;
@@ -141,6 +161,37 @@ public final class TlsConfig {
   }
 
   /**
+   * Returns the PEM-encoded client certificate chain path used for mutual TLS authentication.
+   *
+   * @return the client certificate path, or null if client certificate authentication is not
+   *     configured
+   */
+  public Path getClientCertificatePath() {
+    return clientCertificatePath;
+  }
+
+  /**
+   * Returns the PEM-encoded client private key path used for mutual TLS authentication.
+   *
+   * <p>The private key must be an unencrypted PKCS#8 PEM key.
+   *
+   * @return the client private key path, or null if client certificate authentication is not
+   *     configured
+   */
+  public Path getClientPrivateKeyPath() {
+    return clientPrivateKeyPath;
+  }
+
+  /**
+   * Returns whether client certificate authentication is configured.
+   *
+   * @return true if both a client certificate and private key path are configured
+   */
+  public boolean hasClientCertificate() {
+    return clientCertificatePath != null && clientPrivateKeyPath != null;
+  }
+
+  /**
    * Returns whether system CA certificates should be trusted.
    *
    * <p>When true, the JVM's default trust store is included in certificate validation along with
@@ -190,6 +241,10 @@ public final class TlsConfig {
     return "TlsConfig{"
         + "customCaCertPaths="
         + customCaCertPaths
+        + ", clientCertificatePath="
+        + clientCertificatePath
+        + ", clientPrivateKeyPath="
+        + clientPrivateKeyPath
         + ", trustSystemCaCerts="
         + trustSystemCaCerts
         + ", trustAllCertificates="
@@ -214,6 +269,8 @@ public final class TlsConfig {
         && trustAllCertificates == tlsConfig.trustAllCertificates
         && verifyHostname == tlsConfig.verifyHostname
         && Objects.equals(customCaCertPaths, tlsConfig.customCaCertPaths)
+        && Objects.equals(clientCertificatePath, tlsConfig.clientCertificatePath)
+        && Objects.equals(clientPrivateKeyPath, tlsConfig.clientPrivateKeyPath)
         && Objects.equals(sessionCacheConfig, tlsConfig.sessionCacheConfig);
   }
 
@@ -221,6 +278,8 @@ public final class TlsConfig {
   public int hashCode() {
     return Objects.hash(
         customCaCertPaths,
+        clientCertificatePath,
+        clientPrivateKeyPath,
         trustSystemCaCerts,
         trustAllCertificates,
         verifyHostname,
@@ -230,6 +289,8 @@ public final class TlsConfig {
   /** Builder for creating {@link TlsConfig} instances. */
   public static class Builder {
     private List<Path> customCaCertPaths = new ArrayList<>();
+    private Path clientCertificatePath = null;
+    private Path clientPrivateKeyPath = null;
     private boolean trustSystemCaCerts = true;
     private boolean trustAllCertificates = false;
     private boolean verifyHostname = true;
@@ -266,6 +327,29 @@ public final class TlsConfig {
      */
     public Builder withCaCertPaths(Collection<Path> paths) {
       this.customCaCertPaths = paths != null ? new ArrayList<>(paths) : new ArrayList<Path>();
+      return this;
+    }
+
+    /**
+     * Sets the client certificate and private key used for mutual TLS authentication.
+     *
+     * <p>The certificate file should be PEM-encoded and may contain the full certificate chain. The
+     * private key file must be an unencrypted PKCS#8 PEM key.
+     *
+     * @param certificatePath the path to a PEM-encoded client certificate chain
+     * @param privateKeyPath the path to a PEM-encoded unencrypted PKCS#8 private key
+     * @return this builder instance
+     * @throws IllegalArgumentException if either path is null
+     */
+    public Builder withClientCertificate(Path certificatePath, Path privateKeyPath) {
+      if (certificatePath == null) {
+        throw new IllegalArgumentException("Client certificate path cannot be null");
+      }
+      if (privateKeyPath == null) {
+        throw new IllegalArgumentException("Client private key path cannot be null");
+      }
+      this.clientCertificatePath = certificatePath;
+      this.clientPrivateKeyPath = privateKeyPath;
       return this;
     }
 
@@ -357,6 +441,8 @@ public final class TlsConfig {
 
       return new TlsConfig(
           customCaCertPaths,
+          clientCertificatePath,
+          clientPrivateKeyPath,
           trustSystemCaCerts,
           trustAllCertificates,
           effectiveVerifyHostname,

--- a/src/main/java/com/scylladb/alternator/internal/ApacheSyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/ApacheSyncClientFactory.java
@@ -4,6 +4,7 @@ import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.TlsConfig;
 import java.time.Duration;
 import java.util.function.Consumer;
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.TrustManager;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
@@ -53,13 +54,7 @@ public final class ApacheSyncClientFactory {
       builder.connectionTimeout(Duration.ofMillis(config.getConnectionTimeoutMs()));
     }
 
-    // Apply TLS trust manager settings
-    if (tlsConfig != null
-        && !tlsConfig.isTrustAllCertificates()
-        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || !tlsConfig.isTrustSystemCaCerts())) {
-      TrustManager[] trustManagers = TlsContextFactory.createTrustManagers(tlsConfig);
-      builder.tlsTrustManagersProvider(() -> trustManagers);
-    }
+    applyTlsManagers(builder, tlsConfig);
 
     // Apply user customizer last — allows overriding any defaults including TLS
     if (customizer != null) {
@@ -91,18 +86,29 @@ public final class ApacheSyncClientFactory {
 
   private static SdkHttpClient buildWithTls(ApacheHttpClient.Builder builder, TlsConfig tlsConfig) {
     if (tlsConfig != null) {
+      applyTlsManagers(builder, tlsConfig);
       if (tlsConfig.isTrustAllCertificates()) {
         return builder.buildWithDefaults(
             AttributeMap.builder()
                 .put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true)
                 .build());
       }
-      if (!tlsConfig.getCustomCaCertPaths().isEmpty() || !tlsConfig.isTrustSystemCaCerts()) {
-        // Eagerly validate to fail fast on invalid cert paths
-        TrustManager[] trustManagers = TlsContextFactory.createTrustManagers(tlsConfig);
-        builder.tlsTrustManagersProvider(() -> trustManagers);
-      }
     }
     return builder.build();
+  }
+
+  private static void applyTlsManagers(ApacheHttpClient.Builder builder, TlsConfig tlsConfig) {
+    if (tlsConfig == null) {
+      return;
+    }
+    if (tlsConfig.hasClientCertificate()) {
+      KeyManager[] keyManagers = TlsContextFactory.createKeyManagers(tlsConfig);
+      builder.tlsKeyManagersProvider(() -> keyManagers);
+    }
+    if (!tlsConfig.isTrustAllCertificates()
+        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || !tlsConfig.isTrustSystemCaCerts())) {
+      TrustManager[] trustManagers = TlsContextFactory.createTrustManagers(tlsConfig);
+      builder.tlsTrustManagersProvider(() -> trustManagers);
+    }
   }
 }

--- a/src/main/java/com/scylladb/alternator/internal/CrtAsyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/CrtAsyncClientFactory.java
@@ -78,9 +78,10 @@ public final class CrtAsyncClientFactory {
     }
 
     // Validate CRT limitations
-    if (tlsConfig != null && !tlsConfig.getCustomCaCertPaths().isEmpty()) {
+    if (tlsConfig != null
+        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate())) {
       throw new UnsupportedOperationException(
-          "Custom CA certificates are not supported with the CRT async HTTP client. "
+          "Custom CA certificates and client TLS certificates are not supported with the CRT async HTTP client. "
               + "Use Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
     }
 

--- a/src/main/java/com/scylladb/alternator/internal/CrtSyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/CrtSyncClientFactory.java
@@ -76,9 +76,10 @@ public final class CrtSyncClientFactory {
     }
 
     // Validate CRT limitations before customizer
-    if (tlsConfig != null && !tlsConfig.getCustomCaCertPaths().isEmpty()) {
+    if (tlsConfig != null
+        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate())) {
       throw new UnsupportedOperationException(
-          "Custom CA certificates are not supported with the CRT HTTP client. "
+          "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "
               + "Use Apache or Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
     }
 
@@ -97,9 +98,10 @@ public final class CrtSyncClientFactory {
    * @return a configured SdkHttpClient with small pool size
    */
   public static SdkHttpClient createPollingClient(TlsConfig tlsConfig) {
-    if (tlsConfig != null && !tlsConfig.getCustomCaCertPaths().isEmpty()) {
+    if (tlsConfig != null
+        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate())) {
       throw new UnsupportedOperationException(
-          "Custom CA certificates are not supported with the CRT HTTP client. "
+          "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "
               + "Use Apache or Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
     }
     AwsCrtHttpClient.Builder builder = AwsCrtHttpClient.builder();
@@ -115,9 +117,9 @@ public final class CrtSyncClientFactory {
 
   private static SdkHttpClient buildWithTls(AwsCrtHttpClient.Builder builder, TlsConfig tlsConfig) {
     if (tlsConfig != null) {
-      if (!tlsConfig.getCustomCaCertPaths().isEmpty()) {
+      if (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate()) {
         throw new UnsupportedOperationException(
-            "Custom CA certificates are not supported with the CRT HTTP client. "
+            "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "
                 + "Use Apache or Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
       }
       if (tlsConfig.isTrustAllCertificates()) {

--- a/src/main/java/com/scylladb/alternator/internal/NettyAsyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/NettyAsyncClientFactory.java
@@ -5,6 +5,7 @@ import com.scylladb.alternator.TlsConfig;
 import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.TrustManager;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -70,13 +71,7 @@ public final class NettyAsyncClientFactory {
       }
     }
 
-    // Apply TLS trust manager settings (not buildWithDefaults — that happens at build time)
-    if (tlsConfig != null
-        && !tlsConfig.isTrustAllCertificates()
-        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || !tlsConfig.isTrustSystemCaCerts())) {
-      TrustManager[] trustManagers = TlsContextFactory.createTrustManagers(tlsConfig);
-      builder.tlsTrustManagersProvider(() -> trustManagers);
-    }
+    applyTlsManagers(builder, tlsConfig);
 
     // Apply user customizer last — allows overriding any defaults including TLS
     if (customizer != null) {
@@ -91,5 +86,21 @@ public final class NettyAsyncClientFactory {
               .build());
     }
     return builder.build();
+  }
+
+  private static void applyTlsManagers(
+      NettyNioAsyncHttpClient.Builder builder, TlsConfig tlsConfig) {
+    if (tlsConfig == null) {
+      return;
+    }
+    if (tlsConfig.hasClientCertificate()) {
+      KeyManager[] keyManagers = TlsContextFactory.createKeyManagers(tlsConfig);
+      builder.tlsKeyManagersProvider(() -> keyManagers);
+    }
+    if (!tlsConfig.isTrustAllCertificates()
+        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || !tlsConfig.isTrustSystemCaCerts())) {
+      TrustManager[] trustManagers = TlsContextFactory.createTrustManagers(tlsConfig);
+      builder.tlsTrustManagersProvider(() -> trustManagers);
+    }
   }
 }

--- a/src/main/java/com/scylladb/alternator/internal/TlsContextFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/TlsContextFactory.java
@@ -5,19 +5,28 @@ import com.scylladb.alternator.TlsSessionCacheConfig;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyFactory;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManager;
@@ -33,6 +42,7 @@ import javax.net.ssl.X509TrustManager;
  *   <li>Modern TLS protocols (TLS 1.2+) that support session tickets
  *   <li>Configurable session caching for TLS session resumption
  *   <li>Custom CA certificate support for production deployments
+ *   <li>Client certificate support for mutual TLS authentication
  *   <li>Trust-all certificate validation (for development/testing with self-signed certs)
  * </ul>
  *
@@ -57,6 +67,7 @@ public final class TlsContextFactory {
    *
    * <ul>
    *   <li>Custom CA certificates from PEM files
+   *   <li>Client certificate and private key from PEM files
    *   <li>System CA certificates (JVM default trust store)
    *   <li>Combination of custom and system CAs
    *   <li>Trust-all mode for development/testing
@@ -79,13 +90,48 @@ public final class TlsContextFactory {
       trustManagers = createTrustManagers(config);
     }
 
+    KeyManager[] keyManagers = createKeyManagers(config);
+
     try {
       SSLContext sslContext = createBaseContext();
-      sslContext.init(null, trustManagers, new java.security.SecureRandom());
+      sslContext.init(keyManagers, trustManagers, new java.security.SecureRandom());
       configureSessionCache(sslContext, config.getSessionCacheConfig());
       return sslContext;
     } catch (NoSuchAlgorithmException | KeyManagementException e) {
       throw new RuntimeException("Failed to create SSL context", e);
+    }
+  }
+
+  /**
+   * Creates key managers for client certificate authentication.
+   *
+   * @param config the TLS configuration
+   * @return key managers, or null if no client certificate is configured
+   */
+  static KeyManager[] createKeyManagers(TlsConfig config) {
+    if (config == null || !config.hasClientCertificate()) {
+      return null;
+    }
+
+    char[] keyPassword = new char[0];
+    try {
+      Certificate[] certificateChain = loadCertificateChain(config.getClientCertificatePath());
+      PrivateKey privateKey = loadPrivateKey(config.getClientPrivateKeyPath());
+
+      KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keyStore.load(null, null);
+      keyStore.setKeyEntry("alternator-client", privateKey, keyPassword, certificateChain);
+
+      KeyManagerFactory keyManagerFactory =
+          KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      keyManagerFactory.init(keyStore, keyPassword);
+      return keyManagerFactory.getKeyManagers();
+    } catch (CertificateException
+        | IOException
+        | KeyStoreException
+        | NoSuchAlgorithmException
+        | UnrecoverableKeyException e) {
+      throw new RuntimeException("Failed to load client certificate key material", e);
     }
   }
 
@@ -145,16 +191,13 @@ public final class TlsContextFactory {
       KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
       keyStore.load(null, null); // Initialize empty keystore
 
-      CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
       int certIndex = 0;
 
       for (Path certPath : certPaths) {
-        try (InputStream is = new BufferedInputStream(Files.newInputStream(certPath))) {
-          Collection<? extends Certificate> certs = certFactory.generateCertificates(is);
-          for (Certificate cert : certs) {
-            String alias = "custom-ca-" + certIndex++;
-            keyStore.setCertificateEntry(alias, cert);
-          }
+        Certificate[] certs = loadCertificateChain(certPath);
+        for (Certificate cert : certs) {
+          String alias = "custom-ca-" + certIndex++;
+          keyStore.setCertificateEntry(alias, cert);
         }
       }
 
@@ -162,6 +205,66 @@ public final class TlsContextFactory {
     } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
       throw new RuntimeException("Failed to load CA certificates", e);
     }
+  }
+
+  private static Certificate[] loadCertificateChain(Path certPath) {
+    try (InputStream is = new BufferedInputStream(Files.newInputStream(certPath))) {
+      CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+      Collection<? extends Certificate> certs = certFactory.generateCertificates(is);
+      if (certs.isEmpty()) {
+        throw new RuntimeException("No certificates found in " + certPath);
+      }
+      return certs.toArray(new Certificate[0]);
+    } catch (CertificateException | IOException e) {
+      throw new RuntimeException("Failed to load certificate chain from " + certPath, e);
+    }
+  }
+
+  private static PrivateKey loadPrivateKey(Path privateKeyPath) {
+    try {
+      String pem = new String(Files.readAllBytes(privateKeyPath), StandardCharsets.US_ASCII);
+      if (pem.contains("-----BEGIN ENCRYPTED PRIVATE KEY-----")) {
+        throw new RuntimeException(
+            "Encrypted client private keys are not supported; provide an unencrypted PKCS#8 key");
+      }
+      if (pem.contains("-----BEGIN RSA PRIVATE KEY-----")
+          || pem.contains("-----BEGIN EC PRIVATE KEY-----")) {
+        throw new RuntimeException(
+            "PKCS#1 client private keys are not supported; convert the key to unencrypted PKCS#8");
+      }
+
+      String base64 = extractPemBody(pem, "PRIVATE KEY");
+      byte[] keyBytes = Base64.getMimeDecoder().decode(base64);
+      return parsePkcs8PrivateKey(new PKCS8EncodedKeySpec(keyBytes));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load client private key from " + privateKeyPath, e);
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException("Invalid client private key PEM in " + privateKeyPath, e);
+    }
+  }
+
+  private static String extractPemBody(String pem, String type) {
+    String beginMarker = "-----BEGIN " + type + "-----";
+    String endMarker = "-----END " + type + "-----";
+    int begin = pem.indexOf(beginMarker);
+    int end = pem.indexOf(endMarker);
+    if (begin < 0 || end < 0 || end <= begin) {
+      throw new IllegalArgumentException("Missing PEM block: " + type);
+    }
+    begin += beginMarker.length();
+    return pem.substring(begin, end).replaceAll("\\s", "");
+  }
+
+  private static PrivateKey parsePkcs8PrivateKey(PKCS8EncodedKeySpec keySpec) {
+    Exception lastException = null;
+    for (String algorithm : new String[] {"RSA", "EC", "DSA"}) {
+      try {
+        return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+      } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+        lastException = e;
+      }
+    }
+    throw new RuntimeException("Failed to parse client private key as PKCS#8", lastException);
   }
 
   /**

--- a/src/test/java/com/scylladb/alternator/TlsConfigTest.java
+++ b/src/test/java/com/scylladb/alternator/TlsConfigTest.java
@@ -23,6 +23,7 @@ public class TlsConfigTest {
     assertFalse("trustSystemCaCerts should be false", config.isTrustSystemCaCerts());
     assertFalse("verifyHostname should be false", config.isVerifyHostname());
     assertTrue("customCaCertPaths should be empty", config.getCustomCaCertPaths().isEmpty());
+    assertFalse("client certificate should not be configured", config.hasClientCertificate());
     assertNotNull("sessionCacheConfig should not be null", config.getSessionCacheConfig());
   }
 
@@ -34,6 +35,7 @@ public class TlsConfigTest {
     assertTrue("trustSystemCaCerts should be true", config.isTrustSystemCaCerts());
     assertTrue("verifyHostname should be true", config.isVerifyHostname());
     assertTrue("customCaCertPaths should be empty", config.getCustomCaCertPaths().isEmpty());
+    assertFalse("client certificate should not be configured", config.hasClientCertificate());
     assertNotNull("sessionCacheConfig should not be null", config.getSessionCacheConfig());
   }
 
@@ -98,6 +100,21 @@ public class TlsConfigTest {
   }
 
   @Test
+  public void testBuilderWithClientCertificate() {
+    Path certPath = Paths.get("/path/to/client.crt");
+    Path keyPath = Paths.get("/path/to/client.key");
+    TlsConfig config =
+        TlsConfig.builder()
+            .withTrustSystemCaCerts(true)
+            .withClientCertificate(certPath, keyPath)
+            .build();
+
+    assertTrue("client certificate should be configured", config.hasClientCertificate());
+    assertEquals(certPath, config.getClientCertificatePath());
+    assertEquals(keyPath, config.getClientPrivateKeyPath());
+  }
+
+  @Test
   public void testBuilderWithSessionCacheConfig() {
     TlsSessionCacheConfig sessionConfig =
         TlsSessionCacheConfig.builder()
@@ -125,6 +142,16 @@ public class TlsConfigTest {
   @Test(expected = IllegalArgumentException.class)
   public void testBuilderRejectsNullCaCertPath() {
     TlsConfig.builder().withCaCertPath(null).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderRejectsNullClientCertPath() {
+    TlsConfig.builder().withClientCertificate(null, Paths.get("/path/to/client.key")).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderRejectsNullClientKeyPath() {
+    TlsConfig.builder().withClientCertificate(Paths.get("/path/to/client.crt"), null).build();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -173,6 +200,10 @@ public class TlsConfigTest {
 
     String str = config.toString();
     assertTrue("toString should contain customCaCertPaths", str.contains("customCaCertPaths"));
+    assertTrue(
+        "toString should contain clientCertificatePath", str.contains("clientCertificatePath"));
+    assertTrue(
+        "toString should contain clientPrivateKeyPath", str.contains("clientPrivateKeyPath"));
     assertTrue("toString should contain trustSystemCaCerts", str.contains("trustSystemCaCerts"));
     assertTrue(
         "toString should contain trustAllCertificates", str.contains("trustAllCertificates"));
@@ -183,15 +214,29 @@ public class TlsConfigTest {
   @Test
   public void testEqualsAndHashCode() {
     Path certPath = Paths.get("/path/to/ca.pem");
+    Path clientCertPath = Paths.get("/path/to/client.crt");
+    Path clientKeyPath = Paths.get("/path/to/client.key");
 
     TlsConfig config1 =
-        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(false).build();
+        TlsConfig.builder()
+            .withCaCertPath(certPath)
+            .withTrustSystemCaCerts(false)
+            .withClientCertificate(clientCertPath, clientKeyPath)
+            .build();
 
     TlsConfig config2 =
-        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(false).build();
+        TlsConfig.builder()
+            .withCaCertPath(certPath)
+            .withTrustSystemCaCerts(false)
+            .withClientCertificate(clientCertPath, clientKeyPath)
+            .build();
 
     TlsConfig config3 =
-        TlsConfig.builder().withCaCertPath(certPath).withTrustSystemCaCerts(true).build();
+        TlsConfig.builder()
+            .withCaCertPath(certPath)
+            .withTrustSystemCaCerts(false)
+            .withClientCertificate(clientCertPath, Paths.get("/path/to/other-client.key"))
+            .build();
 
     assertEquals(config1, config2);
     assertEquals(config1.hashCode(), config2.hashCode());

--- a/src/test/java/com/scylladb/alternator/TlsContextFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/TlsContextFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.TlsContextFactory;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.net.ssl.SSLContext;
@@ -119,6 +120,52 @@ public class TlsContextFactoryTest {
     }
   }
 
+  @Test
+  public void testCreateSslContextWithClientCertificate() throws IOException {
+    Path clientCert = createTempClientCertificate();
+    Path clientKey = createTempClientPrivateKey();
+    try {
+      TlsConfig config =
+          TlsConfig.builder()
+              .withTrustAllCertificates(true)
+              .withClientCertificate(clientCert, clientKey)
+              .build();
+
+      SSLContext sslContext = TlsContextFactory.createSslContext(config);
+
+      assertNotNull("SSLContext should not be null", sslContext);
+    } finally {
+      Files.deleteIfExists(clientCert);
+      Files.deleteIfExists(clientKey);
+    }
+  }
+
+  @Test
+  public void testCreateSslContextWithInvalidClientPrivateKeyFails() throws IOException {
+    Path clientCert = createTempClientCertificate();
+    Path clientKey = Files.createTempFile("invalid-client-key-", ".pem");
+    try {
+      Files.write(clientKey, "not a private key".getBytes(StandardCharsets.US_ASCII));
+      TlsConfig config =
+          TlsConfig.builder()
+              .withTrustAllCertificates(true)
+              .withClientCertificate(clientCert, clientKey)
+              .build();
+
+      TlsContextFactory.createSslContext(config);
+      fail("Should fail with invalid client private key");
+    } catch (RuntimeException e) {
+      String message = e.toString();
+      if (e.getCause() != null) {
+        message += " " + e.getCause();
+      }
+      assertTrue("Error should mention private key", message.toLowerCase().contains("private key"));
+    } finally {
+      Files.deleteIfExists(clientCert);
+      Files.deleteIfExists(clientKey);
+    }
+  }
+
   @Test(expected = RuntimeException.class)
   public void testCreateSslContextWithInvalidCaCertPath() throws IOException {
     Path invalidPath = Files.createTempFile("invalid", ".pem");
@@ -196,6 +243,69 @@ public class TlsContextFactoryTest {
 
     Path tempFile = Files.createTempFile("test-ca-", ".pem");
     Files.write(tempFile, testCert.getBytes());
+    return tempFile;
+  }
+
+  private Path createTempClientCertificate() throws IOException {
+    String testCert =
+        "-----BEGIN CERTIFICATE-----\n"
+            + "MIIDDTCCAfWgAwIBAgIUQ9vAVQDGKT4oOuaelYW6Vo+LedUwDQYJKoZIhvcNAQEL\n"
+            + "BQAwFjEUMBIGA1UEAwwLdGVzdC1jbGllbnQwHhcNMjYwNjI2MTEyNTM3WhcNMzYw\n"
+            + "NjIzMTEyNTM3WjAWMRQwEgYDVQQDDAt0ZXN0LWNsaWVudDCCASIwDQYJKoZIhvcN\n"
+            + "AQEBBQADggEPADCCAQoCggEBAK/2xNeIpdnAPFnmMv4A2+++8QJyBXcUV05fY/Jv\n"
+            + "PZSURWE84YyWT53XiY2qLnI+mpO8OXJNf5SXy7r6E5UYV7T6aM6s5LpxRyvhNosv\n"
+            + "d7K/ZXimfMKqXXMKeYRuw2FdAGEAjF3vP6FAayEKgtL77/7TeWSZmvOnhVnDSZZo\n"
+            + "uY/AEHnqNBkeLtEyDJmZX4Ed0ffnzG7qNyTIs9/tv+/UvH6WmGerbjDQa5ygfZyV\n"
+            + "r+F+GSxgm41deHVBWcU2E5onmqtHpxdVH8JVnDS0BbAOi7AqZBm0198NX0EaHJS9\n"
+            + "pfApQO/hubtwc6tQcvT+YYnvltkfBa/WRVzE9glS687aiy0CAwEAAaNTMFEwHQYD\n"
+            + "VR0OBBYEFKbGjhXTEZvHZHZZRfaDjR8qfvSgMB8GA1UdIwQYMBaAFKbGjhXTEZvH\n"
+            + "ZHZZRfaDjR8qfvSgMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB\n"
+            + "AA7+bjX6LqzuByr64mMZBOLrIBtUNHbxrFRcxpJ4vU95XTC4fJS9WGlnJecNqSkE\n"
+            + "QFx3uN6YUCcRuz7fWnZT2it+0AyyWgjbj+lOZklekTQz8+KklWSfOACYomEfDXoD\n"
+            + "W/rjqrUh7LD13THen2xaYFctzqxRachrpr1HCLsotsm9ORfaIOKlTyemGpyZsNje\n"
+            + "qx1LPB/1TRrkIcIyHjyd16baTvuhDlbyGmZFpXNqpRoVsg6Q0knNGIggqVWYZQHi\n"
+            + "kWnyK1TM5SE/Gosh9MRY4Hz44yQYOr8chmgRh/5tro+FWx8KKVW6U8IEnslN1QAu\n"
+            + "IdiE7tP9gWke/Fesa1mNRHY=\n"
+            + "-----END CERTIFICATE-----\n";
+
+    Path tempFile = Files.createTempFile("test-client-cert-", ".pem");
+    Files.write(tempFile, testCert.getBytes(StandardCharsets.US_ASCII));
+    return tempFile;
+  }
+
+  private Path createTempClientPrivateKey() throws IOException {
+    String testKey =
+        "-----BEGIN PRIVATE KEY-----\n"
+            + "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCv9sTXiKXZwDxZ\n"
+            + "5jL+ANvvvvECcgV3FFdOX2Pybz2UlEVhPOGMlk+d14mNqi5yPpqTvDlyTX+Ul8u6\n"
+            + "+hOVGFe0+mjOrOS6cUcr4TaLL3eyv2V4pnzCql1zCnmEbsNhXQBhAIxd7z+hQGsh\n"
+            + "CoLS++/+03lkmZrzp4VZw0mWaLmPwBB56jQZHi7RMgyZmV+BHdH358xu6jckyLPf\n"
+            + "7b/v1Lx+lphnq24w0GucoH2cla/hfhksYJuNXXh1QVnFNhOaJ5qrR6cXVR/CVZw0\n"
+            + "tAWwDouwKmQZtNffDV9BGhyUvaXwKUDv4bm7cHOrUHL0/mGJ75bZHwWv1kVcxPYJ\n"
+            + "UuvO2ostAgMBAAECggEAP60pJmYIvnfWXyHyqgBdlrCePqhMWf8+aNoULRMcUbwm\n"
+            + "Lz380QdD4HazDFTdYfJNtdCTaU2qMXeM/iipFXctpgxICSJ/0whTHQnu1wdiZYjl\n"
+            + "i3eUBk3oa00LFGWQxpcFIBU2tndxq0TIf7hyBy+sdabJcyIy9KFWnFkTNB7Jp77b\n"
+            + "i4JhRAk7JRG0tWZKRGCYyRh6Zi7ywlZEnXtT0RuAHcnfR1KtCREeA7ISkHqvCo0c\n"
+            + "l3HxwmlLNfLYrbD20HTlmvpGOBgNtFTM1TB0EQREafjmXETgHXq+8FGo+1vcrfxA\n"
+            + "zthgGFsJ7iaGU3K816SoNxNTTDX7hTIFKxPJAUnE8QKBgQDOXg378gOialyMur/z\n"
+            + "ZjlW/98mhiFcwgzVulsSuKwE7FvYATq4Ad03HW3h0gmf+9BDDGDXnG4WC5tGPLYN\n"
+            + "61RqxVepKtt67n3hcyzZDOHAUz9p53xF91Kyn0d1dyUUoGXkqp1TcVKal2UaElup\n"
+            + "53akCWpJVQxjLFPAxMBrz6nX8wKBgQDaSMmO6eTjNP9y7UgMAY88Nqu8PyAPyFHV\n"
+            + "utaq1gROHhp8gxbP4Hkb1Wwj0PeUWkzTWwnmLVnMuWAktks15Z7VZjgsAwhTkCgG\n"
+            + "/HOZ8n0W2z3J0xvlV5JMfFaW6bsF3wQu24Mw9RDpxlMC8MlQoWB34zosD2L+hcmn\n"
+            + "Sb5H++D4XwKBgQCoXRvTnVNRwqzXM9U+4vuM+xw39d5qKvcFuBBtabUOHzefNwGM\n"
+            + "9hhgyuXHAvFPUMZMrWClB77YxYdc+lMdcA1jPrWSEqEV3lVdBfZk7pmPq1tlL7K3\n"
+            + "8lvJ1yEZuKbL+UCoGnpYhW/7J+EYMDoQmAK3Oec5BOYiUxvRfbPvQXEz+QKBgQCv\n"
+            + "qUuq2sb7oTbBQfpszwR5rHVftF0U1lwk54rBSCGGy+r8sHG3MCnGIGY6HHxgwpp4\n"
+            + "rBa3SV+uxK9+W8UCxpqfmPczU+1rceMEXDybcuz/a8e5l04nreVp79Wu9MEw5Fv1\n"
+            + "aWmWCGFn/9Xl0+fuHzAGyrGRq4A622eAXHPoceaFeQKBgQCtrlbPMYRcsQ3XFWqr\n"
+            + "+j1m170TDDZA2f9Xmabw1gDlXJzl56FjCHw1pwEar951Zz4YxXlAxBFrsSSAoejY\n"
+            + "2k767/Yt4BXgICmLWwzWaLjrXDlTzF0/MAlkrkU/8DbxWJr9ipfk3jV+MRq5lyub\n"
+            + "XnY1EPIr829qOLS66QxTxZUX3w==\n"
+            + "-----END PRIVATE KEY-----\n";
+
+    Path tempFile = Files.createTempFile("test-client-key-", ".pem");
+    Files.write(tempFile, testKey.getBytes(StandardCharsets.US_ASCII));
     return tempFile;
   }
 }

--- a/src/test/java/com/scylladb/alternator/internal/ApacheSyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/ApacheSyncClientFactoryTest.java
@@ -155,6 +155,17 @@ public class ApacheSyncClientFactoryTest {
   }
 
   @Test(expected = RuntimeException.class)
+  public void testCreateWithInvalidClientCertificatePathThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withClientCertificate(
+                Path.of("/non/existent/client.crt"), Path.of("/non/existent/client.key"))
+            .build();
+    ApacheSyncClientFactory.create(null, null, tlsConfig);
+  }
+
+  @Test(expected = RuntimeException.class)
   public void testCreateWithInvalidCaCertContentThrows() throws Exception {
     Path tempFile = Files.createTempFile("invalid-ca-", ".pem");
     try {
@@ -173,6 +184,17 @@ public class ApacheSyncClientFactoryTest {
         TlsConfig.builder()
             .withCaCertPath(Path.of("/non/existent/ca.pem"))
             .withTrustSystemCaCerts(false)
+            .build();
+    ApacheSyncClientFactory.createPollingClient(tlsConfig);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testCreatePollingClientWithInvalidClientCertificatePathThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withClientCertificate(
+                Path.of("/non/existent/client.crt"), Path.of("/non/existent/client.key"))
             .build();
     ApacheSyncClientFactory.createPollingClient(tlsConfig);
   }

--- a/src/test/java/com/scylladb/alternator/internal/CrtAsyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/CrtAsyncClientFactoryTest.java
@@ -172,6 +172,16 @@ public class CrtAsyncClientFactoryTest {
     CrtAsyncClientFactory.create(null, null, tlsConfig);
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithClientCertificateThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withClientCertificate(Path.of("/client.crt"), Path.of("/client.key"))
+            .build();
+    CrtAsyncClientFactory.create(null, null, tlsConfig);
+  }
+
   @Test(expected = RuntimeException.class)
   public void testCreateWithInvalidCaCertContentThrows() throws Exception {
     Path tempFile = Files.createTempFile("invalid-ca-", ".pem");

--- a/src/test/java/com/scylladb/alternator/internal/CrtSyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/CrtSyncClientFactoryTest.java
@@ -193,6 +193,16 @@ public class CrtSyncClientFactoryTest {
     CrtSyncClientFactory.create(null, null, tlsConfig);
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithClientCertificateThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withClientCertificate(Path.of("/client.crt"), Path.of("/client.key"))
+            .build();
+    CrtSyncClientFactory.create(null, null, tlsConfig);
+  }
+
   @Test(expected = RuntimeException.class)
   public void testCreateWithInvalidCaCertContentThrows() throws Exception {
     Path tempFile = Files.createTempFile("invalid-ca-", ".pem");
@@ -212,6 +222,16 @@ public class CrtSyncClientFactoryTest {
         TlsConfig.builder()
             .withCaCertPath(Path.of("/non/existent/ca.pem"))
             .withTrustSystemCaCerts(false)
+            .build();
+    CrtSyncClientFactory.createPollingClient(tlsConfig);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreatePollingClientWithClientCertificateThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withClientCertificate(Path.of("/client.crt"), Path.of("/client.key"))
             .build();
     CrtSyncClientFactory.createPollingClient(tlsConfig);
   }

--- a/src/test/java/com/scylladb/alternator/internal/NettyAsyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/NettyAsyncClientFactoryTest.java
@@ -133,6 +133,17 @@ public class NettyAsyncClientFactoryTest {
   }
 
   @Test(expected = RuntimeException.class)
+  public void testCreateWithInvalidClientCertificatePathThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withTrustAllCertificates(true)
+            .withClientCertificate(
+                Path.of("/non/existent/client.crt"), Path.of("/non/existent/client.key"))
+            .build();
+    NettyAsyncClientFactory.create(null, null, tlsConfig);
+  }
+
+  @Test(expected = RuntimeException.class)
   public void testCreateWithInvalidCaCertContentThrows() throws Exception {
     Path tempFile = Files.createTempFile("invalid-ca-", ".pem");
     try {


### PR DESCRIPTION
## Summary
- add TLS client certificate/private key configuration for mutual TLS
- wire client key managers into Apache sync and Netty async HTTP clients
- fail fast for CRT HTTP clients where client certificates are unsupported
- document certificate usage and keep lint on Java 11 by pinning the formatter plugin

Closes #5

## Testing
- JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH make lint
- JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH make test-unit
- JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH make test-unit