### PR TITLE
Support HTTP response compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,12 +400,29 @@ complete example. After building with `mvn package`, you can run this demo with:
 mvn exec:java -Dexec.mainClass=com.scylladb.alternator.demo.Demo5 -Dexec.classpathScope=test
 ```
 
-### Request Compression
+### HTTP Compression
+
+#### Response compression
+
+The library automatically negotiates compressed responses by sending
+`Accept-Encoding: gzip, deflate` on DynamoDB requests. When Alternator returns
+`Content-Encoding: gzip` or `Content-Encoding: deflate`, the response body is
+decompressed before it reaches the AWS SDK response parser. This works for both
+synchronous and asynchronous clients and does not require any application
+configuration.
+
+Response compression support:
+- `gzip` - supported
+- `deflate` - supported
+
+Request compression is separate and remains opt-in.
+
+#### Request compression
 
 The library supports optional GZIP compression for HTTP request bodies, which can
 reduce network bandwidth usage when sending large payloads to Alternator.
 
-#### Why not use AWS SDK's built-in compression?
+##### Why not use AWS SDK's built-in compression?
 
 AWS SDK for Java v2 includes a `CompressionConfiguration` feature, but it **only works
 for AWS services that have the `@requestCompression` trait** in their service model
@@ -415,7 +432,7 @@ SDK's built-in compression cannot be used for DynamoDB or Alternator requests.
 This library provides its own compression implementation using an `ExecutionInterceptor`
 that works with any DynamoDB/Alternator operation.
 
-#### Enabling compression
+##### Enabling request compression
 
 To enable request compression, configure the builder with a compression algorithm:
 
@@ -430,7 +447,7 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .build();
 ```
 
-#### Compression threshold
+##### Compression threshold
 
 By default, only requests with bodies >= 1024 bytes (1 KB) are compressed. This avoids
 the overhead of compressing small payloads that may not benefit from compression.
@@ -445,7 +462,7 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .build();
 ```
 
-#### When to use compression
+##### When to use request compression
 
 Request compression is recommended for:
 - Large item attributes (documents, JSON blobs)
@@ -505,13 +522,15 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .withOptimizeHeaders(true)
     .withHeadersWhitelist(Arrays.asList(
         "Host", "X-Amz-Target", "Content-Type", "Content-Length",
-        "Authorization", "X-Amz-Date", "User-Agent", "X-Custom-Header"))
+        "Accept-Encoding", "Authorization", "X-Amz-Date", "Connection",
+        "User-Agent", "X-Custom-Header"))
     .build();
 ```
 
 **Important:** When using a custom whitelist, make sure to include all headers required for
 authentication (`Authorization`, `X-Amz-Date`), operation (`Host`, `X-Amz-Target`,
-`Content-Type`, `Content-Length`), and client reporting (`User-Agent`).
+`Content-Type`, `Content-Length`), response compression (`Accept-Encoding`), connection
+reuse (`Connection`), and client reporting (`User-Agent`).
 
 #### User-Agent customization
 

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
@@ -423,6 +423,47 @@ public class AlternatorDynamoDbAsyncClientIT {
   }
 
   @Test
+  public void testResponseCompressionNegotiatesAcceptEncoding() throws Exception {
+    AtomicBoolean acceptEncodingSeen = new AtomicBoolean(false);
+
+    ExecutionInterceptor responseCompressionVerifier =
+        new ExecutionInterceptor() {
+          @Override
+          public void beforeTransmission(
+              Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            context
+                .httpRequest()
+                .firstMatchingHeader("Accept-Encoding")
+                .ifPresent(
+                    value -> {
+                      if (value.contains("gzip") && value.contains("deflate")) {
+                        acceptEncodingSeen.set(true);
+                      }
+                    });
+          }
+        };
+
+    ClientOverrideConfiguration overrideConfig =
+        ClientOverrideConfiguration.builder()
+            .addExecutionInterceptor(responseCompressionVerifier)
+            .build();
+
+    DynamoDbAsyncClient client =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
+            .overrideConfiguration(overrideConfig)
+            .build();
+
+    try {
+      client.listTables(ListTablesRequest.builder().limit(1).build()).get();
+      assertTrue("Accept-Encoding should advertise gzip and deflate", acceptEncodingSeen.get());
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
   public void testHeadersOptimizationFiltersHeaders() throws Exception {
     // Track which headers are seen in the request
     Set<String> seenHeaders = new HashSet<>();
@@ -640,4 +681,5 @@ public class AlternatorDynamoDbAsyncClientIT {
 
     client.close();
   }
+
 }

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
@@ -412,6 +412,47 @@ public class AlternatorDynamoDbClientIT {
   }
 
   @Test
+  public void testResponseCompressionNegotiatesAcceptEncoding() throws Exception {
+    AtomicBoolean acceptEncodingSeen = new AtomicBoolean(false);
+
+    ExecutionInterceptor responseCompressionVerifier =
+        new ExecutionInterceptor() {
+          @Override
+          public void beforeTransmission(
+              Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            context
+                .httpRequest()
+                .firstMatchingHeader("Accept-Encoding")
+                .ifPresent(
+                    value -> {
+                      if (value.contains("gzip") && value.contains("deflate")) {
+                        acceptEncodingSeen.set(true);
+                      }
+                    });
+          }
+        };
+
+    ClientOverrideConfiguration overrideConfig =
+        ClientOverrideConfiguration.builder()
+            .addExecutionInterceptor(responseCompressionVerifier)
+            .build();
+
+    DynamoDbClient client =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
+            .overrideConfiguration(overrideConfig)
+            .build();
+
+    try {
+      client.listTables(ListTablesRequest.builder().limit(1).build());
+      assertTrue("Accept-Encoding should advertise gzip and deflate", acceptEncodingSeen.get());
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
   public void testHeadersOptimizationFiltersHeaders() throws Exception {
     // Track which headers are seen in the request
     Set<String> seenHeaders = new HashSet<>();
@@ -628,4 +669,5 @@ public class AlternatorDynamoDbClientIT {
 
     client.close();
   }
+
 }

--- a/src/integration-test/java/com/scylladb/alternator/ResponseCompressionIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/ResponseCompressionIT.java
@@ -1,0 +1,223 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesResponse;
+
+/** Integration tests for SDK response parsing with gzip/deflate compressed HTTP bodies. */
+public class ResponseCompressionIT {
+
+  private static final String TABLE_NAME = "compressed_table";
+  private static final byte[] RESPONSE_JSON =
+      ("{\"TableNames\":[\"" + TABLE_NAME + "\"]}").getBytes(StandardCharsets.UTF_8);
+
+  @Test
+  public void testSyncSdkClientParsesGzipResponse() throws Exception {
+    verifySyncResponse("gzip", gzip(RESPONSE_JSON));
+  }
+
+  @Test
+  public void testSyncSdkClientParsesDeflateResponse() throws Exception {
+    verifySyncResponse("deflate", deflate(RESPONSE_JSON));
+  }
+
+  @Test
+  public void testAsyncSdkClientParsesGzipResponse() throws Exception {
+    verifyAsyncResponse("gzip", gzip(RESPONSE_JSON));
+  }
+
+  @Test
+  public void testAsyncSdkClientParsesDeflateResponse() throws Exception {
+    verifyAsyncResponse("deflate", deflate(RESPONSE_JSON));
+  }
+
+  private static void verifySyncResponse(String encoding, byte[] compressedBody) {
+    CompressedResponseHttpClient httpClient =
+        new CompressedResponseHttpClient(encoding, compressedBody);
+    DynamoDbClient client =
+        DynamoDbClient.builder()
+            .endpointOverride(URI.create("http://localhost:8000"))
+            .region(Region.US_EAST_1)
+            .credentialsProvider(AnonymousCredentialsProvider.create())
+            .httpClient(httpClient)
+            .overrideConfiguration(c -> c.addExecutionInterceptor(new ResponseCompressionInterceptor()))
+            .build();
+
+    try {
+      ListTablesResponse response = client.listTables();
+
+      assertEquals(TABLE_NAME, response.tableNames().get(0));
+      assertEquals(
+          ResponseCompressionInterceptor.ACCEPT_ENCODING,
+          httpClient.capturedRequest.firstMatchingHeader("Accept-Encoding").get());
+    } finally {
+      client.close();
+    }
+  }
+
+  private static void verifyAsyncResponse(String encoding, byte[] compressedBody) throws Exception {
+    CompressedResponseAsyncHttpClient httpClient =
+        new CompressedResponseAsyncHttpClient(encoding, compressedBody);
+    DynamoDbAsyncClient client =
+        DynamoDbAsyncClient.builder()
+            .endpointOverride(URI.create("http://localhost:8000"))
+            .region(Region.US_EAST_1)
+            .credentialsProvider(AnonymousCredentialsProvider.create())
+            .httpClient(httpClient)
+            .overrideConfiguration(c -> c.addExecutionInterceptor(new ResponseCompressionInterceptor()))
+            .build();
+
+    try {
+      ListTablesResponse response = client.listTables().get();
+
+      assertEquals(TABLE_NAME, response.tableNames().get(0));
+      assertEquals(
+          ResponseCompressionInterceptor.ACCEPT_ENCODING,
+          httpClient.capturedRequest.firstMatchingHeader("Accept-Encoding").get());
+    } finally {
+      client.close();
+    }
+  }
+
+  private static SdkHttpFullResponse compressedResponse(String encoding, int contentLength) {
+    return SdkHttpFullResponse.builder()
+        .statusCode(200)
+        .putHeader("Content-Type", "application/x-amz-json-1.0")
+        .putHeader("Content-Encoding", encoding)
+        .putHeader("Content-Length", Integer.toString(contentLength))
+        .build();
+  }
+
+  private static byte[] gzip(byte[] bytes) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzip = new GZIPOutputStream(output)) {
+      gzip.write(bytes);
+    }
+    return output.toByteArray();
+  }
+
+  private static byte[] deflate(byte[] bytes) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (DeflaterOutputStream deflate = new DeflaterOutputStream(output)) {
+      deflate.write(bytes);
+    }
+    return output.toByteArray();
+  }
+
+  private static final class CompressedResponseHttpClient implements SdkHttpClient {
+    private final String encoding;
+    private final byte[] compressedBody;
+    private SdkHttpRequest capturedRequest;
+
+    private CompressedResponseHttpClient(String encoding, byte[] compressedBody) {
+      this.encoding = encoding;
+      this.compressedBody = compressedBody;
+    }
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      capturedRequest = request.httpRequest();
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() {
+          return HttpExecuteResponse.builder()
+              .response(compressedResponse(encoding, compressedBody.length))
+              .responseBody(
+                  AbortableInputStream.create(new ByteArrayInputStream(compressedBody)))
+              .build();
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "compressed-response-test";
+    }
+  }
+
+  private static final class CompressedResponseAsyncHttpClient implements SdkAsyncHttpClient {
+    private final String encoding;
+    private final byte[] compressedBody;
+    private SdkHttpRequest capturedRequest;
+
+    private CompressedResponseAsyncHttpClient(String encoding, byte[] compressedBody) {
+      this.encoding = encoding;
+      this.compressedBody = compressedBody;
+    }
+
+    @Override
+    public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
+      capturedRequest = request.request();
+      request.responseHandler().onHeaders(compressedResponse(encoding, compressedBody.length));
+      request.responseHandler().onStream(singleBufferPublisher(compressedBody));
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "compressed-response-async-test";
+    }
+  }
+
+  private static Publisher<ByteBuffer> singleBufferPublisher(byte[] bytes) {
+    return subscriber ->
+        subscriber.onSubscribe(
+            new Subscription() {
+              private boolean done;
+
+              @Override
+              public void request(long n) {
+                if (done) {
+                  return;
+                }
+                done = true;
+                if (n <= 0) {
+                  subscriber.onError(new IllegalArgumentException("Demand must be positive"));
+                  return;
+                }
+                subscriber.onNext(ByteBuffer.wrap(bytes));
+                subscriber.onComplete();
+              }
+
+              @Override
+              public void cancel() {
+                done = true;
+              }
+            });
+  }
+}

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -684,15 +684,16 @@ public class AlternatorDynamoDbAsyncClient {
 
       AlternatorConfig alternatorConfig = configBuilder.build();
 
+      ClientOverrideConfiguration.Builder compressionOverrideBuilder =
+          delegate.overrideConfiguration() != null
+              ? delegate.overrideConfiguration().toBuilder()
+              : ClientOverrideConfiguration.builder();
+      compressionOverrideBuilder.addExecutionInterceptor(new ResponseCompressionInterceptor());
       if (alternatorConfig.getCompressionAlgorithm().isEnabled()) {
-        ClientOverrideConfiguration.Builder overrideBuilder =
-            delegate.overrideConfiguration() != null
-                ? delegate.overrideConfiguration().toBuilder()
-                : ClientOverrideConfiguration.builder();
-        overrideBuilder.addExecutionInterceptor(
+        compressionOverrideBuilder.addExecutionInterceptor(
             new GzipRequestInterceptor(alternatorConfig.getMinCompressionSizeBytes()));
-        delegate.overrideConfiguration(overrideBuilder.build());
       }
+      delegate.overrideConfiguration(compressionOverrideBuilder.build());
 
       TlsConfig tlsConfig = alternatorConfig.getTlsConfig();
       if (!httpClientSet) {

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -705,15 +705,16 @@ public class AlternatorDynamoDbClient {
 
       AlternatorConfig alternatorConfig = configBuilder.build();
 
+      ClientOverrideConfiguration.Builder compressionOverrideBuilder =
+          delegate.overrideConfiguration() != null
+              ? delegate.overrideConfiguration().toBuilder()
+              : ClientOverrideConfiguration.builder();
+      compressionOverrideBuilder.addExecutionInterceptor(new ResponseCompressionInterceptor());
       if (alternatorConfig.getCompressionAlgorithm().isEnabled()) {
-        ClientOverrideConfiguration.Builder overrideBuilder =
-            delegate.overrideConfiguration() != null
-                ? delegate.overrideConfiguration().toBuilder()
-                : ClientOverrideConfiguration.builder();
-        overrideBuilder.addExecutionInterceptor(
+        compressionOverrideBuilder.addExecutionInterceptor(
             new GzipRequestInterceptor(alternatorConfig.getMinCompressionSizeBytes()));
-        delegate.overrideConfiguration(overrideBuilder.build());
       }
+      delegate.overrideConfiguration(compressionOverrideBuilder.build());
 
       TlsConfig tlsConfig = alternatorConfig.getTlsConfig();
       SdkHttpClient pollingClient = null;

--- a/src/main/java/com/scylladb/alternator/ResponseCompressionInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/ResponseCompressionInterceptor.java
@@ -1,0 +1,294 @@
+package com.scylladb.alternator;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+/** Adds HTTP response compression negotiation and decompresses gzip/deflate responses. */
+class ResponseCompressionInterceptor implements ExecutionInterceptor {
+
+  static final String ACCEPT_ENCODING = "gzip, deflate";
+
+  private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
+  private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
+  private static final String CONTENT_LENGTH_HEADER = "Content-Length";
+  private static final ExecutionAttribute<Encoding> RESPONSE_ENCODING =
+      new ExecutionAttribute<>("ResponseCompressionInterceptor.responseEncoding");
+
+  @Override
+  public SdkHttpRequest modifyHttpRequest(
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    return withAcceptEncoding(context.httpRequest());
+  }
+
+  @Override
+  public SdkHttpResponse modifyHttpResponse(
+      Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+    Optional<Encoding> encoding = responseEncoding(context.httpResponse());
+    encoding.ifPresent(value -> executionAttributes.putAttribute(RESPONSE_ENCODING, value));
+    return encoding.isPresent()
+        ? stripCompressionHeaders(context.httpResponse())
+        : context.httpResponse();
+  }
+
+  @Override
+  public Optional<InputStream> modifyHttpResponseContent(
+      Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+    Encoding encoding = executionAttributes.getAttribute(RESPONSE_ENCODING);
+    if (encoding == null || !context.responseBody().isPresent()) {
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(decompress(context.responseBody().get(), encoding));
+    } catch (IOException e) {
+      throw SdkClientException.create(
+          "Failed to initialize " + encoding.name + " response decompression", e);
+    }
+  }
+
+  @Override
+  public Optional<Publisher<ByteBuffer>> modifyAsyncHttpResponseContent(
+      Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+    Encoding encoding = executionAttributes.getAttribute(RESPONSE_ENCODING);
+    if (encoding == null || !context.responsePublisher().isPresent()) {
+      return Optional.empty();
+    }
+    return Optional.of(new DecompressingPublisher(context.responsePublisher().get(), encoding));
+  }
+
+  private static SdkHttpRequest withAcceptEncoding(SdkHttpRequest request) {
+    return request.toBuilder().putHeader(ACCEPT_ENCODING_HEADER, ACCEPT_ENCODING).build();
+  }
+
+  private static Optional<Encoding> responseEncoding(SdkHttpResponse response) {
+    List<String> values = response.matchingHeaders(CONTENT_ENCODING_HEADER);
+    List<String> tokens = new ArrayList<>();
+    for (String value : values) {
+      for (String token : value.split(",")) {
+        tokens.add(token);
+      }
+    }
+    if (tokens.size() == 1) {
+      return Encoding.from(tokens.get(0));
+    }
+    return Optional.empty();
+  }
+
+  private static SdkHttpResponse stripCompressionHeaders(SdkHttpResponse response) {
+    SdkHttpResponse.Builder builder = response.toBuilder();
+    for (String headerName : response.headers().keySet()) {
+      if (isHeader(headerName, CONTENT_ENCODING_HEADER)
+          || isHeader(headerName, CONTENT_LENGTH_HEADER)) {
+        builder.removeHeader(headerName);
+      }
+    }
+    return builder.build();
+  }
+
+  private static InputStream decompress(InputStream compressed, Encoding encoding)
+      throws IOException {
+    switch (encoding) {
+      case GZIP:
+        return new GZIPInputStream(compressed);
+      case DEFLATE:
+        return new InflaterInputStream(compressed);
+      default:
+        throw new IllegalArgumentException("Unsupported response encoding: " + encoding);
+    }
+  }
+
+  private static byte[] decompress(byte[] compressed, Encoding encoding) throws IOException {
+    try (InputStream input = decompress(new ByteArrayInputStream(compressed), encoding)) {
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
+      byte[] buffer = new byte[4096];
+      int read;
+      while ((read = input.read(buffer)) != -1) {
+        output.write(buffer, 0, read);
+      }
+      return output.toByteArray();
+    }
+  }
+
+  private static boolean isHeader(String actual, String expected) {
+    return actual != null && actual.equalsIgnoreCase(expected);
+  }
+
+  private enum Encoding {
+    GZIP("gzip"),
+    DEFLATE("deflate");
+
+    private final String name;
+
+    Encoding(String name) {
+      this.name = name;
+    }
+
+    static Optional<Encoding> from(String value) {
+      if (value == null) {
+        return Optional.empty();
+      }
+      String token = value.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+      for (Encoding encoding : values()) {
+        if (encoding.name.equals(token)) {
+          return Optional.of(encoding);
+        }
+      }
+      return Optional.empty();
+    }
+  }
+
+  private static final class DecompressingPublisher implements Publisher<ByteBuffer> {
+    private final Publisher<ByteBuffer> delegate;
+    private final Encoding encoding;
+
+    private DecompressingPublisher(Publisher<ByteBuffer> delegate, Encoding encoding) {
+      this.delegate = delegate;
+      this.encoding = encoding;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+      delegate.subscribe(new DecompressingSubscriber(subscriber, encoding));
+    }
+  }
+
+  private static final class DecompressingSubscriber
+      implements Subscriber<ByteBuffer>, Subscription {
+    private final Subscriber<? super ByteBuffer> downstream;
+    private final Encoding encoding;
+    private final ByteArrayOutputStream compressedBytes = new ByteArrayOutputStream();
+    private Subscription upstream;
+    private boolean upstreamRequested;
+    private boolean completed;
+    private boolean cancelled;
+    private boolean emitted;
+    private long demand;
+    private byte[] decompressedBytes;
+
+    private DecompressingSubscriber(Subscriber<? super ByteBuffer> downstream, Encoding encoding) {
+      this.downstream = downstream;
+      this.encoding = encoding;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+      this.upstream = subscription;
+      downstream.onSubscribe(this);
+    }
+
+    @Override
+    public void onNext(ByteBuffer byteBuffer) {
+      if (isCancelled()) {
+        return;
+      }
+      ByteBuffer copy = byteBuffer.asReadOnlyBuffer();
+      byte[] bytes = new byte[copy.remaining()];
+      copy.get(bytes);
+      compressedBytes.write(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      if (!isCancelled()) {
+        downstream.onError(throwable);
+      }
+    }
+
+    @Override
+    public void onComplete() {
+      byte[] decompressed;
+      try {
+        decompressed = decompress(compressedBytes.toByteArray(), encoding);
+      } catch (IOException e) {
+        if (!isCancelled()) {
+          downstream.onError(
+              SdkClientException.create("Failed to decompress " + encoding.name + " response", e));
+        }
+        return;
+      }
+      synchronized (this) {
+        decompressedBytes = decompressed;
+        completed = true;
+      }
+      emitIfReady();
+    }
+
+    @Override
+    public void request(long n) {
+      if (n <= 0) {
+        cancel();
+        downstream.onError(new IllegalArgumentException("Demand must be positive"));
+        return;
+      }
+
+      boolean shouldRequestUpstream = false;
+      synchronized (this) {
+        demand = saturatedAdd(demand, n);
+        if (!upstreamRequested) {
+          upstreamRequested = true;
+          shouldRequestUpstream = true;
+        }
+      }
+      if (shouldRequestUpstream) {
+        upstream.request(Long.MAX_VALUE);
+      }
+      emitIfReady();
+    }
+
+    @Override
+    public void cancel() {
+      Subscription subscription;
+      synchronized (this) {
+        cancelled = true;
+        subscription = upstream;
+      }
+      if (subscription != null) {
+        subscription.cancel();
+      }
+    }
+
+    private void emitIfReady() {
+      ByteBuffer item = null;
+      synchronized (this) {
+        if (!cancelled && completed && !emitted && demand > 0) {
+          emitted = true;
+          item = ByteBuffer.wrap(decompressedBytes);
+        }
+      }
+      if (item != null) {
+        downstream.onNext(item);
+        if (!isCancelled()) {
+          downstream.onComplete();
+        }
+      }
+    }
+
+    private synchronized boolean isCancelled() {
+      return cancelled;
+    }
+
+    private static long saturatedAdd(long left, long right) {
+      long result = left + right;
+      return result < 0 ? Long.MAX_VALUE : result;
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/ResponseCompressionInterceptorTest.java
+++ b/src/test/java/com/scylladb/alternator/ResponseCompressionInterceptorTest.java
@@ -1,0 +1,335 @@
+package com.scylladb.alternator;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesRequest;
+
+/** Unit tests for gzip/deflate HTTP response compression support. */
+public class ResponseCompressionInterceptorTest {
+
+  private final ResponseCompressionInterceptor interceptor = new ResponseCompressionInterceptor();
+
+  @Test
+  public void testAddsAcceptEncodingWhenMissing() {
+    SdkHttpRequest request = createHttpRequest();
+
+    SdkHttpRequest modified =
+        interceptor.modifyHttpRequest(requestContext(request), new ExecutionAttributes());
+
+    assertEquals(
+        ResponseCompressionInterceptor.ACCEPT_ENCODING,
+        modified.firstMatchingHeader("Accept-Encoding").get());
+  }
+
+  @Test
+  public void testReplacesExistingAcceptEncoding() {
+    SdkHttpRequest request =
+        createHttpRequest().toBuilder().putHeader("Accept-Encoding", "br").build();
+
+    SdkHttpRequest modified =
+        interceptor.modifyHttpRequest(requestContext(request), new ExecutionAttributes());
+
+    assertEquals(
+        ResponseCompressionInterceptor.ACCEPT_ENCODING,
+        modified.firstMatchingHeader("Accept-Encoding").get());
+  }
+
+  @Test
+  public void testGzipSyncResponseIsDecompressedAndHeadersAreStripped() throws Exception {
+    byte[] original = "compressed gzip response".getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = gzip(original);
+    SdkHttpResponse response =
+        SdkHttpResponse.builder()
+            .statusCode(200)
+            .putHeader("Content-Encoding", "gzip")
+            .putHeader("Content-Length", Integer.toString(compressed.length))
+            .putHeader("X-Test", "kept")
+            .build();
+    ExecutionAttributes attrs = new ExecutionAttributes();
+    Context.ModifyHttpResponse context =
+        responseContext(response, new ByteArrayInputStream(compressed), null);
+
+    SdkHttpResponse modifiedResponse = interceptor.modifyHttpResponse(context, attrs);
+    Optional<InputStream> modifiedContent = interceptor.modifyHttpResponseContent(context, attrs);
+
+    assertFalse(modifiedResponse.firstMatchingHeader("Content-Encoding").isPresent());
+    assertFalse(modifiedResponse.firstMatchingHeader("Content-Length").isPresent());
+    assertEquals("kept", modifiedResponse.firstMatchingHeader("X-Test").get());
+    assertArrayEquals(original, readAll(modifiedContent.get()));
+  }
+
+  @Test
+  public void testDeflateSyncResponseIsDecompressed() throws Exception {
+    byte[] original = "compressed deflate response".getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = deflate(original);
+    SdkHttpResponse response =
+        SdkHttpResponse.builder().statusCode(200).putHeader("Content-Encoding", "deflate").build();
+    ExecutionAttributes attrs = new ExecutionAttributes();
+    Context.ModifyHttpResponse context =
+        responseContext(response, new ByteArrayInputStream(compressed), null);
+
+    interceptor.modifyHttpResponse(context, attrs);
+    Optional<InputStream> modifiedContent = interceptor.modifyHttpResponseContent(context, attrs);
+
+    assertArrayEquals(original, readAll(modifiedContent.get()));
+  }
+
+  @Test
+  public void testUnsupportedEncodingIsNotModified() {
+    SdkHttpResponse response =
+        SdkHttpResponse.builder().statusCode(200).putHeader("Content-Encoding", "br").build();
+    ExecutionAttributes attrs = new ExecutionAttributes();
+    Context.ModifyHttpResponse context =
+        responseContext(response, new ByteArrayInputStream(new byte[] {1, 2, 3}), null);
+
+    SdkHttpResponse modifiedResponse = interceptor.modifyHttpResponse(context, attrs);
+    Optional<InputStream> modifiedContent = interceptor.modifyHttpResponseContent(context, attrs);
+
+    assertEquals("br", modifiedResponse.firstMatchingHeader("Content-Encoding").get());
+    assertFalse(modifiedContent.isPresent());
+  }
+
+  @Test
+  public void testMultipleContentEncodingsAreNotModified() {
+    SdkHttpResponse response =
+        SdkHttpResponse.builder().statusCode(200).putHeader("Content-Encoding", "gzip, br").build();
+    ExecutionAttributes attrs = new ExecutionAttributes();
+    Context.ModifyHttpResponse context =
+        responseContext(response, new ByteArrayInputStream(new byte[] {1, 2, 3}), null);
+
+    SdkHttpResponse modifiedResponse = interceptor.modifyHttpResponse(context, attrs);
+    Optional<InputStream> modifiedContent = interceptor.modifyHttpResponseContent(context, attrs);
+
+    assertEquals("gzip, br", modifiedResponse.firstMatchingHeader("Content-Encoding").get());
+    assertFalse(modifiedContent.isPresent());
+  }
+
+  @Test
+  public void testGzipAsyncResponseIsDecompressedAndHeadersAreStripped() throws Exception {
+    byte[] original = "async gzip response".getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = gzip(original);
+    SdkHttpResponse response =
+        SdkHttpResponse.builder()
+            .statusCode(200)
+            .putHeader("Content-Encoding", "gzip")
+            .putHeader("Content-Length", Integer.toString(compressed.length))
+            .build();
+    ExecutionAttributes attrs = new ExecutionAttributes();
+    Context.ModifyHttpResponse context =
+        responseContext(response, null, singleBufferPublisher(compressed));
+
+    SdkHttpResponse modifiedResponse = interceptor.modifyHttpResponse(context, attrs);
+    Optional<Publisher<ByteBuffer>> modifiedPublisher =
+        interceptor.modifyAsyncHttpResponseContent(context, attrs);
+
+    assertFalse(modifiedResponse.firstMatchingHeader("Content-Encoding").isPresent());
+    assertFalse(modifiedResponse.firstMatchingHeader("Content-Length").isPresent());
+    assertArrayEquals(original, collect(modifiedPublisher.get()));
+  }
+
+  @Test
+  public void testDeflateAsyncResponseIsDecompressed() throws Exception {
+    byte[] original = "async deflate response".getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = deflate(original);
+    SdkHttpResponse response =
+        SdkHttpResponse.builder().statusCode(200).putHeader("Content-Encoding", "deflate").build();
+    ExecutionAttributes attrs = new ExecutionAttributes();
+    Context.ModifyHttpResponse context =
+        responseContext(response, null, singleBufferPublisher(compressed));
+
+    interceptor.modifyHttpResponse(context, attrs);
+    Optional<Publisher<ByteBuffer>> modifiedPublisher =
+        interceptor.modifyAsyncHttpResponseContent(context, attrs);
+
+    assertArrayEquals(original, collect(modifiedPublisher.get()));
+  }
+
+  private static SdkHttpRequest createHttpRequest() {
+    return SdkHttpRequest.builder()
+        .protocol("http")
+        .host("localhost")
+        .port(8043)
+        .method(SdkHttpMethod.POST)
+        .encodedPath("/")
+        .build();
+  }
+
+  private static Context.ModifyHttpRequest requestContext(SdkHttpRequest httpRequest) {
+    return new Context.ModifyHttpRequest() {
+      @Override
+      public SdkHttpRequest httpRequest() {
+        return httpRequest;
+      }
+
+      @Override
+      public Optional<RequestBody> requestBody() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<AsyncRequestBody> asyncRequestBody() {
+        return Optional.empty();
+      }
+
+      @Override
+      public SdkRequest request() {
+        return ListTablesRequest.builder().build();
+      }
+    };
+  }
+
+  private static Context.ModifyHttpResponse responseContext(
+      SdkHttpResponse response, InputStream body, Publisher<ByteBuffer> publisher) {
+    return new Context.ModifyHttpResponse() {
+      @Override
+      public SdkHttpResponse httpResponse() {
+        return response;
+      }
+
+      @Override
+      public Optional<Publisher<ByteBuffer>> responsePublisher() {
+        return Optional.ofNullable(publisher);
+      }
+
+      @Override
+      public Optional<InputStream> responseBody() {
+        return Optional.ofNullable(body);
+      }
+
+      @Override
+      public SdkHttpRequest httpRequest() {
+        return createHttpRequest();
+      }
+
+      @Override
+      public Optional<RequestBody> requestBody() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<AsyncRequestBody> asyncRequestBody() {
+        return Optional.empty();
+      }
+
+      @Override
+      public SdkRequest request() {
+        return ListTablesRequest.builder().build();
+      }
+    };
+  }
+
+  private static byte[] gzip(byte[] bytes) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzip = new GZIPOutputStream(output)) {
+      gzip.write(bytes);
+    }
+    return output.toByteArray();
+  }
+
+  private static byte[] deflate(byte[] bytes) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (DeflaterOutputStream deflate = new DeflaterOutputStream(output)) {
+      deflate.write(bytes);
+    }
+    return output.toByteArray();
+  }
+
+  private static byte[] readAll(InputStream input) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    byte[] buffer = new byte[4096];
+    int read;
+    while ((read = input.read(buffer)) != -1) {
+      output.write(buffer, 0, read);
+    }
+    return output.toByteArray();
+  }
+
+  private static Publisher<ByteBuffer> singleBufferPublisher(byte[] bytes) {
+    return subscriber ->
+        subscriber.onSubscribe(
+            new Subscription() {
+              private boolean done;
+
+              @Override
+              public void request(long n) {
+                if (done) {
+                  return;
+                }
+                done = true;
+                if (n <= 0) {
+                  subscriber.onError(new IllegalArgumentException("Demand must be positive"));
+                  return;
+                }
+                subscriber.onNext(ByteBuffer.wrap(bytes));
+                subscriber.onComplete();
+              }
+
+              @Override
+              public void cancel() {
+                done = true;
+              }
+            });
+  }
+
+  private static byte[] collect(Publisher<ByteBuffer> publisher) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    CountDownLatch done = new CountDownLatch(1);
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    publisher.subscribe(
+        new Subscriber<ByteBuffer>() {
+          @Override
+          public void onSubscribe(Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(ByteBuffer byteBuffer) {
+            ByteBuffer copy = byteBuffer.asReadOnlyBuffer();
+            byte[] bytes = new byte[copy.remaining()];
+            copy.get(bytes);
+            output.write(bytes, 0, bytes.length);
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            error.set(throwable);
+            done.countDown();
+          }
+
+          @Override
+          public void onComplete() {
+            done.countDown();
+          }
+        });
+
+    assertTrue("Publisher should complete", done.await(5, TimeUnit.SECONDS));
+    if (error.get() != null) {
+      throw new AssertionError("Publisher failed", error.get());
+    }
+    return output.toByteArray();
+  }
+}


### PR DESCRIPTION
## Summary
- negotiate compressed Alternator responses with `Accept-Encoding: gzip, deflate`
- decompress `gzip` and `deflate` response bodies for sync and async clients before SDK parsing
- add unit, mock integration, Scylla-backed integration coverage, and README docs

Fixes #115

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q -Dtest=ResponseCompressionInterceptorTest,ResponseCompressionIT test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q fmt:check checkstyle:check`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH make test-integration`