### PR TITLE
Handle malformed localnodes responses

### DIFF
--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -631,29 +631,46 @@ public class AlternatorLiveNodes extends Thread {
         responseStr = streamToString(body);
       }
 
-      // response looks like: ["127.0.0.2","127.0.0.3","127.0.0.1"]
-      responseStr = responseStr.trim();
-      responseStr = responseStr.substring(1, responseStr.length() - 1);
-      String[] list = responseStr.split(",");
-      List<URI> newHosts = new ArrayList<>();
-      for (String host : list) {
-        if (host.isEmpty()) {
-          continue;
-        }
-        host = host.trim();
-        host = host.substring(1, host.length() - 1);
-        try {
-          newHosts.add(this.hostToURI(host));
-        } catch (URISyntaxException | MalformedURLException e) {
-          logger.log(Level.WARNING, "Invalid host: " + host, e);
-        }
-      }
-      return newHosts;
+      return parseLocalNodesResponse(responseStr);
     } catch (IOException e) {
       // Ensure the response body is consumed on error
       response.responseBody().ifPresent(this::consumeAndClose);
       throw e;
     }
+  }
+
+  private List<URI> parseLocalNodesResponse(String responseStr) {
+    // response looks like: ["127.0.0.2","127.0.0.3","127.0.0.1"]
+    responseStr = responseStr.trim();
+    if (!responseStr.startsWith("[") || !responseStr.endsWith("]")) {
+      logger.log(Level.WARNING, "Malformed /localnodes response: " + responseStr);
+      return Collections.emptyList();
+    }
+
+    String responseBody = responseStr.substring(1, responseStr.length() - 1).trim();
+    if (responseBody.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    String[] list = responseBody.split(",");
+    List<URI> newHosts = new ArrayList<>();
+    for (String host : list) {
+      host = host.trim();
+      if (host.isEmpty()) {
+        continue;
+      }
+      if (host.length() < 2 || !host.startsWith("\"") || !host.endsWith("\"")) {
+        logger.log(Level.WARNING, "Malformed host entry in /localnodes response: " + host);
+        continue;
+      }
+      host = host.substring(1, host.length() - 1);
+      try {
+        newHosts.add(this.hostToURI(host));
+      } catch (URISyntaxException | MalformedURLException e) {
+        logger.log(Level.WARNING, "Invalid host: " + host, e);
+      }
+    }
+    return newHosts;
   }
 
   /**

--- a/src/test/java/com/scylladb/alternator/internal/ConnectionLeakTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/ConnectionLeakTest.java
@@ -93,6 +93,22 @@ public class ConnectionLeakTest {
     assertEquals(2, liveNodes.getLiveNodes().size());
   }
 
+  /** Verifies malformed successful /localnodes responses do not terminate discovery. */
+  @Test(timeout = 10000)
+  public void testMalformedSuccessfulResponsesDoNotThrowOrLeakConnections() throws Exception {
+    responseCode = 200;
+    String[] malformedBodies = {"", "not-json", "[", "[\"127.0.0.1\",bad]", "[bad]"};
+    AlternatorLiveNodes liveNodes = createLiveNodes();
+
+    for (int i = 0; i < 30; i++) {
+      responseBody = malformedBodies[i % malformedBodies.length];
+      liveNodes.updateLiveNodes();
+    }
+
+    assertEquals(1, liveNodes.getLiveNodes().size());
+    assertEquals("127.0.0.1", liveNodes.getLiveNodes().get(0).getHost());
+  }
+
   /** Verifies no leaks when alternating between error and success responses. */
   @Test(timeout = 10000)
   public void testNoConnectionLeakOnAlternatingResponses() throws Exception {


### PR DESCRIPTION
Fixes #123

## Summary
- validate `/localnodes` response shape before parsing host entries
- return an empty discovery result for malformed top-level responses instead of throwing runtime exceptions
- skip malformed host entries while preserving valid entries
- add a regression test that repeatedly polls malformed successful responses without throwing or leaking connections

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -Dtest=ConnectionLeakTest,AlternatorLiveNodesScopeFallbackTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn fmt:check checkstyle:check`