### PR TITLE
Keep live-node updater running after external interrupts

### DIFF
--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -78,9 +78,12 @@ public class AlternatorLiveNodes extends Thread {
         try {
           Thread.sleep(getRefreshInterval());
         } catch (InterruptedException e) {
-          logger.log(Level.INFO, "AlternatorLiveNodes thread interrupted and stopping");
-          Thread.currentThread().interrupt(); // Restore interrupted status
-          return;
+          if (shutdownRequested.get()) {
+            logger.log(Level.INFO, "AlternatorLiveNodes thread interrupted and stopping");
+            Thread.currentThread().interrupt(); // Restore interrupted status
+            return;
+          }
+          logger.log(Level.FINE, "AlternatorLiveNodes thread interrupted without shutdown request");
         }
       }
     } finally {

--- a/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesInterruptTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesInterruptTest.java
@@ -1,0 +1,80 @@
+package com.scylladb.alternator.internal;
+
+import static org.junit.Assert.assertTrue;
+
+import com.scylladb.alternator.AlternatorConfig;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+
+public class AlternatorLiveNodesInterruptTest {
+
+  @Test
+  public void testExternalInterruptDoesNotStopThread() throws Exception {
+    CountingSuccessHttpClient client = new CountingSuccessHttpClient();
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedNode(URI.create("http://127.0.0.1:8000"))
+            .withIdleRefreshIntervalMs(60_000)
+            .build();
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, client);
+
+    liveNodes.start();
+    assertTrue("initial polling request should run", client.firstCall.await(5, TimeUnit.SECONDS));
+
+    liveNodes.interrupt();
+
+    assertTrue(
+        "polling should continue after external interrupt",
+        client.secondCall.await(5, TimeUnit.SECONDS));
+    assertTrue("live-node thread should still be running", liveNodes.isRunning());
+    assertTrue("live-node thread should stop", liveNodes.shutdownAndWait(5_000));
+  }
+
+  private static final class CountingSuccessHttpClient implements SdkHttpClient {
+    private final AtomicInteger calls = new AtomicInteger();
+    private final CountDownLatch firstCall = new CountDownLatch(1);
+    private final CountDownLatch secondCall = new CountDownLatch(1);
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+      int callNumber = calls.incrementAndGet();
+      return new ExecutableHttpRequest() {
+        @Override
+        public HttpExecuteResponse call() {
+          if (callNumber == 1) {
+            firstCall.countDown();
+          } else {
+            secondCall.countDown();
+          }
+          byte[] body = "[\"127.0.0.1\"]".getBytes(StandardCharsets.UTF_8);
+          return HttpExecuteResponse.builder()
+              .response(SdkHttpFullResponse.builder().statusCode(200).build())
+              .responseBody(AbortableInputStream.create(new ByteArrayInputStream(body)))
+              .build();
+        }
+
+        @Override
+        public void abort() {}
+      };
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public String clientName() {
+      return "counting-success";
+    }
+  }
+}


### PR DESCRIPTION
Summary:
- treat `interrupt()` as a stop signal only when shutdown was requested
- add a regression test that verifies polling continues after an external interrupt and still stops on shutdown

Tests:
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH mvn -q -Dtest=AlternatorLiveNodesInterruptTest test`