### PR TITLE
Fix user-agent state when copying Alternator config

### DIFF
--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -413,6 +413,10 @@ public class AlternatorDynamoDbAsyncClient {
         configBuilder.withOptimizeHeaders(config.isOptimizeHeaders());
         configBuilder.withHeadersWhitelist(config.getHeadersWhitelist());
         configBuilder.withUserAgentEnabled(config.isUserAgentEnabled());
+        userAgentTransformer =
+            config.isUserAgentEnabled()
+                ? AlternatorUserAgent.defaultUserAgent()
+                : AlternatorUserAgent.disable();
         configBuilder.withTlsConfig(config.getTlsConfig());
         configBuilder.withTlsSessionCacheConfig(config.getTlsSessionCacheConfig());
         configBuilder.withKeyRouteAffinity(config.getKeyRouteAffinityConfig());

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -450,6 +450,10 @@ public class AlternatorDynamoDbClient {
         configBuilder.withOptimizeHeaders(config.isOptimizeHeaders());
         configBuilder.withHeadersWhitelist(config.getHeadersWhitelist());
         configBuilder.withUserAgentEnabled(config.isUserAgentEnabled());
+        userAgentTransformer =
+            config.isUserAgentEnabled()
+                ? AlternatorUserAgent.defaultUserAgent()
+                : AlternatorUserAgent.disable();
         configBuilder.withTlsConfig(config.getTlsConfig());
         configBuilder.withTlsSessionCacheConfig(config.getTlsSessionCacheConfig());
         configBuilder.withKeyRouteAffinity(config.getKeyRouteAffinityConfig());

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
@@ -3,6 +3,7 @@ package com.scylladb.alternator;
 import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.AsyncClientDetector;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.function.UnaryOperator;
@@ -370,6 +371,28 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
     builder.validateAndDetectAsyncClientType();
   }
 
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testWithAlternatorConfigDisablesUserAgentTransformer() throws Exception {
+    AlternatorConfig config =
+        AlternatorConfig.builder().withOptimizeHeaders(true).withUserAgentEnabled(false).build();
+    var builder = AlternatorDynamoDbAsyncClient.builder().withAlternatorConfig(config);
+
+    assertNull(userAgentTransformer(builder).apply("aws-sdk-java/2.x"));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testWithAlternatorConfigEnablesDefaultUserAgentTransformer() throws Exception {
+    AlternatorConfig config = AlternatorConfig.builder().withUserAgentEnabled(true).build();
+    var builder =
+        AlternatorDynamoDbAsyncClient.builder().withoutUserAgent().withAlternatorConfig(config);
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        userAgentTransformer(builder).apply("aws-sdk-java/2.x"));
+  }
+
   @Test(expected = IllegalStateException.class)
   public void testHttpClientTypeConflictsWithHttpClientBuilder() {
     AlternatorDynamoDbAsyncClient.builder()
@@ -387,5 +410,13 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
             .withTlsConfig(TlsConfig.trustAll())
             .withNettyHttpClientCustomizer(b -> {});
     assertNotNull("Builder with TLS and customizer should be valid", builder);
+  }
+
+  @SuppressWarnings("unchecked")
+  private UnaryOperator<String> userAgentTransformer(
+      AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder) throws Exception {
+    Field field = builder.getClass().getDeclaredField("userAgentTransformer");
+    field.setAccessible(true);
+    return (UnaryOperator<String>) field.get(builder);
   }
 }

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
@@ -3,6 +3,7 @@ package com.scylladb.alternator;
 import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.SyncClientDetector;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.function.UnaryOperator;
@@ -370,6 +371,28 @@ public class AlternatorDynamoDbClientCustomizerTest {
     builder.validateAndDetectSyncClientType();
   }
 
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testWithAlternatorConfigDisablesUserAgentTransformer() throws Exception {
+    AlternatorConfig config =
+        AlternatorConfig.builder().withOptimizeHeaders(true).withUserAgentEnabled(false).build();
+    var builder = AlternatorDynamoDbClient.builder().withAlternatorConfig(config);
+
+    assertNull(userAgentTransformer(builder).apply("aws-sdk-java/2.x"));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testWithAlternatorConfigEnablesDefaultUserAgentTransformer() throws Exception {
+    AlternatorConfig config = AlternatorConfig.builder().withUserAgentEnabled(true).build();
+    var builder =
+        AlternatorDynamoDbClient.builder().withoutUserAgent().withAlternatorConfig(config);
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        userAgentTransformer(builder).apply("aws-sdk-java/2.x"));
+  }
+
   @Test(expected = IllegalStateException.class)
   public void testHttpClientTypeConflictsWithHttpClientBuilder() {
     AlternatorDynamoDbClient.builder()
@@ -387,5 +410,13 @@ public class AlternatorDynamoDbClientCustomizerTest {
             .withTlsConfig(TlsConfig.trustAll())
             .withApacheHttpClientCustomizer(b -> {});
     assertNotNull("Builder with TLS and customizer should be valid", builder);
+  }
+
+  @SuppressWarnings("unchecked")
+  private UnaryOperator<String> userAgentTransformer(
+      AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder) throws Exception {
+    Field field = builder.getClass().getDeclaredField("userAgentTransformer");
+    field.setAccessible(true);
+    return (UnaryOperator<String>) field.get(builder);
   }
 }


### PR DESCRIPTION
Fixes #121

## Summary
- synchronize the builder user-agent transformer when `withAlternatorConfig(...)` copies `userAgentEnabled`
- restore the default Alternator user-agent when copied config enables it
- use the disable transformer when copied config disables it
- add sync and async regression tests for both copied states

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -Dtest=AlternatorDynamoDbClientCustomizerTest,AlternatorDynamoDbAsyncClientCustomizerTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn fmt:check`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn checkstyle:check`