### PR TITLE
Add user agent to /localnodes polling requests

### DIFF
--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClient.java
@@ -759,6 +759,7 @@ public class AlternatorDynamoDbAsyncClient {
       SyncClientDetector.SyncClientType syncType = SyncClientDetector.detect();
       SdkHttpClient pollingClient = SyncClientDetector.createPollingClient(syncType, tlsConfig);
 
+      pollingClient = configurePollingSyncClient(pollingClient, alternatorConfig);
       AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(alternatorConfig, pollingClient);
       liveNodes.start();
 
@@ -907,6 +908,14 @@ public class AlternatorDynamoDbAsyncClient {
 
     private boolean needsHttpClientWrapper(AlternatorConfig alternatorConfig) {
       return userAgentTransformer != null || alternatorConfig.isOptimizeHeaders();
+    }
+
+    private SdkHttpClient configurePollingSyncClient(
+        SdkHttpClient pollingClient, AlternatorConfig alternatorConfig) {
+      if (alternatorConfig.isUserAgentEnabled()) {
+        return new UserAgentSdkHttpClient(pollingClient, userAgentTransformer);
+      }
+      return pollingClient;
     }
 
     private void applyEndpointToConfig() {

--- a/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
+++ b/src/main/java/com/scylladb/alternator/AlternatorDynamoDbClient.java
@@ -781,6 +781,7 @@ public class AlternatorDynamoDbClient {
         pollingClient = SyncClientDetector.createPollingClient(pollingType, tlsConfig);
       }
 
+      pollingClient = configurePollingSyncClient(pollingClient, alternatorConfig);
       AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(alternatorConfig, pollingClient);
       liveNodes.start();
 
@@ -906,6 +907,14 @@ public class AlternatorDynamoDbClient {
                 configuredClient, alternatorConfig.getHeadersWhitelist());
       }
       return configuredClient;
+    }
+
+    private SdkHttpClient configurePollingSyncClient(
+        SdkHttpClient pollingClient, AlternatorConfig alternatorConfig) {
+      if (alternatorConfig.isUserAgentEnabled()) {
+        return new UserAgentSdkHttpClient(pollingClient, userAgentTransformer);
+      }
+      return pollingClient;
     }
 
     private void configureCustomSyncClient(AlternatorConfig alternatorConfig) {

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbAsyncClientCustomizerTest.java
@@ -4,10 +4,17 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.AsyncClientDetector;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.function.UnaryOperator;
 import org.junit.Test;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 
@@ -428,6 +435,37 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
         userAgentTransformer(builder).apply("aws-sdk-java/2.x"));
   }
 
+  @Test
+  public void testPollingClientAddsDefaultUserAgent() throws Exception {
+    var builder = AlternatorDynamoDbAsyncClient.builder().endpointOverride(SEED_URI);
+    CapturingSdkHttpClient delegate = new CapturingSdkHttpClient();
+    SdkHttpClient configured =
+        configurePollingSyncClient(builder, delegate, AlternatorConfig.builder().build());
+
+    configured.prepareRequest(HttpExecuteRequest.builder().request(localNodesRequest()).build());
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        delegate.capturedRequest.firstMatchingHeader("User-Agent").get());
+  }
+
+  @Test
+  public void testPollingClientAppliesCustomUserAgent() throws Exception {
+    var builder =
+        AlternatorDynamoDbAsyncClient.builder()
+            .endpointOverride(SEED_URI)
+            .withUserAgent(userAgent -> userAgent + " app/1");
+    CapturingSdkHttpClient delegate = new CapturingSdkHttpClient();
+    SdkHttpClient configured =
+        configurePollingSyncClient(builder, delegate, AlternatorConfig.builder().build());
+
+    configured.prepareRequest(HttpExecuteRequest.builder().request(localNodesRequest()).build());
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken() + " app/1",
+        delegate.capturedRequest.firstMatchingHeader("User-Agent").get());
+  }
+
   @Test(expected = IllegalStateException.class)
   public void testHttpClientTypeConflictsWithHttpClientBuilder() {
     AlternatorDynamoDbAsyncClient.builder()
@@ -453,5 +491,54 @@ public class AlternatorDynamoDbAsyncClientCustomizerTest {
     Field field = builder.getClass().getDeclaredField("userAgentTransformer");
     field.setAccessible(true);
     return (UnaryOperator<String>) field.get(builder);
+  }
+
+  private SdkHttpClient configurePollingSyncClient(
+      AlternatorDynamoDbAsyncClient.AlternatorDynamoDbAsyncClientBuilder builder,
+      SdkHttpClient pollingClient,
+      AlternatorConfig config)
+      throws Exception {
+    Method method =
+        builder
+            .getClass()
+            .getDeclaredMethod(
+                "configurePollingSyncClient", SdkHttpClient.class, AlternatorConfig.class);
+    method.setAccessible(true);
+    return (SdkHttpClient) method.invoke(builder, pollingClient, config);
+  }
+
+  private SdkHttpRequest localNodesRequest() {
+    return SdkHttpRequest.builder()
+        .method(SdkHttpMethod.GET)
+        .uri(SEED_URI.resolve("/localnodes"))
+        .putHeader("Host", SEED_URI.getHost() + ":" + SEED_URI.getPort())
+        .putHeader("Connection", "keep-alive")
+        .build();
+  }
+
+  private static class CapturingSdkHttpClient implements SdkHttpClient {
+    SdkHttpRequest capturedRequest;
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      capturedRequest = request.httpRequest();
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() {
+          return null;
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "capturing";
+    }
   }
 }

--- a/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
+++ b/src/test/java/com/scylladb/alternator/AlternatorDynamoDbClientCustomizerTest.java
@@ -4,11 +4,17 @@ import static org.junit.Assert.*;
 
 import com.scylladb.alternator.internal.SyncClientDetector;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.function.UnaryOperator;
 import org.junit.Test;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 /**
@@ -428,6 +434,37 @@ public class AlternatorDynamoDbClientCustomizerTest {
         userAgentTransformer(builder).apply("aws-sdk-java/2.x"));
   }
 
+  @Test
+  public void testPollingClientAddsDefaultUserAgent() throws Exception {
+    var builder = AlternatorDynamoDbClient.builder().endpointOverride(SEED_URI);
+    CapturingSdkHttpClient delegate = new CapturingSdkHttpClient();
+    SdkHttpClient configured =
+        configurePollingSyncClient(builder, delegate, AlternatorConfig.builder().build());
+
+    configured.prepareRequest(HttpExecuteRequest.builder().request(localNodesRequest()).build());
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken(),
+        delegate.capturedRequest.firstMatchingHeader("User-Agent").get());
+  }
+
+  @Test
+  public void testPollingClientAppliesCustomUserAgent() throws Exception {
+    var builder =
+        AlternatorDynamoDbClient.builder()
+            .endpointOverride(SEED_URI)
+            .withUserAgent(userAgent -> userAgent + " app/1");
+    CapturingSdkHttpClient delegate = new CapturingSdkHttpClient();
+    SdkHttpClient configured =
+        configurePollingSyncClient(builder, delegate, AlternatorConfig.builder().build());
+
+    configured.prepareRequest(HttpExecuteRequest.builder().request(localNodesRequest()).build());
+
+    assertEquals(
+        AlternatorUserAgent.userAgentToken() + " app/1",
+        delegate.capturedRequest.firstMatchingHeader("User-Agent").get());
+  }
+
   @Test(expected = IllegalStateException.class)
   public void testHttpClientTypeConflictsWithHttpClientBuilder() {
     AlternatorDynamoDbClient.builder()
@@ -453,5 +490,54 @@ public class AlternatorDynamoDbClientCustomizerTest {
     Field field = builder.getClass().getDeclaredField("userAgentTransformer");
     field.setAccessible(true);
     return (UnaryOperator<String>) field.get(builder);
+  }
+
+  private SdkHttpClient configurePollingSyncClient(
+      AlternatorDynamoDbClient.AlternatorDynamoDbClientBuilder builder,
+      SdkHttpClient pollingClient,
+      AlternatorConfig config)
+      throws Exception {
+    Method method =
+        builder
+            .getClass()
+            .getDeclaredMethod(
+                "configurePollingSyncClient", SdkHttpClient.class, AlternatorConfig.class);
+    method.setAccessible(true);
+    return (SdkHttpClient) method.invoke(builder, pollingClient, config);
+  }
+
+  private SdkHttpRequest localNodesRequest() {
+    return SdkHttpRequest.builder()
+        .method(SdkHttpMethod.GET)
+        .uri(SEED_URI.resolve("/localnodes"))
+        .putHeader("Host", SEED_URI.getHost() + ":" + SEED_URI.getPort())
+        .putHeader("Connection", "keep-alive")
+        .build();
+  }
+
+  private static class CapturingSdkHttpClient implements SdkHttpClient {
+    SdkHttpRequest capturedRequest;
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      capturedRequest = request.httpRequest();
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() {
+          return null;
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "capturing";
+    }
   }
 }


### PR DESCRIPTION
Summary:
- wrap the live-node polling sync HTTP client with the existing user-agent wrapper when user-agent reporting is enabled
- cover sync and async builder polling clients, including custom user-agent transforms

Tests:
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q -Dtest=AlternatorDynamoDbClientCustomizerTest,AlternatorDynamoDbAsyncClientCustomizerTest test`