### PR TITLE
Apply TLS session cache config to HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,10 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .build();
 ```
 
+Custom session cache settings are applied by the Apache sync HTTP client. The AWS SDK Netty and
+CRT HTTP clients do not expose TLS session cache controls, so non-default session cache settings are
+rejected for those client types instead of being silently ignored.
+
 #### Disabling TLS session caching
 
 If you need to disable TLS session caching:

--- a/src/main/java/com/scylladb/alternator/internal/ApacheSyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/ApacheSyncClientFactory.java
@@ -105,9 +105,13 @@ public final class ApacheSyncClientFactory {
     if (tlsConfig == null) {
       return;
     }
-    if (TlsHttpClientSupport.requiresHostnameVerificationDisabled(tlsConfig)) {
+    if (TlsHttpClientSupport.requiresHostnameVerificationDisabled(tlsConfig)
+        || TlsSessionCacheSupport.hasCustomSessionCacheConfig(tlsConfig)) {
       SSLContext sslContext = TlsContextFactory.createSslContext(tlsConfig);
-      HostnameVerifier hostnameVerifier = NoopHostnameVerifier.INSTANCE;
+      HostnameVerifier hostnameVerifier =
+          tlsConfig.isVerifyHostname()
+              ? SSLConnectionSocketFactory.getDefaultHostnameVerifier()
+              : NoopHostnameVerifier.INSTANCE;
       builder.socketFactory(new SSLConnectionSocketFactory(sslContext, hostnameVerifier));
       return;
     }

--- a/src/main/java/com/scylladb/alternator/internal/CrtAsyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/CrtAsyncClientFactory.java
@@ -98,6 +98,7 @@ public final class CrtAsyncClientFactory {
       return;
     }
     TlsHttpClientSupport.rejectUnsupportedHostnameVerification(tlsConfig, "CRT async");
+    TlsSessionCacheSupport.rejectUnsupportedSessionCacheConfig(tlsConfig, "CRT async");
     if (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate()) {
       throw new UnsupportedOperationException(
           "Custom CA certificates and client TLS certificates are not supported with the CRT async HTTP client. "

--- a/src/main/java/com/scylladb/alternator/internal/CrtSyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/CrtSyncClientFactory.java
@@ -122,6 +122,7 @@ public final class CrtSyncClientFactory {
       return;
     }
     TlsHttpClientSupport.rejectUnsupportedHostnameVerification(tlsConfig, "CRT sync");
+    TlsSessionCacheSupport.rejectUnsupportedSessionCacheConfig(tlsConfig, "CRT sync");
     if (!tlsConfig.getCustomCaCertPaths().isEmpty() || tlsConfig.hasClientCertificate()) {
       throw new UnsupportedOperationException(
           "Custom CA certificates and client TLS certificates are not supported with the CRT HTTP client. "

--- a/src/main/java/com/scylladb/alternator/internal/NettyAsyncClientFactory.java
+++ b/src/main/java/com/scylladb/alternator/internal/NettyAsyncClientFactory.java
@@ -94,6 +94,7 @@ public final class NettyAsyncClientFactory {
       return;
     }
     TlsHttpClientSupport.rejectUnsupportedHostnameVerification(tlsConfig, "Netty async");
+    TlsSessionCacheSupport.rejectUnsupportedSessionCacheConfig(tlsConfig, "Netty async");
     if (tlsConfig.hasClientCertificate()) {
       KeyManager[] keyManagers = TlsContextFactory.createKeyManagers(tlsConfig);
       builder.tlsKeyManagersProvider(() -> keyManagers);

--- a/src/main/java/com/scylladb/alternator/internal/TlsSessionCacheSupport.java
+++ b/src/main/java/com/scylladb/alternator/internal/TlsSessionCacheSupport.java
@@ -1,0 +1,24 @@
+package com.scylladb.alternator.internal;
+
+import com.scylladb.alternator.TlsConfig;
+import com.scylladb.alternator.TlsSessionCacheConfig;
+
+/** Shared TLS session cache capability checks for AWS SDK HTTP client factories. */
+final class TlsSessionCacheSupport {
+
+  private TlsSessionCacheSupport() {}
+
+  static boolean hasCustomSessionCacheConfig(TlsConfig tlsConfig) {
+    return tlsConfig != null
+        && !TlsSessionCacheConfig.getDefault().equals(tlsConfig.getSessionCacheConfig());
+  }
+
+  static void rejectUnsupportedSessionCacheConfig(TlsConfig tlsConfig, String clientName) {
+    if (hasCustomSessionCacheConfig(tlsConfig)) {
+      throw new UnsupportedOperationException(
+          "Custom TLS session cache configuration is not supported with the "
+              + clientName
+              + " HTTP client.");
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/internal/ApacheSyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/ApacheSyncClientFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.TlsConfig;
+import com.scylladb.alternator.TlsSessionCacheConfig;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -118,6 +119,27 @@ public class ApacheSyncClientFactoryTest {
   }
 
   @Test
+  public void testCreateWithCustomSessionCacheUsesCustomSocketFactory() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder()
+            .withSessionCacheConfig(
+                TlsSessionCacheConfig.builder()
+                    .withSessionCacheSize(64)
+                    .withSessionTimeoutSeconds(300)
+                    .build())
+            .build();
+    AtomicReference<ConnectionSocketFactory> socketFactory = new AtomicReference<>();
+    SdkHttpClient client =
+        ApacheSyncClientFactory.create(
+            builder -> socketFactory.set(readSocketFactory(builder)), null, tlsConfig);
+
+    assertTrue(
+        "Should use a custom SSL socket factory for custom TLS session cache config",
+        socketFactory.get() instanceof SSLConnectionSocketFactory);
+    client.close();
+  }
+
+  @Test
   public void testCreateWithConfigAndTls() {
     AlternatorConfig config =
         AlternatorConfig.builder()
@@ -168,6 +190,15 @@ public class ApacheSyncClientFactoryTest {
     TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
     SdkHttpClient client = ApacheSyncClientFactory.createPollingClient(tlsConfig);
     assertNotNull("Should create polling client with hostname verification disabled", client);
+    client.close();
+  }
+
+  @Test
+  public void testCreatePollingClientWithCustomSessionCache() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withSessionCacheConfig(TlsSessionCacheConfig.disabled()).build();
+    SdkHttpClient client = ApacheSyncClientFactory.createPollingClient(tlsConfig);
+    assertNotNull("Should create polling client with custom TLS session cache config", client);
     client.close();
   }
 

--- a/src/test/java/com/scylladb/alternator/internal/CrtAsyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/CrtAsyncClientFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.TlsConfig;
+import com.scylladb.alternator.TlsSessionCacheConfig;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -105,6 +106,13 @@ public class CrtAsyncClientFactoryTest {
   @Test(expected = UnsupportedOperationException.class)
   public void testCreateWithHostnameVerificationDisabledThrows() {
     TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    CrtAsyncClientFactory.create(null, null, tlsConfig);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithCustomSessionCacheThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withSessionCacheConfig(TlsSessionCacheConfig.disabled()).build();
     CrtAsyncClientFactory.create(null, null, tlsConfig);
   }
 

--- a/src/test/java/com/scylladb/alternator/internal/CrtSyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/CrtSyncClientFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.TlsConfig;
+import com.scylladb.alternator.TlsSessionCacheConfig;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -108,6 +109,13 @@ public class CrtSyncClientFactoryTest {
     CrtSyncClientFactory.create(null, null, tlsConfig);
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithCustomSessionCacheThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withSessionCacheConfig(TlsSessionCacheConfig.disabled()).build();
+    CrtSyncClientFactory.create(null, null, tlsConfig);
+  }
+
   @Test
   public void testCreateWithConfigAndTls() {
     AlternatorConfig config =
@@ -157,6 +165,13 @@ public class CrtSyncClientFactoryTest {
   @Test(expected = UnsupportedOperationException.class)
   public void testCreatePollingClientWithHostnameVerificationDisabledThrows() {
     TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    CrtSyncClientFactory.createPollingClient(tlsConfig);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreatePollingClientWithCustomSessionCacheThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withSessionCacheConfig(TlsSessionCacheConfig.disabled()).build();
     CrtSyncClientFactory.createPollingClient(tlsConfig);
   }
 

--- a/src/test/java/com/scylladb/alternator/internal/NettyAsyncClientFactoryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/NettyAsyncClientFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.TlsConfig;
+import com.scylladb.alternator.TlsSessionCacheConfig;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -100,6 +101,13 @@ public class NettyAsyncClientFactoryTest {
   @Test(expected = UnsupportedOperationException.class)
   public void testCreateWithHostnameVerificationDisabledThrows() {
     TlsConfig tlsConfig = TlsConfig.builder().withVerifyHostname(false).build();
+    NettyAsyncClientFactory.create(null, null, tlsConfig);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCreateWithCustomSessionCacheThrows() {
+    TlsConfig tlsConfig =
+        TlsConfig.builder().withSessionCacheConfig(TlsSessionCacheConfig.disabled()).build();
     NettyAsyncClientFactory.create(null, null, tlsConfig);
   }
 


### PR DESCRIPTION
Fixes #118

Summary:
- route non-default TLS session cache settings through an Apache SSL socket factory backed by `TlsContextFactory`
- reject non-default session cache settings for Netty and CRT clients because the AWS SDK builders do not expose this control
- document the Apache-only support for custom session cache tuning
- add factory-level tests for Apache, Netty, and CRT behavior

Tests:
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -Dtest=ApacheSyncClientFactoryTest,NettyAsyncClientFactoryTest,CrtSyncClientFactoryTest,CrtAsyncClientFactoryTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn fmt:check checkstyle:check`