### PR TITLE
Fix seed-based scoped discovery across datacenters

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,10 +619,35 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
 - **DatacenterScope** - Use only nodes in a specific datacenter
 - **RackScope** - Use only nodes in a specific rack within a datacenter
 
+#### Cluster-Wide Discovery Across Datacenters
+
+For cluster-wide routing, the client queries the configured seed hosts and merges the returned node
+lists. Some Scylla versions return only the contacted node's datacenter from `/localnodes`, even
+with cluster scope. When using those versions across multiple datacenters, configure seed hosts
+from every datacenter that should participate in cluster-wide routing:
+
+```java
+import java.util.Arrays;
+
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://dc1-node.example.com:8043"))
+    .credentialsProvider(myCredentials)
+    .withRoutingScope(ClusterScope.create())
+    .withSeedHosts(Arrays.asList(
+        "dc1-node.example.com",
+        "dc2-node.example.com",
+        "dc3-node.example.com"))
+    .build();
+```
+
 #### Fallback Chains
 
 Each scope can have a fallback scope. When no nodes are available in the current scope,
 the client automatically falls back to the next scope in the chain:
+
+For datacenter or rack scoped routing in a multi-datacenter cluster, include a seed host from the
+target datacenter. The client queries configured seeds with the scope filter and only falls back
+after no seed returns nodes for that scope.
 
 ```java
 // Rack -> Datacenter -> Cluster fallback chain

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -93,6 +93,7 @@ public class AlternatorDynamoDbAsyncClient {
     private final AlternatorConfig.Builder configBuilder;
     private URI seedUri;
     private Region region;
+    private boolean seedHostsSet = false;
     private boolean disableCertificateChecks = false;
     private boolean httpClientSet = false;
     private boolean credentialsProviderSet = false;
@@ -117,6 +118,42 @@ public class AlternatorDynamoDbAsyncClient {
      */
     public AlternatorDynamoDbAsyncClientBuilder withRoutingScope(RoutingScope routingScope) {
       configBuilder.withRoutingScope(routingScope);
+      return this;
+    }
+
+    /**
+     * Sets the seed host addresses used for Alternator node discovery.
+     *
+     * <p>{@link #endpointOverride(URI)} is still required and supplies the scheme and port for
+     * these hosts. When {@code ClusterScope} is used, each configured seed is queried for {@code
+     * /localnodes}; provide seeds from every datacenter that should participate in cluster-wide
+     * routing. For datacenter or rack scoped routing in a multi-datacenter cluster, provide a seed
+     * from the target datacenter.
+     *
+     * @param hosts collection of seed host addresses (IP or hostname)
+     * @return this builder instance
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withSeedHosts(Collection<String> hosts) {
+      if (hosts != null) {
+        configBuilder.withSeedHosts(hosts);
+        seedHostsSet = true;
+      }
+      return this;
+    }
+
+    /**
+     * Sets a single seed host address used for Alternator node discovery.
+     *
+     * @param host seed host address (IP or hostname)
+     * @return this builder instance
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withSeedHost(String host) {
+      if (host != null) {
+        configBuilder.withSeedHost(host);
+        seedHostsSet = true;
+      }
       return this;
     }
 
@@ -366,6 +403,10 @@ public class AlternatorDynamoDbAsyncClient {
     @Deprecated
     public AlternatorDynamoDbAsyncClientBuilder withAlternatorConfig(AlternatorConfig config) {
       if (config != null) {
+        if (!config.getSeedHosts().isEmpty()) {
+          configBuilder.withSeedHosts(config.getSeedHosts());
+          seedHostsSet = true;
+        }
         configBuilder.withRoutingScope(config.getRoutingScope());
         configBuilder.withCompressionAlgorithm(config.getCompressionAlgorithm());
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
@@ -631,7 +672,7 @@ public class AlternatorDynamoDbAsyncClient {
         delegate.credentialsProvider(AnonymousCredentialsProvider.create());
       }
 
-      configBuilder.withSeedNode(seedUri);
+      applyEndpointToConfig();
 
       if (disableCertificateChecks) {
         configBuilder.withTlsConfig(TlsConfig.trustAll());
@@ -808,6 +849,15 @@ public class AlternatorDynamoDbAsyncClient {
 
     private boolean needsHttpClientWrapper(AlternatorConfig alternatorConfig) {
       return userAgentTransformer != null || alternatorConfig.isOptimizeHeaders();
+    }
+
+    private void applyEndpointToConfig() {
+      if (seedHostsSet) {
+        configBuilder.withScheme(seedUri.getScheme());
+        configBuilder.withPort(seedUri.getPort());
+        return;
+      }
+      configBuilder.withSeedNode(seedUri);
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -93,6 +93,7 @@ public class AlternatorDynamoDbClient {
     private final AlternatorConfig.Builder configBuilder;
     private URI seedUri;
     private Region region;
+    private boolean seedHostsSet = false;
     private boolean disableCertificateChecks = false;
     private boolean httpClientSet = false;
     private boolean credentialsProviderSet = false;
@@ -133,6 +134,42 @@ public class AlternatorDynamoDbClient {
      */
     public AlternatorDynamoDbClientBuilder withRoutingScope(RoutingScope routingScope) {
       configBuilder.withRoutingScope(routingScope);
+      return this;
+    }
+
+    /**
+     * Sets the seed host addresses used for Alternator node discovery.
+     *
+     * <p>{@link #endpointOverride(URI)} is still required and supplies the scheme and port for
+     * these hosts. When {@code ClusterScope} is used, each configured seed is queried for {@code
+     * /localnodes}; provide seeds from every datacenter that should participate in cluster-wide
+     * routing. For datacenter or rack scoped routing in a multi-datacenter cluster, provide a seed
+     * from the target datacenter.
+     *
+     * @param hosts collection of seed host addresses (IP or hostname)
+     * @return this builder instance
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbClientBuilder withSeedHosts(Collection<String> hosts) {
+      if (hosts != null) {
+        configBuilder.withSeedHosts(hosts);
+        seedHostsSet = true;
+      }
+      return this;
+    }
+
+    /**
+     * Sets a single seed host address used for Alternator node discovery.
+     *
+     * @param host seed host address (IP or hostname)
+     * @return this builder instance
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbClientBuilder withSeedHost(String host) {
+      if (host != null) {
+        configBuilder.withSeedHost(host);
+        seedHostsSet = true;
+      }
       return this;
     }
 
@@ -403,6 +440,10 @@ public class AlternatorDynamoDbClient {
     @Deprecated
     public AlternatorDynamoDbClientBuilder withAlternatorConfig(AlternatorConfig config) {
       if (config != null) {
+        if (!config.getSeedHosts().isEmpty()) {
+          configBuilder.withSeedHosts(config.getSeedHosts());
+          seedHostsSet = true;
+        }
         configBuilder.withRoutingScope(config.getRoutingScope());
         configBuilder.withCompressionAlgorithm(config.getCompressionAlgorithm());
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
@@ -652,7 +693,7 @@ public class AlternatorDynamoDbClient {
         delegate.credentialsProvider(AnonymousCredentialsProvider.create());
       }
 
-      configBuilder.withSeedNode(seedUri);
+      applyEndpointToConfig();
 
       if (disableCertificateChecks) {
         configBuilder.withTlsConfig(TlsConfig.trustAll());
@@ -830,6 +871,15 @@ public class AlternatorDynamoDbClient {
 
     private boolean needsHttpClientWrapper(AlternatorConfig alternatorConfig) {
       return userAgentTransformer != null || alternatorConfig.isOptimizeHeaders();
+    }
+
+    private void applyEndpointToConfig() {
+      if (seedHostsSet) {
+        configBuilder.withScheme(seedUri.getScheme());
+        configBuilder.withPort(seedUri.getPort());
+        return;
+      }
+      configBuilder.withSeedNode(seedUri);
     }
   }
 }

--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -351,16 +351,7 @@ public class AlternatorLiveNodes extends Thread {
     }
     this.alternatorScheme = config.getScheme();
     this.alternatorPort = config.getPort();
-    // Build URIs from hosts, scheme, and port
-    List<URI> seedUris = new ArrayList<>();
-    for (String host : seedHosts) {
-      try {
-        seedUris.add(new URI(alternatorScheme, null, host, alternatorPort, null, null, null));
-      } catch (URISyntaxException e) {
-        throw new RuntimeException("Invalid host: " + host, e);
-      }
-    }
-    this.initialNodes = seedUris;
+    this.initialNodes = hostsToUris(seedHosts);
     this.liveNodes = new AtomicReference<>();
     this.nextLiveNodeIndex = new AtomicInteger(0);
     this.config = config;
@@ -463,6 +454,18 @@ public class AlternatorLiveNodes extends Thread {
     return uri;
   }
 
+  private List<URI> hostsToUris(List<String> hosts) {
+    List<URI> uris = new ArrayList<>();
+    for (String host : hosts) {
+      try {
+        uris.add(hostToURI(host));
+      } catch (URISyntaxException | MalformedURLException e) {
+        throw new RuntimeException("Invalid host: " + host, e);
+      }
+    }
+    return uris;
+  }
+
   /**
    * nextAsURI.
    *
@@ -488,11 +491,15 @@ public class AlternatorLiveNodes extends Thread {
   public URI nextAsURI(String path, String query) {
     try {
       URI uri = this.nextAsURI();
-      return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), path, query, null);
+      return withPathAndQuery(uri, path, query);
     } catch (URISyntaxException e) {
       // Should never happen, nextAsURI content is already validated
       throw new RuntimeException(e);
     }
+  }
+
+  private URI withPathAndQuery(URI uri, String path, String query) throws URISyntaxException {
+    return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), path, query, null);
   }
 
   // Utility function for reading the entire contents of an input stream
@@ -511,10 +518,8 @@ public class AlternatorLiveNodes extends Thread {
     RoutingScope scope = this.config.getRoutingScope();
     IOException lastException = null;
     while (scope != null) {
-      String query = scope.getLocalNodesQuery();
-      URI uri = nextAsURI("/localnodes", query.isEmpty() ? null : query);
       try {
-        List<URI> nodes = getNodes(uri);
+        List<URI> nodes = getNodesForScope(scope);
         if (!nodes.isEmpty()) {
           liveNodes.set(mergeWithInitialNodes(nodes));
           logger.log(
@@ -522,8 +527,7 @@ public class AlternatorLiveNodes extends Thread {
           return;
         }
       } catch (IOException e) {
-        logger.log(
-            Level.WARNING, "Failed to contact node " + uri + " for " + scope.getDescription(), e);
+        logger.log(Level.WARNING, "Failed to discover nodes for " + scope.getDescription(), e);
         lastException = e;
       }
       RoutingScope fallback = scope.getFallback();
@@ -546,6 +550,39 @@ public class AlternatorLiveNodes extends Thread {
     } else {
       logger.log(Level.WARNING, "No nodes found in any routing scope, keeping existing node list");
     }
+  }
+
+  private List<URI> getNodesForScope(RoutingScope scope) throws IOException {
+    String query = scope.getLocalNodesQuery();
+    String requestQuery = query.isEmpty() ? null : query;
+    IOException lastException = null;
+    Set<URI> nodes = new LinkedHashSet<>();
+    for (URI seedNode : initialNodes) {
+      try {
+        List<URI> seedNodes = getNodes(withPathAndQuery(seedNode, "/localnodes", requestQuery));
+        if (!seedNodes.isEmpty()) {
+          if (!(scope instanceof ClusterScope)) {
+            return seedNodes;
+          }
+          nodes.addAll(seedNodes);
+        }
+      } catch (IOException e) {
+        logger.log(
+            Level.WARNING,
+            "Failed to contact seed node " + seedNode + " for " + scope.getDescription(),
+            e);
+        lastException = e;
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    if (!nodes.isEmpty()) {
+      return new ArrayList<>(nodes);
+    }
+    if (lastException != null) {
+      throw lastException;
+    }
+    return Collections.emptyList();
   }
 
   /**
@@ -689,8 +726,7 @@ public class AlternatorLiveNodes extends Thread {
       return;
     }
     try {
-      URI uri = nextAsURI("/localnodes", query);
-      List<URI> nodes = getNodes(uri);
+      List<URI> nodes = getNodesForScope(scope);
       if (nodes.isEmpty()) {
         throw new ValidationError(
             "node returned empty list for "

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.AsyncClientDetector;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.function.UnaryOperator;
 import org.junit.Test;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -168,6 +169,23 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
     assertSame(builder, builder.withUserAgent("custom/1"));
     assertSame(builder, builder.withUserAgent(userAgent -> userAgent + " app/1"));
     assertSame(builder, builder.withoutUserAgent());
+  }
+
+  @Test
+  public void testSeedHostsBuilderPreservesExplicitSeeds() {
+    AlternatorDynamoDbAsyncClientWrapper wrapper =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withSeedHosts(Arrays.asList("127.0.0.1", "127.0.0.2"))
+            .buildWithAlternatorAPI();
+    try {
+      AlternatorConfig config = wrapper.getAlternatorConfig();
+      assertEquals(Arrays.asList("127.0.0.1", "127.0.0.2"), config.getSeedHosts());
+      assertEquals(SEED_URI.getScheme(), config.getScheme());
+      assertEquals(SEED_URI.getPort(), config.getPort());
+    } finally {
+      wrapper.close();
+    }
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.SyncClientDetector;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.function.UnaryOperator;
 import org.junit.Test;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -168,6 +169,23 @@ public class AlternatorDynamoDbClientCustomizerTest {
     assertSame(builder, builder.withUserAgent("custom/1"));
     assertSame(builder, builder.withUserAgent(userAgent -> userAgent + " app/1"));
     assertSame(builder, builder.withoutUserAgent());
+  }
+
+  @Test
+  public void testSeedHostsBuilderPreservesExplicitSeeds() {
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withSeedHosts(Arrays.asList("127.0.0.1", "127.0.0.2"))
+            .buildWithAlternatorAPI();
+    try {
+      AlternatorConfig config = wrapper.getAlternatorConfig();
+      assertEquals(Arrays.asList("127.0.0.1", "127.0.0.2"), config.getSeedHosts());
+      assertEquals(SEED_URI.getScheme(), config.getScheme());
+      assertEquals(SEED_URI.getPort(), config.getPort());
+    } finally {
+      wrapper.close();
+    }
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesClusterDiscoveryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesClusterDiscoveryTest.java
@@ -1,0 +1,234 @@
+package com.scylladb.alternator.internal;
+
+import static org.junit.Assert.*;
+
+import com.scylladb.alternator.AlternatorConfig;
+import com.scylladb.alternator.routing.ClusterScope;
+import com.scylladb.alternator.routing.DatacenterScope;
+import com.scylladb.alternator.routing.RackScope;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.Test;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+/** Unit tests for cluster-wide discovery across user-provided seed nodes. */
+public class AlternatorLiveNodesClusterDiscoveryTest {
+
+  private static class DiscoveryHttpClient implements SdkHttpClient {
+    final List<SdkHttpRequest> capturedRequests = new CopyOnWriteArrayList<>();
+    private final Map<String, String> responsesByHost;
+    private final Set<String> failingHosts;
+
+    DiscoveryHttpClient(Map<String, String> responsesByHost) {
+      this(responsesByHost, Collections.<String>emptySet());
+    }
+
+    DiscoveryHttpClient(Map<String, String> responsesByHost, Set<String> failingHosts) {
+      this.responsesByHost = responsesByHost;
+      this.failingHosts = failingHosts;
+    }
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      SdkHttpRequest httpRequest = request.httpRequest();
+      capturedRequests.add(httpRequest);
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() throws IOException {
+          String host = httpRequest.host();
+          if (failingHosts.contains(host)) {
+            throw new IOException("simulated discovery failure for " + host);
+          }
+          if (!responsesByHost.containsKey(host)) {
+            throw new AssertionError("Unexpected discovery host: " + host);
+          }
+          byte[] body = responsesByHost.get(host).getBytes(StandardCharsets.UTF_8);
+          return HttpExecuteResponse.builder()
+              .response(SdkHttpFullResponse.builder().statusCode(200).build())
+              .responseBody(AbortableInputStream.create(new ByteArrayInputStream(body)))
+              .build();
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "DiscoveryHttpClient";
+    }
+  }
+
+  @Test
+  public void testClusterScopeMergesConfiguredSeedNodes() throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    responses.put("dc1-node1.example.com", "[\"dc1-node1.example.com\",\"dc1-node2.example.com\"]");
+    responses.put("dc2-node1.example.com", "[\"dc2-node1.example.com\",\"dc2-node2.example.com\"]");
+    DiscoveryHttpClient httpClient = new DiscoveryHttpClient(responses);
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHosts(Arrays.asList("dc1-node1.example.com", "dc2-node1.example.com"))
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(ClusterScope.create())
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+
+    liveNodes.updateLiveNodes();
+
+    assertEquals(
+        new LinkedHashSet<>(
+            Arrays.asList(
+                "dc1-node1.example.com",
+                "dc1-node2.example.com",
+                "dc2-node1.example.com",
+                "dc2-node2.example.com")),
+        hostSet(liveNodes.getLiveNodes()));
+    assertEquals(
+        new HashSet<>(Arrays.asList("dc1-node1.example.com", "dc2-node1.example.com")),
+        capturedHostSet(httpClient.capturedRequests));
+    for (SdkHttpRequest request : httpClient.capturedRequests) {
+      assertEquals("/localnodes", request.encodedPath());
+      assertTrue(request.rawQueryParameters().isEmpty());
+    }
+  }
+
+  @Test
+  public void testClusterScopeKeepsSuccessfulDiscoveryWhenAnotherSeedFails() throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    responses.put("dc1-node1.example.com", "[\"dc1-node1.example.com\"]");
+    DiscoveryHttpClient httpClient =
+        new DiscoveryHttpClient(responses, new HashSet<>(Arrays.asList("dc2-node1.example.com")));
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHosts(Arrays.asList("dc1-node1.example.com", "dc2-node1.example.com"))
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(ClusterScope.create())
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+
+    liveNodes.updateLiveNodes();
+
+    assertEquals(
+        new LinkedHashSet<>(Arrays.asList("dc1-node1.example.com", "dc2-node1.example.com")),
+        hostSet(liveNodes.getLiveNodes()));
+    assertEquals(
+        new HashSet<>(Arrays.asList("dc1-node1.example.com", "dc2-node1.example.com")),
+        capturedHostSet(httpClient.capturedRequests));
+  }
+
+  @Test
+  public void testRackScopeTriesNextSeedWhenFirstSeedIsInWrongDatacenter() throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    responses.put("dc2-node1.example.com", "[]");
+    responses.put("dc1-node1.example.com", "[\"dc1-rack1-node.example.com\"]");
+    DiscoveryHttpClient httpClient = new DiscoveryHttpClient(responses);
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHosts(Arrays.asList("dc2-node1.example.com", "dc1-node1.example.com"))
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(
+                RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create())))
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+
+    liveNodes.updateLiveNodes();
+
+    assertEquals(
+        new LinkedHashSet<>(
+            Arrays.asList(
+                "dc1-rack1-node.example.com", "dc2-node1.example.com", "dc1-node1.example.com")),
+        hostSet(liveNodes.getLiveNodes()));
+    assertEquals(
+        Arrays.asList("dc2-node1.example.com", "dc1-node1.example.com"),
+        capturedHosts(httpClient.capturedRequests));
+    for (SdkHttpRequest request : httpClient.capturedRequests) {
+      assertTrue(request.rawQueryParameters().containsKey("dc"));
+      assertTrue(request.rawQueryParameters().containsKey("rack"));
+    }
+  }
+
+  @Test
+  public void testRackScopeValidationTriesNextSeedWhenFirstSeedIsInWrongDatacenter()
+      throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    responses.put("dc2-node1.example.com", "[]");
+    responses.put("dc1-node1.example.com", "[\"dc1-rack1-node.example.com\"]");
+    DiscoveryHttpClient httpClient = new DiscoveryHttpClient(responses);
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHosts(Arrays.asList("dc2-node1.example.com", "dc1-node1.example.com"))
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(
+                RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create())))
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+
+    liveNodes.checkIfRackAndDatacenterSetCorrectly();
+
+    assertEquals(
+        Arrays.asList("dc2-node1.example.com", "dc1-node1.example.com"),
+        capturedHosts(httpClient.capturedRequests));
+    for (SdkHttpRequest request : httpClient.capturedRequests) {
+      assertTrue(request.rawQueryParameters().containsKey("dc"));
+      assertTrue(request.rawQueryParameters().containsKey("rack"));
+    }
+  }
+
+  private static Set<String> hostSet(List<URI> uris) {
+    Set<String> hosts = new LinkedHashSet<>();
+    for (URI uri : uris) {
+      hosts.add(uri.getHost());
+    }
+    return hosts;
+  }
+
+  private static Set<String> capturedHostSet(List<SdkHttpRequest> requests) {
+    Set<String> hosts = new HashSet<>();
+    for (SdkHttpRequest request : requests) {
+      hosts.add(request.host());
+    }
+    return hosts;
+  }
+
+  private static List<String> capturedHosts(List<SdkHttpRequest> requests) {
+    List<String> hosts = new ArrayList<>();
+    for (SdkHttpRequest request : requests) {
+      hosts.add(request.host());
+    }
+    return hosts;
+  }
+}


### PR DESCRIPTION
## Summary
- expose `withSeedHosts` / `withSeedHost` on the sync and async DynamoDB builders so users can provide discovery seeds directly
- use configured seed hosts as discovery entry points for `ClusterScope`, `DatacenterScope`, and `RackScope`
- merge `ClusterScope` `/localnodes` responses across all configured seeds, so cluster-wide routing can include nodes from all participating datacenters
- for datacenter/rack scoped routing, query each configured seed with the scope filter and only fall back after no seed returns nodes for that scope
- document that cluster-wide routing needs seeds from participating datacenters, and rack/datacenter scope in a multi-DC cluster needs a seed from the target datacenter

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 mvn fmt:check`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 mvn checkstyle:check`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 mvn test`

Closes #116