### PR TITLE
Compress async request bodies

### DIFF
--- a/src/main/java/com/scylladb/alternator/GzipRequestInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/GzipRequestInterceptor.java
@@ -3,8 +3,11 @@ package com.scylladb.alternator;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.zip.GZIPOutputStream;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -46,32 +49,32 @@ public class GzipRequestInterceptor implements ExecutionInterceptor {
   public SdkHttpRequest modifyHttpRequest(
       Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
 
-    Optional<RequestBody> requestBody = context.requestBody();
-    if (!requestBody.isPresent()) {
-      executionAttributes.putAttribute(SHOULD_COMPRESS, false);
-      return context.httpRequest();
-    }
-
+    byte[] originalContent;
     try {
-      // Read the original content and cache it for modifyHttpContent
-      byte[] originalContent = readAllBytes(requestBody.get().contentStreamProvider().newStream());
-      executionAttributes.putAttribute(ORIGINAL_BODY_BYTES, originalContent);
-
-      // Check if we should compress based on size
-      boolean shouldCompress = originalContent.length >= minCompressionSizeBytes;
-      executionAttributes.putAttribute(SHOULD_COMPRESS, shouldCompress);
-
-      if (shouldCompress) {
-        // Add Content-Encoding header
-        return context.httpRequest().toBuilder().putHeader("Content-Encoding", "gzip").build();
-      }
-
-      return context.httpRequest();
-
-    } catch (IOException e) {
+      originalContent = readOriginalBody(context);
+    } catch (IOException | CompletionException e) {
       executionAttributes.putAttribute(SHOULD_COMPRESS, false);
       return context.httpRequest();
     }
+
+    if (originalContent == null) {
+      executionAttributes.putAttribute(SHOULD_COMPRESS, false);
+      return context.httpRequest();
+    }
+
+    // Cache the original content for modifyHttpContent / modifyAsyncHttpContent.
+    executionAttributes.putAttribute(ORIGINAL_BODY_BYTES, originalContent);
+
+    // Check if we should compress based on size.
+    boolean shouldCompress = originalContent.length >= minCompressionSizeBytes;
+    executionAttributes.putAttribute(SHOULD_COMPRESS, shouldCompress);
+
+    if (shouldCompress) {
+      // Add Content-Encoding header.
+      return context.httpRequest().toBuilder().putHeader("Content-Encoding", "gzip").build();
+    }
+
+    return context.httpRequest();
   }
 
   @Override
@@ -104,6 +107,46 @@ public class GzipRequestInterceptor implements ExecutionInterceptor {
     }
   }
 
+  @Override
+  public Optional<AsyncRequestBody> modifyAsyncHttpContent(
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+
+    Boolean shouldCompress = executionAttributes.getAttribute(SHOULD_COMPRESS);
+    if (shouldCompress == null || !shouldCompress) {
+      byte[] cachedBytes = executionAttributes.getAttribute(ORIGINAL_BODY_BYTES);
+      if (cachedBytes != null) {
+        return Optional.of(AsyncRequestBody.fromBytes(cachedBytes));
+      }
+      return context.asyncRequestBody();
+    }
+
+    byte[] originalContent = executionAttributes.getAttribute(ORIGINAL_BODY_BYTES);
+    if (originalContent == null) {
+      return context.asyncRequestBody();
+    }
+
+    try {
+      byte[] compressedContent = gzipCompress(originalContent);
+      return Optional.of(AsyncRequestBody.fromBytes(compressedContent));
+    } catch (IOException e) {
+      return Optional.of(AsyncRequestBody.fromBytes(originalContent));
+    }
+  }
+
+  private byte[] readOriginalBody(Context.ModifyHttpRequest context) throws IOException {
+    Optional<RequestBody> requestBody = context.requestBody();
+    if (requestBody.isPresent()) {
+      return readAllBytes(requestBody.get().contentStreamProvider().newStream());
+    }
+
+    Optional<AsyncRequestBody> asyncRequestBody = context.asyncRequestBody();
+    if (asyncRequestBody.isPresent()) {
+      return readAllBytes(asyncRequestBody.get());
+    }
+
+    return null;
+  }
+
   private byte[] readAllBytes(InputStream is) throws IOException {
     try {
       ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -116,6 +159,20 @@ public class GzipRequestInterceptor implements ExecutionInterceptor {
     } finally {
       is.close();
     }
+  }
+
+  private byte[] readAllBytes(AsyncRequestBody requestBody) {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    requestBody
+        .subscribe(
+            byteBuffer -> {
+              ByteBuffer copy = byteBuffer.asReadOnlyBuffer();
+              byte[] data = new byte[copy.remaining()];
+              copy.get(data);
+              buffer.write(data, 0, data.length);
+            })
+        .join();
+    return buffer.toByteArray();
   }
 
   private byte[] gzipCompress(byte[] data) throws IOException {

--- a/src/test/java/com/scylladb/alternator/GzipRequestInterceptorTest.java
+++ b/src/test/java/com/scylladb/alternator/GzipRequestInterceptorTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +66,31 @@ public class GzipRequestInterceptorTest {
     };
   }
 
+  private Context.ModifyHttpRequest createAsyncMockContext(
+      SdkHttpRequest httpRequest, AsyncRequestBody body) {
+    return new Context.ModifyHttpRequest() {
+      @Override
+      public SdkHttpRequest httpRequest() {
+        return httpRequest;
+      }
+
+      @Override
+      public Optional<RequestBody> requestBody() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<AsyncRequestBody> asyncRequestBody() {
+        return Optional.ofNullable(body);
+      }
+
+      @Override
+      public SdkRequest request() {
+        return ListTablesRequest.builder().build();
+      }
+    };
+  }
+
   private byte[] gzipDecompress(byte[] compressed) throws IOException {
     ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
     GZIPInputStream gis = new GZIPInputStream(bis);
@@ -92,6 +118,21 @@ public class GzipRequestInterceptorTest {
     while ((len = is.read(buf)) != -1) {
       bos.write(buf, 0, len);
     }
+    return bos.toByteArray();
+  }
+
+  private byte[] readAsyncRequestBody(Optional<AsyncRequestBody> body) {
+    assertTrue("Async request body should be present", body.isPresent());
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    body.get()
+        .subscribe(
+            byteBuffer -> {
+              ByteBuffer copy = byteBuffer.asReadOnlyBuffer();
+              byte[] bytes = new byte[copy.remaining()];
+              copy.get(bytes);
+              bos.write(bytes, 0, bytes.length);
+            })
+        .join();
     return bos.toByteArray();
   }
 
@@ -127,6 +168,45 @@ public class GzipRequestInterceptorTest {
     byte[] compressedBytes = readRequestBody(modifiedBody);
     byte[] decompressed = gzipDecompress(compressedBytes);
     assertArrayEquals("Decompressed body should match original", testData, decompressed);
+  }
+
+  @Test
+  public void testAsyncCompressedBodyIsValidGzip() throws IOException {
+    GzipRequestInterceptor interceptor = new GzipRequestInterceptor(DEFAULT_MIN_COMPRESSION_SIZE);
+    byte[] testData = generateTestData(1024);
+    SdkHttpRequest httpRequest = createHttpRequest();
+    AsyncRequestBody requestBody = AsyncRequestBody.fromBytes(testData);
+    Context.ModifyHttpRequest context = createAsyncMockContext(httpRequest, requestBody);
+    ExecutionAttributes attrs = new ExecutionAttributes();
+
+    SdkHttpRequest modifiedRequest = interceptor.modifyHttpRequest(context, attrs);
+    Optional<AsyncRequestBody> modifiedBody = interceptor.modifyAsyncHttpContent(context, attrs);
+
+    assertTrue(
+        "Content-Encoding header should be present",
+        modifiedRequest.headers().containsKey("Content-Encoding"));
+    byte[] compressedBytes = readAsyncRequestBody(modifiedBody);
+    byte[] decompressed = gzipDecompress(compressedBytes);
+    assertArrayEquals("Decompressed async body should match original", testData, decompressed);
+  }
+
+  @Test
+  public void testAsyncBodyBelowMinCompressionSizeIsNotCompressed() {
+    int minSize = 512;
+    GzipRequestInterceptor interceptor = new GzipRequestInterceptor(minSize);
+    byte[] testData = generateTestData(256);
+    SdkHttpRequest httpRequest = createHttpRequest();
+    AsyncRequestBody requestBody = AsyncRequestBody.fromBytes(testData);
+    Context.ModifyHttpRequest context = createAsyncMockContext(httpRequest, requestBody);
+    ExecutionAttributes attrs = new ExecutionAttributes();
+
+    SdkHttpRequest modifiedRequest = interceptor.modifyHttpRequest(context, attrs);
+    Optional<AsyncRequestBody> modifiedBody = interceptor.modifyAsyncHttpContent(context, attrs);
+
+    assertFalse(
+        "Content-Encoding header should NOT be present for small async body",
+        modifiedRequest.headers().containsKey("Content-Encoding"));
+    assertArrayEquals(testData, readAsyncRequestBody(modifiedBody));
   }
 
   @Test


### PR DESCRIPTION
Fixes #120

## Summary
- teach `GzipRequestInterceptor` to read async request bodies during the compression decision step
- implement `modifyAsyncHttpContent(...)` so async clients receive a compressed `AsyncRequestBody`
- preserve original async bytes when the body is below the compression threshold
- add async-only unit coverage for compressed and uncompressed request bodies

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -Dtest=GzipRequestInterceptorTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn fmt:check checkstyle:check`