### PR TITLE
Move formatter plugin version to pom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ DOCKER_COMPOSE_VERSION := 2.34.0
 
 MAVEN_GPG_PASSPHRASE ?=
 MAVEN_OPTS ?=
-FMT_MAVEN_PLUGIN := com.spotify.fmt:fmt-maven-plugin:2.25
 
 SONATYPE_TOKEN_USERNAME ?=
 SONATYPE_TOKEN_PASSWORD ?=
@@ -51,7 +50,7 @@ verify:
 	${mvn} verify
 
 lint:
-	${mvn} ${FMT_MAVEN_PLUGIN}:check
+	${mvn} fmt:check
 	${mvn} checkstyle:check
 	${mvn} compile test-compile
 	$(MAKE) lint-docs
@@ -61,7 +60,7 @@ lint-docs:
 	${mvn} javadoc:jar javadoc:aggregate javadoc:aggregate-jar javadoc:resource-bundle
 
 lint-fix:
-	${mvn} ${FMT_MAVEN_PLUGIN}:format
+	${mvn} fmt:format
 
 compile:
 	${mvn} compile

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
                 <version>2.17.1</version>
             </plugin>
             <plugin>
+                <groupId>com.spotify.fmt</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.25</version>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.5.0</version>


### PR DESCRIPTION
## Summary
- declare fmt-maven-plugin in pom.xml
- simplify Makefile lint targets to call fmt:check and fmt:format

## Testing
- JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q fmt:check
- JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH make lint
- JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH make test-unit