### PR TITLE
Add configurable response compression algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,29 @@ Response compression support:
 - `gzip` - supported
 - `deflate` - supported
 
+You can restrict response compression to a supported subset, and the configured
+order is used for `Accept-Encoding`:
+
+```java
+import com.scylladb.alternator.ResponseCompressionAlgorithm;
+
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://127.0.0.1:8043"))
+    .credentialsProvider(myCredentials)
+    .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.DEFLATE)
+    .build();
+```
+
+To disable response compression negotiation and decompression:
+
+```java
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://127.0.0.1:8043"))
+    .credentialsProvider(myCredentials)
+    .withResponseCompressionDisabled()
+    .build();
+```
+
 Request compression is separate and remains opt-in.
 
 #### Request compression
@@ -529,8 +552,8 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
 
 **Important:** When using a custom whitelist, make sure to include all headers required for
 authentication (`Authorization`, `X-Amz-Date`), operation (`Host`, `X-Amz-Target`,
-`Content-Type`, `Content-Length`), response compression (`Accept-Encoding`), connection
-reuse (`Connection`), and client reporting (`User-Agent`).
+`Content-Type`, `Content-Length`), response compression when enabled (`Accept-Encoding`),
+connection reuse (`Connection`), and client reporting (`User-Agent`).
 
 #### User-Agent customization
 

--- a/README.md
+++ b/README.md
@@ -404,18 +404,31 @@ mvn exec:java -Dexec.mainClass=com.scylladb.alternator.demo.Demo5 -Dexec.classpa
 
 #### Response compression
 
-The library automatically negotiates compressed responses by sending
-`Accept-Encoding: gzip, deflate` on DynamoDB requests. When Alternator returns
-`Content-Encoding: gzip` or `Content-Encoding: deflate`, the response body is
-decompressed before it reaches the AWS SDK response parser. This works for both
-synchronous and asynchronous clients and does not require any application
-configuration.
+Response compression is disabled by default. To negotiate compressed responses,
+configure the supported algorithms to advertise on DynamoDB requests. When enabled
+and Alternator returns `Content-Encoding: gzip` or `Content-Encoding: deflate`, the
+response body is decompressed before it reaches the AWS SDK response parser. This
+works for both synchronous and asynchronous clients.
 
 Response compression support:
 - `gzip` - supported
 - `deflate` - supported
 
-You can restrict response compression to a supported subset, and the configured
+To enable response compression for all supported algorithms:
+
+```java
+import com.scylladb.alternator.ResponseCompressionAlgorithm;
+
+DynamoDbClient client = AlternatorDynamoDbClient.builder()
+    .endpointOverride(URI.create("https://127.0.0.1:8043"))
+    .credentialsProvider(myCredentials)
+    .withResponseCompressionAlgorithms(
+        ResponseCompressionAlgorithm.GZIP,
+        ResponseCompressionAlgorithm.DEFLATE)
+    .build();
+```
+
+You can also restrict response compression to a supported subset, and the configured
 order is used for `Accept-Encoding`:
 
 ```java
@@ -428,7 +441,7 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .build();
 ```
 
-To disable response compression negotiation and decompression:
+To explicitly disable response compression negotiation and decompression:
 
 ```java
 DynamoDbClient client = AlternatorDynamoDbClient.builder()
@@ -519,12 +532,13 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
 
 #### Default headers whitelist
 
-When headers optimization is enabled, only the following headers are preserved by default:
+When headers optimization is enabled, the default whitelist preserves the headers required for
+the active configuration:
 - `Host` - Required by HTTP/1.1
 - `X-Amz-Target` - Specifies the DynamoDB operation
 - `Content-Type` - MIME type for DynamoDB API
 - `Content-Length` - Required for request body
-- `Accept-Encoding` - For response compression negotiation
+- `Accept-Encoding` - For response compression negotiation (when enabled)
 - `Content-Encoding` - For request compression (when enabled)
 - `Authorization` - AWS SigV4 signature (when authentication is enabled)
 - `X-Amz-Date` - Timestamp for AWS signature (when authentication is enabled)
@@ -545,8 +559,8 @@ DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .withOptimizeHeaders(true)
     .withHeadersWhitelist(Arrays.asList(
         "Host", "X-Amz-Target", "Content-Type", "Content-Length",
-        "Accept-Encoding", "Authorization", "X-Amz-Date", "Connection",
-        "User-Agent", "X-Custom-Header"))
+        "Authorization", "X-Amz-Date", "Connection", "User-Agent",
+        "X-Custom-Header"))
     .build();
 ```
 

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
@@ -424,6 +424,42 @@ public class AlternatorDynamoDbAsyncClientIT {
   }
 
   @Test
+  public void testResponseCompressionDisabledByDefaultDoesNotSetAcceptEncoding() throws Exception {
+    AtomicReference<String> acceptEncoding = new AtomicReference<>();
+
+    ExecutionInterceptor responseCompressionVerifier =
+        new ExecutionInterceptor() {
+          @Override
+          public void beforeTransmission(
+              Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            context
+                .httpRequest()
+                .firstMatchingHeader("Accept-Encoding")
+                .ifPresent(acceptEncoding::set);
+          }
+        };
+
+    ClientOverrideConfiguration overrideConfig =
+        ClientOverrideConfiguration.builder()
+            .addExecutionInterceptor(responseCompressionVerifier)
+            .build();
+
+    DynamoDbAsyncClient client =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
+            .overrideConfiguration(overrideConfig)
+            .build();
+
+    try {
+      client.listTables(ListTablesRequest.builder().limit(1).build()).get();
+      assertNull(acceptEncoding.get());
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
   public void testResponseCompressionNegotiatesAcceptEncoding() throws Exception {
     AtomicReference<String> acceptEncoding = new AtomicReference<>();
 
@@ -449,6 +485,8 @@ public class AlternatorDynamoDbAsyncClientIT {
             .endpointOverride(seedUri)
             .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
             .overrideConfiguration(overrideConfig)
+            .withResponseCompressionAlgorithms(
+                ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE)
             .build();
 
     try {
@@ -564,7 +602,6 @@ public class AlternatorDynamoDbAsyncClientIT {
                 "X-Amz-Target",
                 "Content-Type",
                 "Content-Length",
-                "Accept-Encoding", // Required header
                 "Authorization",
                 "X-Amz-Date",
                 "Connection",

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -424,7 +425,7 @@ public class AlternatorDynamoDbAsyncClientIT {
 
   @Test
   public void testResponseCompressionNegotiatesAcceptEncoding() throws Exception {
-    AtomicBoolean acceptEncodingSeen = new AtomicBoolean(false);
+    AtomicReference<String> acceptEncoding = new AtomicReference<>();
 
     ExecutionInterceptor responseCompressionVerifier =
         new ExecutionInterceptor() {
@@ -434,12 +435,7 @@ public class AlternatorDynamoDbAsyncClientIT {
             context
                 .httpRequest()
                 .firstMatchingHeader("Accept-Encoding")
-                .ifPresent(
-                    value -> {
-                      if (value.contains("gzip") && value.contains("deflate")) {
-                        acceptEncodingSeen.set(true);
-                      }
-                    });
+                .ifPresent(acceptEncoding::set);
           }
         };
 
@@ -457,7 +453,44 @@ public class AlternatorDynamoDbAsyncClientIT {
 
     try {
       client.listTables(ListTablesRequest.builder().limit(1).build()).get();
-      assertTrue("Accept-Encoding should advertise gzip and deflate", acceptEncodingSeen.get());
+      assertEquals(ResponseCompressionInterceptor.ACCEPT_ENCODING, acceptEncoding.get());
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testResponseCompressionNegotiatesCustomAcceptEncoding() throws Exception {
+    AtomicReference<String> acceptEncoding = new AtomicReference<>();
+
+    ExecutionInterceptor responseCompressionVerifier =
+        new ExecutionInterceptor() {
+          @Override
+          public void beforeTransmission(
+              Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            context
+                .httpRequest()
+                .firstMatchingHeader("Accept-Encoding")
+                .ifPresent(acceptEncoding::set);
+          }
+        };
+
+    ClientOverrideConfiguration overrideConfig =
+        ClientOverrideConfiguration.builder()
+            .addExecutionInterceptor(responseCompressionVerifier)
+            .build();
+
+    DynamoDbAsyncClient client =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
+            .overrideConfiguration(overrideConfig)
+            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.DEFLATE)
+            .build();
+
+    try {
+      client.listTables(ListTablesRequest.builder().limit(1).build()).get();
+      assertEquals("deflate", acceptEncoding.get());
     } finally {
       client.close();
     }

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
@@ -413,6 +413,42 @@ public class AlternatorDynamoDbClientIT {
   }
 
   @Test
+  public void testResponseCompressionDisabledByDefaultDoesNotSetAcceptEncoding() throws Exception {
+    AtomicReference<String> acceptEncoding = new AtomicReference<>();
+
+    ExecutionInterceptor responseCompressionVerifier =
+        new ExecutionInterceptor() {
+          @Override
+          public void beforeTransmission(
+              Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            context
+                .httpRequest()
+                .firstMatchingHeader("Accept-Encoding")
+                .ifPresent(acceptEncoding::set);
+          }
+        };
+
+    ClientOverrideConfiguration overrideConfig =
+        ClientOverrideConfiguration.builder()
+            .addExecutionInterceptor(responseCompressionVerifier)
+            .build();
+
+    DynamoDbClient client =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
+            .overrideConfiguration(overrideConfig)
+            .build();
+
+    try {
+      client.listTables(ListTablesRequest.builder().limit(1).build());
+      assertNull(acceptEncoding.get());
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
   public void testResponseCompressionNegotiatesAcceptEncoding() throws Exception {
     AtomicReference<String> acceptEncoding = new AtomicReference<>();
 
@@ -438,6 +474,8 @@ public class AlternatorDynamoDbClientIT {
             .endpointOverride(seedUri)
             .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
             .overrideConfiguration(overrideConfig)
+            .withResponseCompressionAlgorithms(
+                ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE)
             .build();
 
     try {
@@ -554,7 +592,6 @@ public class AlternatorDynamoDbClientIT {
                 "X-Amz-Target",
                 "Content-Type",
                 "Content-Length",
-                "Accept-Encoding", // Required header
                 "Authorization",
                 "X-Amz-Date",
                 "Connection",

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -413,7 +414,7 @@ public class AlternatorDynamoDbClientIT {
 
   @Test
   public void testResponseCompressionNegotiatesAcceptEncoding() throws Exception {
-    AtomicBoolean acceptEncodingSeen = new AtomicBoolean(false);
+    AtomicReference<String> acceptEncoding = new AtomicReference<>();
 
     ExecutionInterceptor responseCompressionVerifier =
         new ExecutionInterceptor() {
@@ -423,12 +424,7 @@ public class AlternatorDynamoDbClientIT {
             context
                 .httpRequest()
                 .firstMatchingHeader("Accept-Encoding")
-                .ifPresent(
-                    value -> {
-                      if (value.contains("gzip") && value.contains("deflate")) {
-                        acceptEncodingSeen.set(true);
-                      }
-                    });
+                .ifPresent(acceptEncoding::set);
           }
         };
 
@@ -446,7 +442,44 @@ public class AlternatorDynamoDbClientIT {
 
     try {
       client.listTables(ListTablesRequest.builder().limit(1).build());
-      assertTrue("Accept-Encoding should advertise gzip and deflate", acceptEncodingSeen.get());
+      assertEquals(ResponseCompressionInterceptor.ACCEPT_ENCODING, acceptEncoding.get());
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testResponseCompressionNegotiatesCustomAcceptEncoding() throws Exception {
+    AtomicReference<String> acceptEncoding = new AtomicReference<>();
+
+    ExecutionInterceptor responseCompressionVerifier =
+        new ExecutionInterceptor() {
+          @Override
+          public void beforeTransmission(
+              Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            context
+                .httpRequest()
+                .firstMatchingHeader("Accept-Encoding")
+                .ifPresent(acceptEncoding::set);
+          }
+        };
+
+    ClientOverrideConfiguration overrideConfig =
+        ClientOverrideConfiguration.builder()
+            .addExecutionInterceptor(responseCompressionVerifier)
+            .build();
+
+    DynamoDbClient client =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(seedUri)
+            .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
+            .overrideConfiguration(overrideConfig)
+            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.DEFLATE)
+            .build();
+
+    try {
+      client.listTables(ListTablesRequest.builder().limit(1).build());
+      assertEquals("deflate", acceptEncoding.get());
     } finally {
       client.close();
     }

--- a/src/integration-test/java/com/scylladb/alternator/ResponseCompressionIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/ResponseCompressionIT.java
@@ -81,7 +81,7 @@ public class ResponseCompressionIT {
     verifySyncResponse(
         encoding,
         compressedBody,
-        ResponseCompressionAlgorithm.defaultAlgorithms(),
+        ResponseCompressionAlgorithm.supportedAlgorithms(),
         ResponseCompressionInterceptor.ACCEPT_ENCODING);
   }
 
@@ -118,7 +118,7 @@ public class ResponseCompressionIT {
     verifyAsyncResponse(
         encoding,
         compressedBody,
-        ResponseCompressionAlgorithm.defaultAlgorithms(),
+        ResponseCompressionAlgorithm.supportedAlgorithms(),
         ResponseCompressionInterceptor.ACCEPT_ENCODING);
   }
 

--- a/src/integration-test/java/com/scylladb/alternator/ResponseCompressionIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/ResponseCompressionIT.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
@@ -57,7 +59,37 @@ public class ResponseCompressionIT {
     verifyAsyncResponse("deflate", deflate(RESPONSE_JSON));
   }
 
+  @Test
+  public void testSyncSdkClientUsesConfiguredResponseCompressionAlgorithms() throws Exception {
+    verifySyncResponse(
+        "gzip",
+        gzip(RESPONSE_JSON),
+        Collections.singletonList(ResponseCompressionAlgorithm.GZIP),
+        "gzip");
+  }
+
+  @Test
+  public void testAsyncSdkClientUsesConfiguredResponseCompressionAlgorithms() throws Exception {
+    verifyAsyncResponse(
+        "gzip",
+        gzip(RESPONSE_JSON),
+        Collections.singletonList(ResponseCompressionAlgorithm.GZIP),
+        "gzip");
+  }
+
   private static void verifySyncResponse(String encoding, byte[] compressedBody) {
+    verifySyncResponse(
+        encoding,
+        compressedBody,
+        ResponseCompressionAlgorithm.defaultAlgorithms(),
+        ResponseCompressionInterceptor.ACCEPT_ENCODING);
+  }
+
+  private static void verifySyncResponse(
+      String encoding,
+      byte[] compressedBody,
+      Collection<ResponseCompressionAlgorithm> algorithms,
+      String expectedAcceptEncoding) {
     CompressedResponseHttpClient httpClient =
         new CompressedResponseHttpClient(encoding, compressedBody);
     DynamoDbClient client =
@@ -66,7 +98,8 @@ public class ResponseCompressionIT {
             .region(Region.US_EAST_1)
             .credentialsProvider(AnonymousCredentialsProvider.create())
             .httpClient(httpClient)
-            .overrideConfiguration(c -> c.addExecutionInterceptor(new ResponseCompressionInterceptor()))
+            .overrideConfiguration(
+                c -> c.addExecutionInterceptor(new ResponseCompressionInterceptor(algorithms)))
             .build();
 
     try {
@@ -74,7 +107,7 @@ public class ResponseCompressionIT {
 
       assertEquals(TABLE_NAME, response.tableNames().get(0));
       assertEquals(
-          ResponseCompressionInterceptor.ACCEPT_ENCODING,
+          expectedAcceptEncoding,
           httpClient.capturedRequest.firstMatchingHeader("Accept-Encoding").get());
     } finally {
       client.close();
@@ -82,6 +115,19 @@ public class ResponseCompressionIT {
   }
 
   private static void verifyAsyncResponse(String encoding, byte[] compressedBody) throws Exception {
+    verifyAsyncResponse(
+        encoding,
+        compressedBody,
+        ResponseCompressionAlgorithm.defaultAlgorithms(),
+        ResponseCompressionInterceptor.ACCEPT_ENCODING);
+  }
+
+  private static void verifyAsyncResponse(
+      String encoding,
+      byte[] compressedBody,
+      Collection<ResponseCompressionAlgorithm> algorithms,
+      String expectedAcceptEncoding)
+      throws Exception {
     CompressedResponseAsyncHttpClient httpClient =
         new CompressedResponseAsyncHttpClient(encoding, compressedBody);
     DynamoDbAsyncClient client =
@@ -90,7 +136,8 @@ public class ResponseCompressionIT {
             .region(Region.US_EAST_1)
             .credentialsProvider(AnonymousCredentialsProvider.create())
             .httpClient(httpClient)
-            .overrideConfiguration(c -> c.addExecutionInterceptor(new ResponseCompressionInterceptor()))
+            .overrideConfiguration(
+                c -> c.addExecutionInterceptor(new ResponseCompressionInterceptor(algorithms)))
             .build();
 
     try {
@@ -98,7 +145,7 @@ public class ResponseCompressionIT {
 
       assertEquals(TABLE_NAME, response.tableNames().get(0));
       assertEquals(
-          ResponseCompressionInterceptor.ACCEPT_ENCODING,
+          expectedAcceptEncoding,
           httpClient.capturedRequest.firstMatchingHeader("Accept-Encoding").get());
     } finally {
       client.close();

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -127,7 +127,6 @@ public class AlternatorConfig {
    *   <li>{@code X-Amz-Target} - Specifies the DynamoDB operation
    *   <li>{@code Content-Type} - MIME type for DynamoDB API (application/x-amz-json-1.0)
    *   <li>{@code Content-Length} - Required for request body
-   *   <li>{@code Accept-Encoding} - For response compression negotiation
    *   <li>{@code Connection} - HTTP keep-alive for connection reuse
    * </ul>
    *
@@ -137,12 +136,19 @@ public class AlternatorConfig {
       Collections.unmodifiableSet(
           new HashSet<>(
               Arrays.asList(
-                  "Host",
-                  "X-Amz-Target",
-                  "Content-Type",
-                  "Content-Length",
-                  "Accept-Encoding",
-                  "Connection")));
+                  "Host", "X-Amz-Target", "Content-Type", "Content-Length", "Connection")));
+
+  /**
+   * HTTP headers required when response compression is enabled.
+   *
+   * <ul>
+   *   <li>{@code Accept-Encoding} - For response compression negotiation
+   * </ul>
+   *
+   * @since 2.0.6
+   */
+  public static final Set<String> RESPONSE_COMPRESSION_HEADERS =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("Accept-Encoding")));
 
   /**
    * HTTP headers required when user-agent reporting is enabled.
@@ -187,6 +193,7 @@ public class AlternatorConfig {
   private final RoutingScope routingScope;
   private final RequestCompressionAlgorithm compressionAlgorithm;
   private final int minCompressionSizeBytes;
+  private final List<ResponseCompressionAlgorithm> responseCompressionAlgorithms;
   private final boolean optimizeHeaders;
   private final Set<String> headersWhitelist;
   private final boolean userAgentEnabled;
@@ -211,6 +218,7 @@ public class AlternatorConfig {
    * @param routingScope the routing scope for node targeting
    * @param compressionAlgorithm the compression algorithm to use
    * @param minCompressionSizeBytes minimum request size in bytes to trigger compression
+   * @param responseCompressionAlgorithms response compression algorithms to advertise and decode
    * @param optimizeHeaders whether to enable HTTP header optimization
    * @param headersWhitelist the set of headers to preserve when optimization is enabled
    * @param userAgentEnabled whether user-agent reporting is enabled
@@ -236,6 +244,7 @@ public class AlternatorConfig {
       RoutingScope routingScope,
       RequestCompressionAlgorithm compressionAlgorithm,
       int minCompressionSizeBytes,
+      List<ResponseCompressionAlgorithm> responseCompressionAlgorithms,
       boolean optimizeHeaders,
       Set<String> headersWhitelist,
       boolean userAgentEnabled,
@@ -261,6 +270,10 @@ public class AlternatorConfig {
         compressionAlgorithm != null ? compressionAlgorithm : RequestCompressionAlgorithm.NONE;
     this.minCompressionSizeBytes =
         minCompressionSizeBytes >= 0 ? minCompressionSizeBytes : DEFAULT_MIN_COMPRESSION_SIZE_BYTES;
+    this.responseCompressionAlgorithms =
+        responseCompressionAlgorithms != null
+            ? Collections.unmodifiableList(new ArrayList<>(responseCompressionAlgorithms))
+            : ResponseCompressionAlgorithm.defaultAlgorithms();
     this.optimizeHeaders = optimizeHeaders;
     this.userAgentEnabled = userAgentEnabled;
     this.authenticationEnabled = authenticationEnabled;
@@ -364,6 +377,30 @@ public class AlternatorConfig {
    */
   public int getMinCompressionSizeBytes() {
     return minCompressionSizeBytes;
+  }
+
+  /**
+   * Gets the configured HTTP response compression algorithms.
+   *
+   * <p>The algorithms are ordered as they will be sent in the {@code Accept-Encoding} header. The
+   * default is {@link ResponseCompressionAlgorithm#GZIP} followed by {@link
+   * ResponseCompressionAlgorithm#DEFLATE}. An empty list means response compression is disabled.
+   *
+   * @return response compression algorithms, never null
+   * @since 2.0.6
+   */
+  public List<ResponseCompressionAlgorithm> getResponseCompressionAlgorithms() {
+    return responseCompressionAlgorithms;
+  }
+
+  /**
+   * Checks if HTTP response compression negotiation and decompression are enabled.
+   *
+   * @return true if at least one response compression algorithm is configured
+   * @since 2.0.6
+   */
+  public boolean isResponseCompressionEnabled() {
+    return !responseCompressionAlgorithms.isEmpty();
   }
 
   /**
@@ -569,6 +606,9 @@ public class AlternatorConfig {
    */
   public Set<String> getRequiredHeaders() {
     Set<String> required = new HashSet<>(BASE_REQUIRED_HEADERS);
+    if (isResponseCompressionEnabled()) {
+      required.addAll(RESPONSE_COMPRESSION_HEADERS);
+    }
     if (compressionAlgorithm != null && compressionAlgorithm != RequestCompressionAlgorithm.NONE) {
       required.addAll(COMPRESSION_HEADERS);
     }
@@ -597,6 +637,8 @@ public class AlternatorConfig {
     private RoutingScope routingScope = null;
     private RequestCompressionAlgorithm compressionAlgorithm = RequestCompressionAlgorithm.NONE;
     private int minCompressionSizeBytes = DEFAULT_MIN_COMPRESSION_SIZE_BYTES;
+    private List<ResponseCompressionAlgorithm> responseCompressionAlgorithms =
+        ResponseCompressionAlgorithm.defaultAlgorithms();
     private boolean optimizeHeaders = false;
     private Set<String> headersWhitelist = null; // null means use default based on config
     private boolean headersWhitelistWasSet = false;
@@ -734,6 +776,9 @@ public class AlternatorConfig {
      */
     public Set<String> getRequiredHeaders() {
       Set<String> required = new HashSet<>(BASE_REQUIRED_HEADERS);
+      if (!responseCompressionAlgorithms.isEmpty()) {
+        required.addAll(RESPONSE_COMPRESSION_HEADERS);
+      }
       if (compressionAlgorithm != null && compressionAlgorithm.isEnabled()) {
         required.addAll(COMPRESSION_HEADERS);
       }
@@ -821,6 +866,57 @@ public class AlternatorConfig {
      */
     public Builder withMinCompressionSizeBytes(int minCompressionSizeBytes) {
       this.minCompressionSizeBytes = minCompressionSizeBytes;
+      return this;
+    }
+
+    /**
+     * Sets the HTTP response compression algorithms to advertise and decode.
+     *
+     * <p>The configured order is used for the {@code Accept-Encoding} header. The default is {@link
+     * ResponseCompressionAlgorithm#GZIP} followed by {@link ResponseCompressionAlgorithm#DEFLATE}.
+     *
+     * @param algorithms the response compression algorithms to enable
+     * @return this builder instance
+     * @throws IllegalArgumentException if algorithms is null, empty, or contains null
+     * @since 2.0.6
+     */
+    public Builder withResponseCompressionAlgorithms(ResponseCompressionAlgorithm... algorithms) {
+      if (algorithms == null) {
+        throw new IllegalArgumentException(
+            "responseCompressionAlgorithms cannot be null or empty. "
+                + "Use withResponseCompressionDisabled() to disable response compression.");
+      }
+      return withResponseCompressionAlgorithms(Arrays.asList(algorithms));
+    }
+
+    /**
+     * Sets the HTTP response compression algorithms to advertise and decode.
+     *
+     * <p>The configured order is used for the {@code Accept-Encoding} header. The default is {@link
+     * ResponseCompressionAlgorithm#GZIP} followed by {@link ResponseCompressionAlgorithm#DEFLATE}.
+     *
+     * @param algorithms the response compression algorithms to enable
+     * @return this builder instance
+     * @throws IllegalArgumentException if algorithms is null, empty, or contains null
+     * @since 2.0.6
+     */
+    public Builder withResponseCompressionAlgorithms(
+        Collection<ResponseCompressionAlgorithm> algorithms) {
+      this.responseCompressionAlgorithms = ResponseCompressionAlgorithm.validatedList(algorithms);
+      return this;
+    }
+
+    /**
+     * Disables HTTP response compression negotiation and decompression.
+     *
+     * <p>When disabled, the client does not set {@code Accept-Encoding} and does not decompress
+     * compressed response bodies.
+     *
+     * @return this builder instance
+     * @since 2.0.6
+     */
+    public Builder withResponseCompressionDisabled() {
+      this.responseCompressionAlgorithms = Collections.emptyList();
       return this;
     }
 
@@ -1273,6 +1369,7 @@ public class AlternatorConfig {
           effectiveRoutingScope,
           compressionAlgorithm,
           minCompressionSizeBytes,
+          responseCompressionAlgorithms,
           optimizeHeaders,
           headersWhitelist,
           userAgentEnabled,

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -273,7 +273,7 @@ public class AlternatorConfig {
     this.responseCompressionAlgorithms =
         responseCompressionAlgorithms != null
             ? Collections.unmodifiableList(new ArrayList<>(responseCompressionAlgorithms))
-            : ResponseCompressionAlgorithm.defaultAlgorithms();
+            : Collections.emptyList();
     this.optimizeHeaders = optimizeHeaders;
     this.userAgentEnabled = userAgentEnabled;
     this.authenticationEnabled = authenticationEnabled;
@@ -383,8 +383,7 @@ public class AlternatorConfig {
    * Gets the configured HTTP response compression algorithms.
    *
    * <p>The algorithms are ordered as they will be sent in the {@code Accept-Encoding} header. The
-   * default is {@link ResponseCompressionAlgorithm#GZIP} followed by {@link
-   * ResponseCompressionAlgorithm#DEFLATE}. An empty list means response compression is disabled.
+   * default is an empty list, which means response compression is disabled.
    *
    * @return response compression algorithms, never null
    * @since 2.0.6
@@ -638,7 +637,7 @@ public class AlternatorConfig {
     private RequestCompressionAlgorithm compressionAlgorithm = RequestCompressionAlgorithm.NONE;
     private int minCompressionSizeBytes = DEFAULT_MIN_COMPRESSION_SIZE_BYTES;
     private List<ResponseCompressionAlgorithm> responseCompressionAlgorithms =
-        ResponseCompressionAlgorithm.defaultAlgorithms();
+        Collections.emptyList();
     private boolean optimizeHeaders = false;
     private Set<String> headersWhitelist = null; // null means use default based on config
     private boolean headersWhitelistWasSet = false;
@@ -768,7 +767,7 @@ public class AlternatorConfig {
      *
      * Set<String> required = builder.getRequiredHeaders();
      * // required contains: Host, X-Amz-Target, Content-Type, Content-Length,
-     * //                    Accept-Encoding, Content-Encoding, Authorization, X-Amz-Date
+     * //                    Content-Encoding, Authorization, X-Amz-Date
      * }</pre>
      *
      * @return an unmodifiable set of required header names for the current configuration
@@ -872,8 +871,8 @@ public class AlternatorConfig {
     /**
      * Sets the HTTP response compression algorithms to advertise and decode.
      *
-     * <p>The configured order is used for the {@code Accept-Encoding} header. The default is {@link
-     * ResponseCompressionAlgorithm#GZIP} followed by {@link ResponseCompressionAlgorithm#DEFLATE}.
+     * <p>The configured order is used for the {@code Accept-Encoding} header. Response compression
+     * is disabled by default.
      *
      * @param algorithms the response compression algorithms to enable
      * @return this builder instance
@@ -892,8 +891,8 @@ public class AlternatorConfig {
     /**
      * Sets the HTTP response compression algorithms to advertise and decode.
      *
-     * <p>The configured order is used for the {@code Accept-Encoding} header. The default is {@link
-     * ResponseCompressionAlgorithm#GZIP} followed by {@link ResponseCompressionAlgorithm#DEFLATE}.
+     * <p>The configured order is used for the {@code Accept-Encoding} header. Response compression
+     * is disabled by default.
      *
      * @param algorithms the response compression algorithms to enable
      * @return this builder instance

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -183,6 +183,49 @@ public class AlternatorDynamoDbAsyncClient {
     }
 
     /**
+     * Sets the HTTP response compression algorithms to advertise and decode.
+     *
+     * <p>The configured order is used for the {@code Accept-Encoding} header.
+     *
+     * @param algorithms the response compression algorithms to enable
+     * @return this builder instance
+     * @throws IllegalArgumentException if algorithms is null, empty, or contains null
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withResponseCompressionAlgorithms(
+        ResponseCompressionAlgorithm... algorithms) {
+      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      return this;
+    }
+
+    /**
+     * Sets the HTTP response compression algorithms to advertise and decode.
+     *
+     * <p>The configured order is used for the {@code Accept-Encoding} header.
+     *
+     * @param algorithms the response compression algorithms to enable
+     * @return this builder instance
+     * @throws IllegalArgumentException if algorithms is null, empty, or contains null
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withResponseCompressionAlgorithms(
+        Collection<ResponseCompressionAlgorithm> algorithms) {
+      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      return this;
+    }
+
+    /**
+     * Disables HTTP response compression negotiation and decompression.
+     *
+     * @return this builder instance
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbAsyncClientBuilder withResponseCompressionDisabled() {
+      configBuilder.withResponseCompressionDisabled();
+      return this;
+    }
+
+    /**
      * Enables or disables HTTP header optimization.
      *
      * @param optimizeHeaders true to enable header filtering, false to disable
@@ -410,6 +453,12 @@ public class AlternatorDynamoDbAsyncClient {
         configBuilder.withRoutingScope(config.getRoutingScope());
         configBuilder.withCompressionAlgorithm(config.getCompressionAlgorithm());
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
+        if (config.isResponseCompressionEnabled()) {
+          configBuilder.withResponseCompressionAlgorithms(
+              config.getResponseCompressionAlgorithms());
+        } else {
+          configBuilder.withResponseCompressionDisabled();
+        }
         configBuilder.withOptimizeHeaders(config.isOptimizeHeaders());
         configBuilder.withHeadersWhitelist(config.getHeadersWhitelist());
         configBuilder.withUserAgentEnabled(config.isUserAgentEnabled());
@@ -688,7 +737,11 @@ public class AlternatorDynamoDbAsyncClient {
           delegate.overrideConfiguration() != null
               ? delegate.overrideConfiguration().toBuilder()
               : ClientOverrideConfiguration.builder();
-      compressionOverrideBuilder.addExecutionInterceptor(new ResponseCompressionInterceptor());
+      if (alternatorConfig.isResponseCompressionEnabled()) {
+        compressionOverrideBuilder.addExecutionInterceptor(
+            new ResponseCompressionInterceptor(
+                alternatorConfig.getResponseCompressionAlgorithms()));
+      }
       if (alternatorConfig.getCompressionAlgorithm().isEnabled()) {
         compressionOverrideBuilder.addExecutionInterceptor(
             new GzipRequestInterceptor(alternatorConfig.getMinCompressionSizeBytes()));

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -204,6 +204,49 @@ public class AlternatorDynamoDbClient {
     }
 
     /**
+     * Sets the HTTP response compression algorithms to advertise and decode.
+     *
+     * <p>The configured order is used for the {@code Accept-Encoding} header.
+     *
+     * @param algorithms the response compression algorithms to enable
+     * @return this builder instance
+     * @throws IllegalArgumentException if algorithms is null, empty, or contains null
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbClientBuilder withResponseCompressionAlgorithms(
+        ResponseCompressionAlgorithm... algorithms) {
+      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      return this;
+    }
+
+    /**
+     * Sets the HTTP response compression algorithms to advertise and decode.
+     *
+     * <p>The configured order is used for the {@code Accept-Encoding} header.
+     *
+     * @param algorithms the response compression algorithms to enable
+     * @return this builder instance
+     * @throws IllegalArgumentException if algorithms is null, empty, or contains null
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbClientBuilder withResponseCompressionAlgorithms(
+        Collection<ResponseCompressionAlgorithm> algorithms) {
+      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      return this;
+    }
+
+    /**
+     * Disables HTTP response compression negotiation and decompression.
+     *
+     * @return this builder instance
+     * @since 2.0.6
+     */
+    public AlternatorDynamoDbClientBuilder withResponseCompressionDisabled() {
+      configBuilder.withResponseCompressionDisabled();
+      return this;
+    }
+
+    /**
      * Enables or disables HTTP header optimization.
      *
      * <p>When enabled, outgoing requests will have their HTTP headers filtered to include only
@@ -447,6 +490,12 @@ public class AlternatorDynamoDbClient {
         configBuilder.withRoutingScope(config.getRoutingScope());
         configBuilder.withCompressionAlgorithm(config.getCompressionAlgorithm());
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
+        if (config.isResponseCompressionEnabled()) {
+          configBuilder.withResponseCompressionAlgorithms(
+              config.getResponseCompressionAlgorithms());
+        } else {
+          configBuilder.withResponseCompressionDisabled();
+        }
         configBuilder.withOptimizeHeaders(config.isOptimizeHeaders());
         configBuilder.withHeadersWhitelist(config.getHeadersWhitelist());
         configBuilder.withUserAgentEnabled(config.isUserAgentEnabled());
@@ -709,7 +758,11 @@ public class AlternatorDynamoDbClient {
           delegate.overrideConfiguration() != null
               ? delegate.overrideConfiguration().toBuilder()
               : ClientOverrideConfiguration.builder();
-      compressionOverrideBuilder.addExecutionInterceptor(new ResponseCompressionInterceptor());
+      if (alternatorConfig.isResponseCompressionEnabled()) {
+        compressionOverrideBuilder.addExecutionInterceptor(
+            new ResponseCompressionInterceptor(
+                alternatorConfig.getResponseCompressionAlgorithms()));
+      }
       if (alternatorConfig.getCompressionAlgorithm().isEnabled()) {
         compressionOverrideBuilder.addExecutionInterceptor(
             new GzipRequestInterceptor(alternatorConfig.getMinCompressionSizeBytes()));

--- a/src/main/java/com/scylladb/alternator/ResponseCompressionAlgorithm.java
+++ b/src/main/java/com/scylladb/alternator/ResponseCompressionAlgorithm.java
@@ -1,0 +1,80 @@
+package com.scylladb.alternator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Enumeration of supported HTTP response compression algorithms. */
+public enum ResponseCompressionAlgorithm {
+  /** GZIP response compression. */
+  GZIP("gzip"),
+
+  /** DEFLATE response compression. */
+  DEFLATE("deflate");
+
+  private static final List<ResponseCompressionAlgorithm> DEFAULT_ALGORITHMS =
+      Collections.unmodifiableList(Arrays.asList(GZIP, DEFLATE));
+
+  private final String contentEncoding;
+
+  ResponseCompressionAlgorithm(String contentEncoding) {
+    this.contentEncoding = contentEncoding;
+  }
+
+  /**
+   * Returns the HTTP {@code Content-Encoding} and {@code Accept-Encoding} token for this algorithm.
+   *
+   * @return the encoding token
+   */
+  public String contentEncoding() {
+    return contentEncoding;
+  }
+
+  static List<ResponseCompressionAlgorithm> defaultAlgorithms() {
+    return DEFAULT_ALGORITHMS;
+  }
+
+  static List<ResponseCompressionAlgorithm> validatedList(
+      Collection<ResponseCompressionAlgorithm> algorithms) {
+    if (algorithms == null || algorithms.isEmpty()) {
+      throw new IllegalArgumentException(
+          "responseCompressionAlgorithms cannot be null or empty. "
+              + "Use withResponseCompressionDisabled() to disable response compression.");
+    }
+
+    Set<ResponseCompressionAlgorithm> uniqueAlgorithms = new LinkedHashSet<>();
+    for (ResponseCompressionAlgorithm algorithm : algorithms) {
+      if (algorithm == null) {
+        throw new IllegalArgumentException("responseCompressionAlgorithms cannot contain null");
+      }
+      uniqueAlgorithms.add(algorithm);
+    }
+    return Collections.unmodifiableList(new ArrayList<>(uniqueAlgorithms));
+  }
+
+  static String acceptEncoding(Collection<ResponseCompressionAlgorithm> algorithms) {
+    return algorithms.stream()
+        .map(ResponseCompressionAlgorithm::contentEncoding)
+        .collect(Collectors.joining(", "));
+  }
+
+  static Optional<ResponseCompressionAlgorithm> fromContentEncoding(String value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    String token = value.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+    for (ResponseCompressionAlgorithm algorithm : values()) {
+      if (algorithm.contentEncoding.equals(token)) {
+        return Optional.of(algorithm);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/com/scylladb/alternator/ResponseCompressionAlgorithm.java
+++ b/src/main/java/com/scylladb/alternator/ResponseCompressionAlgorithm.java
@@ -19,7 +19,7 @@ public enum ResponseCompressionAlgorithm {
   /** DEFLATE response compression. */
   DEFLATE("deflate");
 
-  private static final List<ResponseCompressionAlgorithm> DEFAULT_ALGORITHMS =
+  private static final List<ResponseCompressionAlgorithm> SUPPORTED_ALGORITHMS =
       Collections.unmodifiableList(Arrays.asList(GZIP, DEFLATE));
 
   private final String contentEncoding;
@@ -37,8 +37,8 @@ public enum ResponseCompressionAlgorithm {
     return contentEncoding;
   }
 
-  static List<ResponseCompressionAlgorithm> defaultAlgorithms() {
-    return DEFAULT_ALGORITHMS;
+  static List<ResponseCompressionAlgorithm> supportedAlgorithms() {
+    return SUPPORTED_ALGORITHMS;
   }
 
   static List<ResponseCompressionAlgorithm> validatedList(

--- a/src/main/java/com/scylladb/alternator/ResponseCompressionInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/ResponseCompressionInterceptor.java
@@ -28,7 +28,8 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 class ResponseCompressionInterceptor implements ExecutionInterceptor {
 
   static final String ACCEPT_ENCODING =
-      ResponseCompressionAlgorithm.acceptEncoding(ResponseCompressionAlgorithm.defaultAlgorithms());
+      ResponseCompressionAlgorithm.acceptEncoding(
+          ResponseCompressionAlgorithm.supportedAlgorithms());
 
   private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
   private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
@@ -39,7 +40,7 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
   private final String acceptEncoding;
 
   ResponseCompressionInterceptor() {
-    this(ResponseCompressionAlgorithm.defaultAlgorithms());
+    this(ResponseCompressionAlgorithm.supportedAlgorithms());
   }
 
   ResponseCompressionInterceptor(Collection<ResponseCompressionAlgorithm> algorithms) {

--- a/src/main/java/com/scylladb/alternator/ResponseCompressionInterceptor.java
+++ b/src/main/java/com/scylladb/alternator/ResponseCompressionInterceptor.java
@@ -6,9 +6,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 import org.reactivestreams.Publisher;
@@ -25,13 +27,27 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 /** Adds HTTP response compression negotiation and decompresses gzip/deflate responses. */
 class ResponseCompressionInterceptor implements ExecutionInterceptor {
 
-  static final String ACCEPT_ENCODING = "gzip, deflate";
+  static final String ACCEPT_ENCODING =
+      ResponseCompressionAlgorithm.acceptEncoding(ResponseCompressionAlgorithm.defaultAlgorithms());
 
   private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
   private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
   private static final String CONTENT_LENGTH_HEADER = "Content-Length";
-  private static final ExecutionAttribute<Encoding> RESPONSE_ENCODING =
+  private static final ExecutionAttribute<ResponseCompressionAlgorithm> RESPONSE_ENCODING =
       new ExecutionAttribute<>("ResponseCompressionInterceptor.responseEncoding");
+  private final Set<ResponseCompressionAlgorithm> algorithmSet;
+  private final String acceptEncoding;
+
+  ResponseCompressionInterceptor() {
+    this(ResponseCompressionAlgorithm.defaultAlgorithms());
+  }
+
+  ResponseCompressionInterceptor(Collection<ResponseCompressionAlgorithm> algorithms) {
+    List<ResponseCompressionAlgorithm> validatedAlgorithms =
+        ResponseCompressionAlgorithm.validatedList(algorithms);
+    this.algorithmSet = new HashSet<>(validatedAlgorithms);
+    this.acceptEncoding = ResponseCompressionAlgorithm.acceptEncoding(validatedAlgorithms);
+  }
 
   @Override
   public SdkHttpRequest modifyHttpRequest(
@@ -42,7 +58,7 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
   @Override
   public SdkHttpResponse modifyHttpResponse(
       Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
-    Optional<Encoding> encoding = responseEncoding(context.httpResponse());
+    Optional<ResponseCompressionAlgorithm> encoding = responseEncoding(context.httpResponse());
     encoding.ifPresent(value -> executionAttributes.putAttribute(RESPONSE_ENCODING, value));
     return encoding.isPresent()
         ? stripCompressionHeaders(context.httpResponse())
@@ -52,7 +68,7 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
   @Override
   public Optional<InputStream> modifyHttpResponseContent(
       Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
-    Encoding encoding = executionAttributes.getAttribute(RESPONSE_ENCODING);
+    ResponseCompressionAlgorithm encoding = executionAttributes.getAttribute(RESPONSE_ENCODING);
     if (encoding == null || !context.responseBody().isPresent()) {
       return Optional.empty();
     }
@@ -61,25 +77,25 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
       return Optional.of(decompress(context.responseBody().get(), encoding));
     } catch (IOException e) {
       throw SdkClientException.create(
-          "Failed to initialize " + encoding.name + " response decompression", e);
+          "Failed to initialize " + encoding.contentEncoding() + " response decompression", e);
     }
   }
 
   @Override
   public Optional<Publisher<ByteBuffer>> modifyAsyncHttpResponseContent(
       Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
-    Encoding encoding = executionAttributes.getAttribute(RESPONSE_ENCODING);
+    ResponseCompressionAlgorithm encoding = executionAttributes.getAttribute(RESPONSE_ENCODING);
     if (encoding == null || !context.responsePublisher().isPresent()) {
       return Optional.empty();
     }
     return Optional.of(new DecompressingPublisher(context.responsePublisher().get(), encoding));
   }
 
-  private static SdkHttpRequest withAcceptEncoding(SdkHttpRequest request) {
-    return request.toBuilder().putHeader(ACCEPT_ENCODING_HEADER, ACCEPT_ENCODING).build();
+  private SdkHttpRequest withAcceptEncoding(SdkHttpRequest request) {
+    return request.toBuilder().putHeader(ACCEPT_ENCODING_HEADER, acceptEncoding).build();
   }
 
-  private static Optional<Encoding> responseEncoding(SdkHttpResponse response) {
+  private Optional<ResponseCompressionAlgorithm> responseEncoding(SdkHttpResponse response) {
     List<String> values = response.matchingHeaders(CONTENT_ENCODING_HEADER);
     List<String> tokens = new ArrayList<>();
     for (String value : values) {
@@ -88,7 +104,8 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
       }
     }
     if (tokens.size() == 1) {
-      return Encoding.from(tokens.get(0));
+      return ResponseCompressionAlgorithm.fromContentEncoding(tokens.get(0))
+          .filter(algorithmSet::contains);
     }
     return Optional.empty();
   }
@@ -104,8 +121,8 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
     return builder.build();
   }
 
-  private static InputStream decompress(InputStream compressed, Encoding encoding)
-      throws IOException {
+  private static InputStream decompress(
+      InputStream compressed, ResponseCompressionAlgorithm encoding) throws IOException {
     switch (encoding) {
       case GZIP:
         return new GZIPInputStream(compressed);
@@ -116,7 +133,8 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
     }
   }
 
-  private static byte[] decompress(byte[] compressed, Encoding encoding) throws IOException {
+  private static byte[] decompress(byte[] compressed, ResponseCompressionAlgorithm encoding)
+      throws IOException {
     try (InputStream input = decompress(new ByteArrayInputStream(compressed), encoding)) {
       ByteArrayOutputStream output = new ByteArrayOutputStream();
       byte[] buffer = new byte[4096];
@@ -132,35 +150,12 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
     return actual != null && actual.equalsIgnoreCase(expected);
   }
 
-  private enum Encoding {
-    GZIP("gzip"),
-    DEFLATE("deflate");
-
-    private final String name;
-
-    Encoding(String name) {
-      this.name = name;
-    }
-
-    static Optional<Encoding> from(String value) {
-      if (value == null) {
-        return Optional.empty();
-      }
-      String token = value.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
-      for (Encoding encoding : values()) {
-        if (encoding.name.equals(token)) {
-          return Optional.of(encoding);
-        }
-      }
-      return Optional.empty();
-    }
-  }
-
   private static final class DecompressingPublisher implements Publisher<ByteBuffer> {
     private final Publisher<ByteBuffer> delegate;
-    private final Encoding encoding;
+    private final ResponseCompressionAlgorithm encoding;
 
-    private DecompressingPublisher(Publisher<ByteBuffer> delegate, Encoding encoding) {
+    private DecompressingPublisher(
+        Publisher<ByteBuffer> delegate, ResponseCompressionAlgorithm encoding) {
       this.delegate = delegate;
       this.encoding = encoding;
     }
@@ -174,7 +169,7 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
   private static final class DecompressingSubscriber
       implements Subscriber<ByteBuffer>, Subscription {
     private final Subscriber<? super ByteBuffer> downstream;
-    private final Encoding encoding;
+    private final ResponseCompressionAlgorithm encoding;
     private final ByteArrayOutputStream compressedBytes = new ByteArrayOutputStream();
     private Subscription upstream;
     private boolean upstreamRequested;
@@ -184,7 +179,8 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
     private long demand;
     private byte[] decompressedBytes;
 
-    private DecompressingSubscriber(Subscriber<? super ByteBuffer> downstream, Encoding encoding) {
+    private DecompressingSubscriber(
+        Subscriber<? super ByteBuffer> downstream, ResponseCompressionAlgorithm encoding) {
       this.downstream = downstream;
       this.encoding = encoding;
     }
@@ -221,7 +217,8 @@ class ResponseCompressionInterceptor implements ExecutionInterceptor {
       } catch (IOException e) {
         if (!isCancelled()) {
           downstream.onError(
-              SdkClientException.create("Failed to decompress " + encoding.name + " response", e));
+              SdkClientException.create(
+                  "Failed to decompress " + encoding.contentEncoding() + " response", e));
         }
         return;
       }

--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -222,17 +222,24 @@ public class AlternatorLiveNodes extends Thread {
    */
   @Deprecated
   public AlternatorLiveNodes(URI seedUri, AlternatorConfig config) {
-    this(
-        config.getSeedHosts().isEmpty()
-            ? AlternatorConfig.builder()
-                .withSeedNode(seedUri)
-                .withRoutingScope(config.getRoutingScope())
-                .withCompressionAlgorithm(config.getCompressionAlgorithm())
-                .withMinCompressionSizeBytes(config.getMinCompressionSizeBytes())
-                .withOptimizeHeaders(config.isOptimizeHeaders())
-                .withHeadersWhitelist(config.getHeadersWhitelist())
-                .build()
-            : config);
+    this(config.getSeedHosts().isEmpty() ? configWithSeedUri(seedUri, config) : config);
+  }
+
+  private static AlternatorConfig configWithSeedUri(URI seedUri, AlternatorConfig config) {
+    AlternatorConfig.Builder builder =
+        AlternatorConfig.builder()
+            .withSeedNode(seedUri)
+            .withRoutingScope(config.getRoutingScope())
+            .withCompressionAlgorithm(config.getCompressionAlgorithm())
+            .withMinCompressionSizeBytes(config.getMinCompressionSizeBytes())
+            .withOptimizeHeaders(config.isOptimizeHeaders())
+            .withHeadersWhitelist(config.getHeadersWhitelist());
+    if (config.isResponseCompressionEnabled()) {
+      builder.withResponseCompressionAlgorithms(config.getResponseCompressionAlgorithms());
+    } else {
+      builder.withResponseCompressionDisabled();
+    }
+    return builder.build();
   }
 
   /**

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
@@ -6,6 +6,7 @@ import com.scylladb.alternator.routing.ClusterScope;
 import com.scylladb.alternator.routing.DatacenterScope;
 import com.scylladb.alternator.routing.RackScope;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 
 /**
@@ -23,10 +24,8 @@ public class AlternatorConfigCompressionTest {
     assertEquals(
         AlternatorConfig.DEFAULT_MIN_COMPRESSION_SIZE_BYTES, config.getMinCompressionSizeBytes());
     assertFalse(config.getCompressionAlgorithm().isEnabled());
-    assertEquals(
-        Arrays.asList(ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE),
-        config.getResponseCompressionAlgorithms());
-    assertTrue(config.isResponseCompressionEnabled());
+    assertEquals(Collections.emptyList(), config.getResponseCompressionAlgorithms());
+    assertFalse(config.isResponseCompressionEnabled());
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import com.scylladb.alternator.routing.ClusterScope;
 import com.scylladb.alternator.routing.DatacenterScope;
 import com.scylladb.alternator.routing.RackScope;
+import java.util.Arrays;
 import org.junit.Test;
 
 /**
@@ -22,6 +23,10 @@ public class AlternatorConfigCompressionTest {
     assertEquals(
         AlternatorConfig.DEFAULT_MIN_COMPRESSION_SIZE_BYTES, config.getMinCompressionSizeBytes());
     assertFalse(config.getCompressionAlgorithm().isEnabled());
+    assertEquals(
+        Arrays.asList(ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE),
+        config.getResponseCompressionAlgorithms());
+    assertTrue(config.isResponseCompressionEnabled());
   }
 
   @Test
@@ -119,5 +124,45 @@ public class AlternatorConfigCompressionTest {
   public void testDefaultMinCompressionSizeValue() {
     // Verify the default constant value is 1024 bytes (1 KB)
     assertEquals(1024, AlternatorConfig.DEFAULT_MIN_COMPRESSION_SIZE_BYTES);
+  }
+
+  @Test
+  public void testCustomResponseCompressionAlgorithmsPreserveOrder() {
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withResponseCompressionAlgorithms(
+                ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP)
+            .build();
+
+    assertEquals(
+        Arrays.asList(ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP),
+        config.getResponseCompressionAlgorithms());
+    assertTrue(config.isResponseCompressionEnabled());
+  }
+
+  @Test
+  public void testResponseCompressionDisabled() {
+    AlternatorConfig config = AlternatorConfig.builder().withResponseCompressionDisabled().build();
+
+    assertTrue(config.getResponseCompressionAlgorithms().isEmpty());
+    assertFalse(config.isResponseCompressionEnabled());
+    assertFalse(config.getRequiredHeaders().contains("Accept-Encoding"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullResponseCompressionAlgorithmsThrowException() {
+    AlternatorConfig.builder()
+        .withResponseCompressionAlgorithms((ResponseCompressionAlgorithm[]) null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyResponseCompressionAlgorithmsThrowException() {
+    AlternatorConfig.builder().withResponseCompressionAlgorithms();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullResponseCompressionAlgorithmThrowsException() {
+    AlternatorConfig.builder()
+        .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP, null);
   }
 }

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
@@ -157,6 +157,35 @@ public class AlternatorConfigHeadersTest {
   }
 
   @Test
+  public void testResponseCompressionDisabledRemovesAcceptEncodingFromRequiredHeaders() {
+    AlternatorConfig config = AlternatorConfig.builder().withResponseCompressionDisabled().build();
+
+    assertFalse(config.isResponseCompressionEnabled());
+    assertFalse(config.getRequiredHeaders().contains("Accept-Encoding"));
+    assertFalse(config.getHeadersWhitelist().contains("Accept-Encoding"));
+  }
+
+  @Test
+  public void testCustomWhitelistWithoutAcceptEncodingSucceedsWhenResponseCompressionDisabled() {
+    AlternatorConfig.Builder builder =
+        AlternatorConfig.builder().withResponseCompressionDisabled().withOptimizeHeaders(true);
+    Set<String> whitelist = new HashSet<>(builder.getRequiredHeaders());
+
+    AlternatorConfig config = builder.withHeadersWhitelist(whitelist).build();
+
+    assertFalse(config.getHeadersWhitelist().contains("Accept-Encoding"));
+    assertEquals(whitelist, config.getHeadersWhitelist());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCustomWhitelistWithoutAcceptEncodingFailsWhenResponseCompressionEnabled() {
+    Set<String> whitelist = new HashSet<>(AlternatorConfig.builder().getRequiredHeaders());
+    whitelist.remove("Accept-Encoding");
+
+    AlternatorConfig.builder().withOptimizeHeaders(true).withHeadersWhitelist(whitelist).build();
+  }
+
+  @Test
   public void testUserAgentDisabledRemovesUserAgentFromRequiredHeaders() {
     AlternatorConfig config =
         AlternatorConfig.builder().withOptimizeHeaders(true).withUserAgentEnabled(false).build();

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
@@ -135,10 +135,12 @@ public class AlternatorConfigHeadersTest {
 
   @Test
   public void testFullHeadersWhitelistContents() {
-    // Config with compression=true, auth=true should have all headers
+    // Config with request compression, response compression, and auth should have all headers
     AlternatorConfig config =
         AlternatorConfig.builder()
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withResponseCompressionAlgorithms(
+                ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE)
             .authenticationEnabled(true)
             .build();
     Set<String> headers = config.getRequiredHeaders();
@@ -179,10 +181,13 @@ public class AlternatorConfigHeadersTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testCustomWhitelistWithoutAcceptEncodingFailsWhenResponseCompressionEnabled() {
-    Set<String> whitelist = new HashSet<>(AlternatorConfig.builder().getRequiredHeaders());
+    AlternatorConfig.Builder builder =
+        AlternatorConfig.builder()
+            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP);
+    Set<String> whitelist = new HashSet<>(builder.getRequiredHeaders());
     whitelist.remove("Accept-Encoding");
 
-    AlternatorConfig.builder().withOptimizeHeaders(true).withHeadersWhitelist(whitelist).build();
+    builder.withOptimizeHeaders(true).withHeadersWhitelist(whitelist).build();
   }
 
   @Test
@@ -281,10 +286,11 @@ public class AlternatorConfigHeadersTest {
 
   @Test
   public void testHeadersWhitelistNoAuthContents() {
-    // Config with compression=true, auth=false
+    // Config with request compression, response compression, and auth=false
     AlternatorConfig config =
         AlternatorConfig.builder()
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP)
             .authenticationEnabled(false)
             .build();
     Set<String> noAuthHeaders = config.getRequiredHeaders();
@@ -310,8 +316,9 @@ public class AlternatorConfigHeadersTest {
             .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
             .authenticationEnabled(false)
             .build();
-    assertEquals(7, noCompressionNoAuth.getRequiredHeaders().size());
+    assertEquals(6, noCompressionNoAuth.getRequiredHeaders().size());
     assertFalse(noCompressionNoAuth.getRequiredHeaders().contains("Content-Encoding"));
+    assertFalse(noCompressionNoAuth.getRequiredHeaders().contains("Accept-Encoding"));
     assertFalse(noCompressionNoAuth.getRequiredHeaders().contains("Authorization"));
     assertTrue(noCompressionNoAuth.getRequiredHeaders().contains("User-Agent"));
 
@@ -320,8 +327,9 @@ public class AlternatorConfigHeadersTest {
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
             .authenticationEnabled(false)
             .build();
-    assertEquals(8, withCompressionNoAuth.getRequiredHeaders().size());
+    assertEquals(7, withCompressionNoAuth.getRequiredHeaders().size());
     assertTrue(withCompressionNoAuth.getRequiredHeaders().contains("Content-Encoding"));
+    assertFalse(withCompressionNoAuth.getRequiredHeaders().contains("Accept-Encoding"));
     assertFalse(withCompressionNoAuth.getRequiredHeaders().contains("Authorization"));
 
     AlternatorConfig noCompressionWithAuth =
@@ -329,8 +337,9 @@ public class AlternatorConfigHeadersTest {
             .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
             .authenticationEnabled(true)
             .build();
-    assertEquals(9, noCompressionWithAuth.getRequiredHeaders().size());
+    assertEquals(8, noCompressionWithAuth.getRequiredHeaders().size());
     assertFalse(noCompressionWithAuth.getRequiredHeaders().contains("Content-Encoding"));
+    assertFalse(noCompressionWithAuth.getRequiredHeaders().contains("Accept-Encoding"));
     assertTrue(noCompressionWithAuth.getRequiredHeaders().contains("Authorization"));
 
     AlternatorConfig withCompressionWithAuth =
@@ -338,8 +347,9 @@ public class AlternatorConfigHeadersTest {
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
             .authenticationEnabled(true)
             .build();
-    assertEquals(10, withCompressionWithAuth.getRequiredHeaders().size());
+    assertEquals(9, withCompressionWithAuth.getRequiredHeaders().size());
     assertTrue(withCompressionWithAuth.getRequiredHeaders().contains("Content-Encoding"));
+    assertFalse(withCompressionWithAuth.getRequiredHeaders().contains("Accept-Encoding"));
     assertTrue(withCompressionWithAuth.getRequiredHeaders().contains("Authorization"));
   }
 
@@ -349,23 +359,34 @@ public class AlternatorConfigHeadersTest {
     AlternatorConfig.Builder builder = AlternatorConfig.builder();
     Set<String> defaultRequired = builder.getRequiredHeaders();
     // Default is no compression, with auth
-    assertEquals(9, defaultRequired.size());
+    assertEquals(8, defaultRequired.size());
     assertFalse(defaultRequired.contains("Content-Encoding"));
+    assertFalse(defaultRequired.contains("Accept-Encoding"));
     assertTrue(defaultRequired.contains("Authorization"));
     assertTrue(defaultRequired.contains("User-Agent"));
 
-    // Enable compression
+    // Enable request compression
     builder.withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP);
     Set<String> withCompression = builder.getRequiredHeaders();
-    assertEquals(10, withCompression.size());
+    assertEquals(9, withCompression.size());
     assertTrue(withCompression.contains("Content-Encoding"));
+    assertFalse(withCompression.contains("Accept-Encoding"));
 
     // Disable auth
     builder.authenticationEnabled(false);
     Set<String> noAuth = builder.getRequiredHeaders();
-    assertEquals(8, noAuth.size());
+    assertEquals(7, noAuth.size());
     assertTrue(noAuth.contains("Content-Encoding"));
+    assertFalse(noAuth.contains("Accept-Encoding"));
     assertFalse(noAuth.contains("Authorization"));
+
+    // Enable response compression
+    builder.withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP);
+    Set<String> withResponseCompression = builder.getRequiredHeaders();
+    assertEquals(8, withResponseCompression.size());
+    assertTrue(withResponseCompression.contains("Content-Encoding"));
+    assertTrue(withResponseCompression.contains("Accept-Encoding"));
+    assertFalse(withResponseCompression.contains("Authorization"));
   }
 
   @Test
@@ -377,8 +398,9 @@ public class AlternatorConfigHeadersTest {
             .build();
 
     Set<String> required = config.getRequiredHeaders();
-    assertEquals(10, required.size());
+    assertEquals(9, required.size());
     assertTrue(required.contains("Content-Encoding"));
+    assertFalse(required.contains("Accept-Encoding"));
     assertTrue(required.contains("Authorization"));
     assertTrue(required.contains("User-Agent"));
   }

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
@@ -189,6 +189,41 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
     }
   }
 
+  @Test
+  public void testResponseCompressionAlgorithmsPropagateToConfig() {
+    AlternatorDynamoDbAsyncClientWrapper wrapper =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withResponseCompressionAlgorithms(
+                ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP)
+            .buildWithAlternatorAPI();
+    try {
+      AlternatorConfig config = wrapper.getAlternatorConfig();
+      assertEquals(
+          Arrays.asList(ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP),
+          config.getResponseCompressionAlgorithms());
+      assertTrue(config.isResponseCompressionEnabled());
+    } finally {
+      wrapper.close();
+    }
+  }
+
+  @Test
+  public void testResponseCompressionDisabledPropagatesToConfig() {
+    AlternatorDynamoDbAsyncClientWrapper wrapper =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withResponseCompressionDisabled()
+            .buildWithAlternatorAPI();
+    try {
+      AlternatorConfig config = wrapper.getAlternatorConfig();
+      assertTrue(config.getResponseCompressionAlgorithms().isEmpty());
+      assertFalse(config.isResponseCompressionEnabled());
+    } finally {
+      wrapper.close();
+    }
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testWithUserAgentRejectsNullString() {
     AlternatorDynamoDbAsyncClient.builder().endpointOverride(SEED_URI).withUserAgent((String) null);

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
@@ -189,6 +189,41 @@ public class AlternatorDynamoDbClientCustomizerTest {
     }
   }
 
+  @Test
+  public void testResponseCompressionAlgorithmsPropagateToConfig() {
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withResponseCompressionAlgorithms(
+                ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP)
+            .buildWithAlternatorAPI();
+    try {
+      AlternatorConfig config = wrapper.getAlternatorConfig();
+      assertEquals(
+          Arrays.asList(ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP),
+          config.getResponseCompressionAlgorithms());
+      assertTrue(config.isResponseCompressionEnabled());
+    } finally {
+      wrapper.close();
+    }
+  }
+
+  @Test
+  public void testResponseCompressionDisabledPropagatesToConfig() {
+    AlternatorDynamoDbClientWrapper wrapper =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withResponseCompressionDisabled()
+            .buildWithAlternatorAPI();
+    try {
+      AlternatorConfig config = wrapper.getAlternatorConfig();
+      assertTrue(config.getResponseCompressionAlgorithms().isEmpty());
+      assertFalse(config.isResponseCompressionEnabled());
+    } finally {
+      wrapper.close();
+    }
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testWithUserAgentRejectsNullString() {
     AlternatorDynamoDbClient.builder().endpointOverride(SEED_URI).withUserAgent((String) null);

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkAsyncHttpClientTest.java
@@ -203,7 +203,8 @@ public class HeadersFilteringSdkAsyncHttpClientTest {
     assertTrue(mockClient.capturedRequest.headers().containsKey("Content-Length"));
     assertTrue(mockClient.capturedRequest.headers().containsKey("Authorization"));
     assertTrue(mockClient.capturedRequest.headers().containsKey("X-Amz-Date"));
-    assertTrue(mockClient.capturedRequest.headers().containsKey("Accept-Encoding"));
+    // Accept-Encoding is preserved only when response compression is enabled.
+    assertFalse(mockClient.capturedRequest.headers().containsKey("Accept-Encoding"));
 
     // User-Agent should be preserved for driver reporting; other SDK metadata is filtered
     assertTrue(mockClient.capturedRequest.headers().containsKey("User-Agent"));

--- a/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
+++ b/src/test/java/com/scylladb/alternator/HeadersFilteringSdkHttpClientTest.java
@@ -206,7 +206,8 @@ public class HeadersFilteringSdkHttpClientTest {
     assertTrue(mockClient.capturedRequest.headers().containsKey("Content-Length"));
     assertTrue(mockClient.capturedRequest.headers().containsKey("Authorization"));
     assertTrue(mockClient.capturedRequest.headers().containsKey("X-Amz-Date"));
-    assertTrue(mockClient.capturedRequest.headers().containsKey("Accept-Encoding"));
+    // Accept-Encoding is preserved only when response compression is enabled.
+    assertFalse(mockClient.capturedRequest.headers().containsKey("Accept-Encoding"));
 
     // User-Agent should be preserved for driver reporting; other SDK metadata is filtered
     assertTrue(mockClient.capturedRequest.headers().containsKey("User-Agent"));

--- a/src/test/java/com/scylladb/alternator/ResponseCompressionInterceptorTest.java
+++ b/src/test/java/com/scylladb/alternator/ResponseCompressionInterceptorTest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -56,6 +58,19 @@ public class ResponseCompressionInterceptorTest {
     assertEquals(
         ResponseCompressionInterceptor.ACCEPT_ENCODING,
         modified.firstMatchingHeader("Accept-Encoding").get());
+  }
+
+  @Test
+  public void testCustomAcceptEncodingOrder() {
+    ResponseCompressionInterceptor customInterceptor =
+        new ResponseCompressionInterceptor(
+            Arrays.asList(ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP));
+    SdkHttpRequest request = createHttpRequest();
+
+    SdkHttpRequest modified =
+        customInterceptor.modifyHttpRequest(requestContext(request), new ExecutionAttributes());
+
+    assertEquals("deflate, gzip", modified.firstMatchingHeader("Accept-Encoding").get());
   }
 
   @Test
@@ -110,6 +125,26 @@ public class ResponseCompressionInterceptorTest {
     Optional<InputStream> modifiedContent = interceptor.modifyHttpResponseContent(context, attrs);
 
     assertEquals("br", modifiedResponse.firstMatchingHeader("Content-Encoding").get());
+    assertFalse(modifiedContent.isPresent());
+  }
+
+  @Test
+  public void testSupportedButNotConfiguredEncodingIsNotModified() throws Exception {
+    ResponseCompressionInterceptor gzipOnlyInterceptor =
+        new ResponseCompressionInterceptor(
+            Collections.singletonList(ResponseCompressionAlgorithm.GZIP));
+    byte[] compressed = deflate("deflate response".getBytes(StandardCharsets.UTF_8));
+    SdkHttpResponse response =
+        SdkHttpResponse.builder().statusCode(200).putHeader("Content-Encoding", "deflate").build();
+    ExecutionAttributes attrs = new ExecutionAttributes();
+    Context.ModifyHttpResponse context =
+        responseContext(response, new ByteArrayInputStream(compressed), null);
+
+    SdkHttpResponse modifiedResponse = gzipOnlyInterceptor.modifyHttpResponse(context, attrs);
+    Optional<InputStream> modifiedContent =
+        gzipOnlyInterceptor.modifyHttpResponseContent(context, attrs);
+
+    assertEquals("deflate", modifiedResponse.firstMatchingHeader("Content-Encoding").get());
     assertFalse(modifiedContent.isPresent());
   }
 


### PR DESCRIPTION
## Summary
- add `ResponseCompressionAlgorithm` and `withResponseCompressionAlgorithms(...)` APIs for sync/async builders and `AlternatorConfig`
- disable response compression by default; callers opt in by choosing supported algorithms and order for `Accept-Encoding`
- keep `withResponseCompressionDisabled()` for explicit disable/copying paths
- only require `Accept-Encoding` in optimized header whitelists when response compression is enabled
- update unit, mock integration, live integration, and README coverage

Follow-up to #130 / #115.

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q -Dtest=ResponseCompressionInterceptorTest,ResponseCompressionIT,AlternatorConfigCompressionTest,AlternatorConfigHeadersTest,AlternatorDynamoDbClientIT,AlternatorDynamoDbAsyncClientIT,AlternatorDynamoDbClientCustomizerTest,AlternatorDynamoDbAsyncClientCustomizerTest test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q fmt:check checkstyle:check`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH make test-integration`