### PR TITLE
Close async affinity resolver with wrapper

### DIFF
--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -711,11 +711,12 @@ public class AlternatorDynamoDbAsyncClient {
               : ClientOverrideConfiguration.builder();
 
       KeyRouteAffinityConfig keyAffinityConfig = alternatorConfig.getKeyRouteAffinityConfig();
+      AffinityQueryPlanInterceptor affinityInterceptor = null;
       if (keyAffinityConfig != null
           && keyAffinityConfig.getType() != null
           && keyAffinityConfig.getType() != KeyRouteAffinity.NONE) {
-        overrideBuilder.addExecutionInterceptor(
-            new AffinityQueryPlanInterceptor(keyAffinityConfig, liveNodes));
+        affinityInterceptor = new AffinityQueryPlanInterceptor(keyAffinityConfig, liveNodes);
+        overrideBuilder.addExecutionInterceptor(affinityInterceptor);
       } else {
         overrideBuilder.addExecutionInterceptor(new BasicQueryPlanInterceptor(liveNodes));
       }
@@ -729,7 +730,7 @@ public class AlternatorDynamoDbAsyncClient {
 
       DynamoDbAsyncClient client = delegate.build();
       return new AlternatorDynamoDbAsyncClientWrapper(
-          client, liveNodes, alternatorConfig, pollingClient);
+          client, liveNodes, alternatorConfig, affinityInterceptor, pollingClient);
     }
 
     /**

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientWrapper.java
@@ -1,6 +1,7 @@
 package com.scylladb.alternator;
 
 import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.queryplan.AffinityQueryPlanInterceptor;
 import java.net.URI;
 import java.util.List;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -38,6 +39,7 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
   private final DynamoDbAsyncClient client;
   private final AlternatorLiveNodes liveNodes;
   private final AlternatorConfig config;
+  private final AffinityQueryPlanInterceptor affinityInterceptor;
   private final SdkHttpClient pollingHttpClient;
 
   /**
@@ -48,7 +50,7 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
    */
   public AlternatorDynamoDbAsyncClientWrapper(
       DynamoDbAsyncClient client, AlternatorLiveNodes liveNodes) {
-    this(client, liveNodes, null, null);
+    this(client, liveNodes, null, null, null);
   }
 
   /**
@@ -60,7 +62,7 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
    */
   public AlternatorDynamoDbAsyncClientWrapper(
       DynamoDbAsyncClient client, AlternatorLiveNodes liveNodes, AlternatorConfig config) {
-    this(client, liveNodes, config, null);
+    this(client, liveNodes, config, null, null);
   }
 
   /**
@@ -77,9 +79,30 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
       AlternatorLiveNodes liveNodes,
       AlternatorConfig config,
       SdkHttpClient pollingHttpClient) {
+    this(client, liveNodes, config, null, pollingHttpClient);
+  }
+
+  /**
+   * Creates a new wrapper with the given client, live nodes, config, interceptor, and polling
+   * client.
+   *
+   * @param client the underlying DynamoDbAsyncClient
+   * @param liveNodes the AlternatorLiveNodes instance managing node discovery
+   * @param config the AlternatorConfig used for this client
+   * @param affinityInterceptor the AffinityQueryPlanInterceptor (may be null)
+   * @param pollingHttpClient the SdkHttpClient used for LiveNodes polling (may be null)
+   * @since 2.1.0
+   */
+  public AlternatorDynamoDbAsyncClientWrapper(
+      DynamoDbAsyncClient client,
+      AlternatorLiveNodes liveNodes,
+      AlternatorConfig config,
+      AffinityQueryPlanInterceptor affinityInterceptor,
+      SdkHttpClient pollingHttpClient) {
     this.client = client;
     this.liveNodes = liveNodes;
     this.config = config;
+    this.affinityInterceptor = affinityInterceptor;
     this.pollingHttpClient = pollingHttpClient;
   }
 
@@ -145,6 +168,8 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
    * <p>This includes:
    *
    * <ul>
+   *   <li>Shutting down the partition key resolver's discovery executor if key route affinity is
+   *       enabled
    *   <li>Stopping the LiveNodes background thread
    *   <li>Closing the polling HTTP client
    *   <li>Closing the underlying async DynamoDB client
@@ -152,6 +177,9 @@ public class AlternatorDynamoDbAsyncClientWrapper implements AutoCloseable {
    */
   @Override
   public void close() {
+    if (affinityInterceptor != null) {
+      affinityInterceptor.getPartitionKeyResolver().shutdown();
+    }
     liveNodes.shutdownAndWait();
     if (pollingHttpClient != null) {
       pollingHttpClient.close();

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapperShutdownTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientWrapperShutdownTest.java
@@ -3,8 +3,11 @@ package com.scylladb.alternator;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.scylladb.alternator.internal.AlternatorLiveNodes;
+import com.scylladb.alternator.keyrouting.PartitionKeyResolver;
+import com.scylladb.alternator.queryplan.AffinityQueryPlanInterceptor;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,6 +63,39 @@ public class AlternatorDynamoDbClientWrapperShutdownTest {
     wrapper.close();
 
     assertEquals(Arrays.asList("live-nodes", "polling-client", "client"), events);
+  }
+
+  @Test
+  public void testAsyncWrapperShutsDownAffinityResolverBeforeClosingClients() {
+    List<String> events = new ArrayList<>();
+    TrackingLiveNodes liveNodes = new TrackingLiveNodes(events);
+    TrackingPollingClient pollingClient = new TrackingPollingClient(events);
+    DynamoDbAsyncClient client = mock(DynamoDbAsyncClient.class);
+    AffinityQueryPlanInterceptor affinityInterceptor = mock(AffinityQueryPlanInterceptor.class);
+    PartitionKeyResolver resolver = mock(PartitionKeyResolver.class);
+    when(affinityInterceptor.getPartitionKeyResolver()).thenReturn(resolver);
+    doAnswer(
+            invocation -> {
+              events.add("resolver");
+              return null;
+            })
+        .when(resolver)
+        .shutdown();
+    doAnswer(
+            invocation -> {
+              events.add("client");
+              return null;
+            })
+        .when(client)
+        .close();
+
+    AlternatorDynamoDbAsyncClientWrapper wrapper =
+        new AlternatorDynamoDbAsyncClientWrapper(
+            client, liveNodes, null, affinityInterceptor, pollingClient);
+
+    wrapper.close();
+
+    assertEquals(Arrays.asList("resolver", "live-nodes", "polling-client", "client"), events);
   }
 
   private static final class TrackingLiveNodes extends AlternatorLiveNodes {


### PR DESCRIPTION
Fixes #122

## Summary
- retain the async affinity interceptor in `AlternatorDynamoDbAsyncClientWrapper`
- shut down the interceptor partition-key resolver before closing live-node and HTTP resources
- keep existing async wrapper constructors compatible by delegating to the new overload
- add a shutdown-order regression test for the async affinity resolver

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -Dtest=AlternatorDynamoDbClientWrapperShutdownTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn fmt:check checkstyle:check`