### PR TITLE
Handle hostname verification TLS config

### DIFF
--- a/src/main/java/com/scylladb/alternator/internal/ApacheSyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/ApacheSyncClientFactory.java
@@ -4,8 +4,12 @@ import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.TlsConfig;
 import java.time.Duration;
 import java.util.function.Consumer;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -99,6 +103,12 @@ public final class ApacheSyncClientFactory {
 
   private static void applyTlsManagers(ApacheHttpClient.Builder builder, TlsConfig tlsConfig) {
     if (tlsConfig == null) {
+      return;
+    }
+    if (TlsHttpClientSupport.requiresHostnameVerificationDisabled(tlsConfig)) {
+      SSLContext sslContext = TlsContextFactory.createSslContext(tlsConfig);
+      HostnameVerifier hostnameVerifier = NoopHostnameVerifier.INSTANCE;
+      builder.socketFactory(new SSLConnectionSocketFactory(sslContext, hostnameVerifier));
       return;
     }
     if (tlsConfig.hasClientCertificate()) {

--- a/src/main/java/com/scylladb/alternator/internal/CrtAsyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/CrtAsyncClientFactory.java
@@ -77,13 +77,7 @@ public final class CrtAsyncClientFactory {
       }
     }
 
-    // Validate CRT limitations
-    if (tlsConfig != null
-        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate())) {
-      throw new UnsupportedOperationException(
-          "Custom CA certificates and client TLS certificates are not supported with the CRT async HTTP client. "
-              + "Use Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
-    }
+    validateTlsConfig(tlsConfig);
 
     // Apply user customizer last — allows overriding any defaults
     if (customizer != null) {
@@ -97,5 +91,17 @@ public final class CrtAsyncClientFactory {
               .build());
     }
     return builder.build();
+  }
+
+  private static void validateTlsConfig(TlsConfig tlsConfig) {
+    if (tlsConfig == null) {
+      return;
+    }
+    TlsHttpClientSupport.rejectUnsupportedHostnameVerification(tlsConfig, "CRT async");
+    if (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate()) {
+      throw new UnsupportedOperationException(
+          "Custom CA certificates and client TLS certificates are not supported with the CRT async HTTP client. "
+              + "Use Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
+    }
   }
 }

--- a/src/main/java/com/scylladb/alternator/internal/CrtSyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/CrtSyncClientFactory.java
@@ -75,13 +75,7 @@ public final class CrtSyncClientFactory {
       }
     }
 
-    // Validate CRT limitations before customizer
-    if (tlsConfig != null
-        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate())) {
-      throw new UnsupportedOperationException(
-          "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "
-              + "Use Apache or Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
-    }
+    validateTlsConfig(tlsConfig);
 
     // Apply user customizer last — allows overriding any defaults
     if (customizer != null) {
@@ -98,12 +92,7 @@ public final class CrtSyncClientFactory {
    * @return a configured SdkHttpClient with small pool size
    */
   public static SdkHttpClient createPollingClient(TlsConfig tlsConfig) {
-    if (tlsConfig != null
-        && (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate())) {
-      throw new UnsupportedOperationException(
-          "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "
-              + "Use Apache or Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
-    }
+    validateTlsConfig(tlsConfig);
     AwsCrtHttpClient.Builder builder = AwsCrtHttpClient.builder();
     builder.tcpKeepAliveConfiguration(
         TcpKeepAliveConfiguration.builder()
@@ -117,11 +106,7 @@ public final class CrtSyncClientFactory {
 
   private static SdkHttpClient buildWithTls(AwsCrtHttpClient.Builder builder, TlsConfig tlsConfig) {
     if (tlsConfig != null) {
-      if (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate()) {
-        throw new UnsupportedOperationException(
-            "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "
-                + "Use Apache or Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
-      }
+      validateTlsConfig(tlsConfig);
       if (tlsConfig.isTrustAllCertificates()) {
         return builder.buildWithDefaults(
             AttributeMap.builder()
@@ -130,5 +115,17 @@ public final class CrtSyncClientFactory {
       }
     }
     return builder.build();
+  }
+
+  private static void validateTlsConfig(TlsConfig tlsConfig) {
+    if (tlsConfig == null) {
+      return;
+    }
+    TlsHttpClientSupport.rejectUnsupportedHostnameVerification(tlsConfig, "CRT sync");
+    if (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate()) {
+      throw new UnsupportedOperationException(
+          "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "
+              + "Use Apache or Netty HTTP client instead, or use TlsConfig.trustAll() for testing.");
+    }
   }
 }

--- a/src/main/java/com/scylladb/alternator/internal/NettyAsyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/NettyAsyncClientFactory.java
@@ -93,6 +93,7 @@ public final class NettyAsyncClientFactory {
     if (tlsConfig == null) {
       return;
     }
+    TlsHttpClientSupport.rejectUnsupportedHostnameVerification(tlsConfig, "Netty async");
     if (tlsConfig.hasClientCertificate()) {
       KeyManager[] keyManagers = TlsContextFactory.createKeyManagers(tlsConfig);
       builder.tlsKeyManagersProvider(() -> keyManagers);

--- a/src/main/java/com/scylladb/alternator/internal/TlsHttpClientSupport.java
+++ b/src/main/java/com/scylladb/alternator/internal/TlsHttpClientSupport.java
@@ -1,0 +1,25 @@
+package com.scylladb.alternator.internal;
+
+import com.scylladb.alternator.TlsConfig;
+
+/** Shared TLS capability checks for AWS SDK HTTP client factories. */
+final class TlsHttpClientSupport {
+
+  private TlsHttpClientSupport() {}
+
+  static boolean requiresHostnameVerificationDisabled(TlsConfig tlsConfig) {
+    return tlsConfig != null
+        && !tlsConfig.isTrustAllCertificates()
+        && !tlsConfig.isVerifyHostname();
+  }
+
+  static void rejectUnsupportedHostnameVerification(TlsConfig tlsConfig, String clientName) {
+    if (requiresHostnameVerificationDisabled(tlsConfig)) {
+      throw new UnsupportedOperationException(
+          "Disabling hostname verification while still validating certificates is not supported"
+              + " with the "
+              + clientName
+              + " HTTP client. Use TlsConfig.trustAll() for testing.");
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/internal/ApacheSyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/ApacheSyncClientFactoryTest.java
@@ -4,11 +4,16 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.TlsConfig;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.junit.Test;
 import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 /**
  * Unit tests for {@link ApacheSyncClientFactory}.
@@ -99,6 +104,20 @@ public class ApacheSyncClientFactoryTest {
   }
 
   @Test
+  public void testCreateWithHostnameVerificationDisabledUsesCustomSocketFactory() {
+    TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    AtomicReference<ConnectionSocketFactory> socketFactory = new AtomicReference<>();
+    SdkHttpClient client =
+        ApacheSyncClientFactory.create(
+            builder -> socketFactory.set(readSocketFactory(builder)), null, tlsConfig);
+
+    assertTrue(
+        "Should use a custom SSL socket factory when hostname verification is disabled",
+        socketFactory.get() instanceof SSLConnectionSocketFactory);
+    client.close();
+  }
+
+  @Test
   public void testCreateWithConfigAndTls() {
     AlternatorConfig config =
         AlternatorConfig.builder()
@@ -141,6 +160,14 @@ public class ApacheSyncClientFactoryTest {
   public void testCreatePollingClientWithSystemDefaultTls() {
     SdkHttpClient client = ApacheSyncClientFactory.createPollingClient(TlsConfig.systemDefault());
     assertNotNull("Should create polling client with system-default TLS", client);
+    client.close();
+  }
+
+  @Test
+  public void testCreatePollingClientWithHostnameVerificationDisabled() {
+    TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    SdkHttpClient client = ApacheSyncClientFactory.createPollingClient(tlsConfig);
+    assertNotNull("Should create polling client with hostname verification disabled", client);
     client.close();
   }
 
@@ -206,5 +233,15 @@ public class ApacheSyncClientFactoryTest {
     SdkHttpClient client = ApacheSyncClientFactory.create(null, null, tlsConfig);
     assertNotNull("Should create client with system CAs", client);
     client.close();
+  }
+
+  private static ConnectionSocketFactory readSocketFactory(ApacheHttpClient.Builder builder) {
+    try {
+      Field socketFactoryField = builder.getClass().getDeclaredField("socketFactory");
+      socketFactoryField.setAccessible(true);
+      return (ConnectionSocketFactory) socketFactoryField.get(builder);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
+    }
   }
 }

--- a/src/test/java/com/scylladb/alternator/internal/CrtAsyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/CrtAsyncClientFactoryTest.java
@@ -102,6 +102,12 @@ public class CrtAsyncClientFactoryTest {
     client.close();
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithHostnameVerificationDisabledThrows() {
+    TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    CrtAsyncClientFactory.create(null, null, tlsConfig);
+  }
+
   @Test
   public void testCreateWithConfigAndTls() {
     AlternatorConfig config =

--- a/src/test/java/com/scylladb/alternator/internal/CrtSyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/CrtSyncClientFactoryTest.java
@@ -102,6 +102,12 @@ public class CrtSyncClientFactoryTest {
     client.close();
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithHostnameVerificationDisabledThrows() {
+    TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    CrtSyncClientFactory.create(null, null, tlsConfig);
+  }
+
   @Test
   public void testCreateWithConfigAndTls() {
     AlternatorConfig config =
@@ -146,6 +152,12 @@ public class CrtSyncClientFactoryTest {
     SdkHttpClient client = CrtSyncClientFactory.createPollingClient(TlsConfig.systemDefault());
     assertNotNull("Should create polling client with system-default TLS", client);
     client.close();
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreatePollingClientWithHostnameVerificationDisabledThrows() {
+    TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    CrtSyncClientFactory.createPollingClient(tlsConfig);
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/internal/NettyAsyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/NettyAsyncClientFactoryTest.java
@@ -97,6 +97,12 @@ public class NettyAsyncClientFactoryTest {
     client.close();
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithHostnameVerificationDisabledThrows() {
+    TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    NettyAsyncClientFactory.create(null, null, tlsConfig);
+  }
+
   @Test
   public void testCreateWithConfigAndTls() {
     AlternatorConfig config =


### PR DESCRIPTION
Fixes #119

Summary:
- install an Apache SSL socket factory with `NoopHostnameVerifier` when hostname verification is disabled but certificate validation remains enabled
- reject unsupported hostname-verification disabling for Netty and CRT clients instead of silently ignoring the TLS config
- add focused factory tests for Apache, Netty, and CRT behavior

Tests:
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -Dtest=ApacheSyncClientFactoryTest,NettyAsyncClientFactoryTest,CrtSyncClientFactoryTest,CrtAsyncClientFactoryTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn fmt:format fmt:check checkstyle:check`