### PR TITLE
Rename response compression builder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ import com.scylladb.alternator.ResponseCompressionAlgorithm;
 DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .endpointOverride(URI.create("https://127.0.0.1:8043"))
     .credentialsProvider(myCredentials)
-    .withResponseCompressionAlgorithms(
+    .withResponseCompression(
         ResponseCompressionAlgorithm.GZIP,
         ResponseCompressionAlgorithm.DEFLATE)
     .build();
@@ -437,7 +437,7 @@ import com.scylladb.alternator.ResponseCompressionAlgorithm;
 DynamoDbClient client = AlternatorDynamoDbClient.builder()
     .endpointOverride(URI.create("https://127.0.0.1:8043"))
     .credentialsProvider(myCredentials)
-    .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.DEFLATE)
+    .withResponseCompression(ResponseCompressionAlgorithm.DEFLATE)
     .build();
 ```
 

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientIT.java
@@ -485,7 +485,7 @@ public class AlternatorDynamoDbAsyncClientIT {
             .endpointOverride(seedUri)
             .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
             .overrideConfiguration(overrideConfig)
-            .withResponseCompressionAlgorithms(
+            .withResponseCompression(
                 ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE)
             .build();
 
@@ -523,7 +523,7 @@ public class AlternatorDynamoDbAsyncClientIT {
             .endpointOverride(seedUri)
             .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
             .overrideConfiguration(overrideConfig)
-            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.DEFLATE)
+            .withResponseCompression(ResponseCompressionAlgorithm.DEFLATE)
             .build();
 
     try {

--- a/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/AlternatorDynamoDbClientIT.java
@@ -474,7 +474,7 @@ public class AlternatorDynamoDbClientIT {
             .endpointOverride(seedUri)
             .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
             .overrideConfiguration(overrideConfig)
-            .withResponseCompressionAlgorithms(
+            .withResponseCompression(
                 ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE)
             .build();
 
@@ -512,7 +512,7 @@ public class AlternatorDynamoDbClientIT {
             .endpointOverride(seedUri)
             .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
             .overrideConfiguration(overrideConfig)
-            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.DEFLATE)
+            .withResponseCompression(ResponseCompressionAlgorithm.DEFLATE)
             .build();
 
     try {

--- a/src/main/java/com/scylladb/alternator/AlternatorConfig.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorConfig.java
@@ -879,13 +879,13 @@ public class AlternatorConfig {
      * @throws IllegalArgumentException if algorithms is null, empty, or contains null
      * @since 2.0.6
      */
-    public Builder withResponseCompressionAlgorithms(ResponseCompressionAlgorithm... algorithms) {
+    public Builder withResponseCompression(ResponseCompressionAlgorithm... algorithms) {
       if (algorithms == null) {
         throw new IllegalArgumentException(
             "responseCompressionAlgorithms cannot be null or empty. "
                 + "Use withResponseCompressionDisabled() to disable response compression.");
       }
-      return withResponseCompressionAlgorithms(Arrays.asList(algorithms));
+      return withResponseCompression(Arrays.asList(algorithms));
     }
 
     /**
@@ -899,8 +899,7 @@ public class AlternatorConfig {
      * @throws IllegalArgumentException if algorithms is null, empty, or contains null
      * @since 2.0.6
      */
-    public Builder withResponseCompressionAlgorithms(
-        Collection<ResponseCompressionAlgorithm> algorithms) {
+    public Builder withResponseCompression(Collection<ResponseCompressionAlgorithm> algorithms) {
       this.responseCompressionAlgorithms = ResponseCompressionAlgorithm.validatedList(algorithms);
       return this;
     }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -192,9 +192,9 @@ public class AlternatorDynamoDbAsyncClient {
      * @throws IllegalArgumentException if algorithms is null, empty, or contains null
      * @since 2.0.6
      */
-    public AlternatorDynamoDbAsyncClientBuilder withResponseCompressionAlgorithms(
+    public AlternatorDynamoDbAsyncClientBuilder withResponseCompression(
         ResponseCompressionAlgorithm... algorithms) {
-      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      configBuilder.withResponseCompression(algorithms);
       return this;
     }
 
@@ -208,9 +208,9 @@ public class AlternatorDynamoDbAsyncClient {
      * @throws IllegalArgumentException if algorithms is null, empty, or contains null
      * @since 2.0.6
      */
-    public AlternatorDynamoDbAsyncClientBuilder withResponseCompressionAlgorithms(
+    public AlternatorDynamoDbAsyncClientBuilder withResponseCompression(
         Collection<ResponseCompressionAlgorithm> algorithms) {
-      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      configBuilder.withResponseCompression(algorithms);
       return this;
     }
 
@@ -454,8 +454,7 @@ public class AlternatorDynamoDbAsyncClient {
         configBuilder.withCompressionAlgorithm(config.getCompressionAlgorithm());
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
         if (config.isResponseCompressionEnabled()) {
-          configBuilder.withResponseCompressionAlgorithms(
-              config.getResponseCompressionAlgorithms());
+          configBuilder.withResponseCompression(config.getResponseCompressionAlgorithms());
         } else {
           configBuilder.withResponseCompressionDisabled();
         }

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -213,9 +213,9 @@ public class AlternatorDynamoDbClient {
      * @throws IllegalArgumentException if algorithms is null, empty, or contains null
      * @since 2.0.6
      */
-    public AlternatorDynamoDbClientBuilder withResponseCompressionAlgorithms(
+    public AlternatorDynamoDbClientBuilder withResponseCompression(
         ResponseCompressionAlgorithm... algorithms) {
-      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      configBuilder.withResponseCompression(algorithms);
       return this;
     }
 
@@ -229,9 +229,9 @@ public class AlternatorDynamoDbClient {
      * @throws IllegalArgumentException if algorithms is null, empty, or contains null
      * @since 2.0.6
      */
-    public AlternatorDynamoDbClientBuilder withResponseCompressionAlgorithms(
+    public AlternatorDynamoDbClientBuilder withResponseCompression(
         Collection<ResponseCompressionAlgorithm> algorithms) {
-      configBuilder.withResponseCompressionAlgorithms(algorithms);
+      configBuilder.withResponseCompression(algorithms);
       return this;
     }
 
@@ -491,8 +491,7 @@ public class AlternatorDynamoDbClient {
         configBuilder.withCompressionAlgorithm(config.getCompressionAlgorithm());
         configBuilder.withMinCompressionSizeBytes(config.getMinCompressionSizeBytes());
         if (config.isResponseCompressionEnabled()) {
-          configBuilder.withResponseCompressionAlgorithms(
-              config.getResponseCompressionAlgorithms());
+          configBuilder.withResponseCompression(config.getResponseCompressionAlgorithms());
         } else {
           configBuilder.withResponseCompressionDisabled();
         }

--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -235,7 +235,7 @@ public class AlternatorLiveNodes extends Thread {
             .withOptimizeHeaders(config.isOptimizeHeaders())
             .withHeadersWhitelist(config.getHeadersWhitelist());
     if (config.isResponseCompressionEnabled()) {
-      builder.withResponseCompressionAlgorithms(config.getResponseCompressionAlgorithms());
+      builder.withResponseCompression(config.getResponseCompressionAlgorithms());
     } else {
       builder.withResponseCompressionDisabled();
     }

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigCompressionTest.java
@@ -129,7 +129,7 @@ public class AlternatorConfigCompressionTest {
   public void testCustomResponseCompressionAlgorithmsPreserveOrder() {
     AlternatorConfig config =
         AlternatorConfig.builder()
-            .withResponseCompressionAlgorithms(
+            .withResponseCompression(
                 ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP)
             .build();
 
@@ -150,18 +150,16 @@ public class AlternatorConfigCompressionTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testNullResponseCompressionAlgorithmsThrowException() {
-    AlternatorConfig.builder()
-        .withResponseCompressionAlgorithms((ResponseCompressionAlgorithm[]) null);
+    AlternatorConfig.builder().withResponseCompression((ResponseCompressionAlgorithm[]) null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testEmptyResponseCompressionAlgorithmsThrowException() {
-    AlternatorConfig.builder().withResponseCompressionAlgorithms();
+    AlternatorConfig.builder().withResponseCompression();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNullResponseCompressionAlgorithmThrowsException() {
-    AlternatorConfig.builder()
-        .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP, null);
+    AlternatorConfig.builder().withResponseCompression(ResponseCompressionAlgorithm.GZIP, null);
   }
 }

--- a/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorConfigHeadersTest.java
@@ -139,7 +139,7 @@ public class AlternatorConfigHeadersTest {
     AlternatorConfig config =
         AlternatorConfig.builder()
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
-            .withResponseCompressionAlgorithms(
+            .withResponseCompression(
                 ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.DEFLATE)
             .authenticationEnabled(true)
             .build();
@@ -182,8 +182,7 @@ public class AlternatorConfigHeadersTest {
   @Test(expected = IllegalArgumentException.class)
   public void testCustomWhitelistWithoutAcceptEncodingFailsWhenResponseCompressionEnabled() {
     AlternatorConfig.Builder builder =
-        AlternatorConfig.builder()
-            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP);
+        AlternatorConfig.builder().withResponseCompression(ResponseCompressionAlgorithm.GZIP);
     Set<String> whitelist = new HashSet<>(builder.getRequiredHeaders());
     whitelist.remove("Accept-Encoding");
 
@@ -290,7 +289,7 @@ public class AlternatorConfigHeadersTest {
     AlternatorConfig config =
         AlternatorConfig.builder()
             .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
-            .withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP)
+            .withResponseCompression(ResponseCompressionAlgorithm.GZIP)
             .authenticationEnabled(false)
             .build();
     Set<String> noAuthHeaders = config.getRequiredHeaders();
@@ -381,7 +380,7 @@ public class AlternatorConfigHeadersTest {
     assertFalse(noAuth.contains("Authorization"));
 
     // Enable response compression
-    builder.withResponseCompressionAlgorithms(ResponseCompressionAlgorithm.GZIP);
+    builder.withResponseCompression(ResponseCompressionAlgorithm.GZIP);
     Set<String> withResponseCompression = builder.getRequiredHeaders();
     assertEquals(8, withResponseCompression.size());
     assertTrue(withResponseCompression.contains("Content-Encoding"));

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
@@ -194,7 +194,7 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
     AlternatorDynamoDbAsyncClientWrapper wrapper =
         AlternatorDynamoDbAsyncClient.builder()
             .endpointOverride(SEED_URI)
-            .withResponseCompressionAlgorithms(
+            .withResponseCompression(
                 ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP)
             .buildWithAlternatorAPI();
     try {

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
@@ -194,7 +194,7 @@ public class AlternatorDynamoDbClientCustomizerTest {
     AlternatorDynamoDbClientWrapper wrapper =
         AlternatorDynamoDbClient.builder()
             .endpointOverride(SEED_URI)
-            .withResponseCompressionAlgorithms(
+            .withResponseCompression(
                 ResponseCompressionAlgorithm.DEFLATE, ResponseCompressionAlgorithm.GZIP)
             .buildWithAlternatorAPI();
     try {


### PR DESCRIPTION
## Summary
- rename `withResponseCompressionAlgorithms(...)` to `withResponseCompression(...)` on `AlternatorConfig` and sync/async builders
- update internal config-copy call sites, tests, integration examples, and README snippets
- remove references to the old fluent method name

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q test`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q fmt:check checkstyle:check`