### PR TITLE
Fix /localnodes discovery handling

### DIFF
--- a/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
+++ b/src/main/java/com/scylladb/alternator/internal/AlternatorLiveNodes.java
@@ -531,7 +531,7 @@ public class AlternatorLiveNodes extends Thread {
       try {
         List<URI> nodes = getNodesForScope(scope);
         if (!nodes.isEmpty()) {
-          liveNodes.set(mergeWithInitialNodes(nodes));
+          liveNodes.set(nodes);
           logger.log(
               Level.FINE, "Updated hosts to " + liveNodes + " using " + scope.getDescription());
           return;
@@ -551,12 +551,12 @@ public class AlternatorLiveNodes extends Thread {
       }
       scope = fallback;
     }
-    // No nodes found in any scope - keep the current list but ensure seeds are present
+    // No nodes found in any scope - keep the current list. Initial seed nodes are retained
+    // separately and remain discovery candidates without being injected into the routing list.
     if (lastException != null) {
-      liveNodes.set(mergeWithInitialNodes(liveNodes.get()));
       logger.log(
           Level.WARNING,
-          "All nodes unreachable in every routing scope, re-injected seed nodes into live list");
+          "All nodes unreachable in every routing scope, keeping existing node list");
     } else {
       logger.log(Level.WARNING, "No nodes found in any routing scope, keeping existing node list");
     }
@@ -565,50 +565,95 @@ public class AlternatorLiveNodes extends Thread {
   private List<URI> getNodesForScope(RoutingScope scope) throws IOException {
     String query = scope.getLocalNodesQuery();
     String requestQuery = query.isEmpty() ? null : query;
+
+    DiscoveryAttempt liveAttempt =
+        discoverNodes(scope, liveDiscoveryCandidates(), requestQuery, "live node");
+    if (!liveAttempt.nodes.isEmpty()) {
+      return liveAttempt.nodes;
+    }
+
+    DiscoveryAttempt seedAttempt =
+        discoverNodes(
+            scope, initialDiscoveryCandidates(liveAttempt.candidates), requestQuery, "seed node");
+    if (!seedAttempt.nodes.isEmpty()) {
+      return seedAttempt.nodes;
+    }
+
+    if (seedAttempt.lastException != null) {
+      throw seedAttempt.lastException;
+    }
+    if (liveAttempt.lastException != null) {
+      throw liveAttempt.lastException;
+    }
+    return Collections.emptyList();
+  }
+
+  private DiscoveryAttempt discoverNodes(
+      RoutingScope scope, List<URI> candidates, String requestQuery, String candidateDescription) {
     IOException lastException = null;
     Set<URI> nodes = new LinkedHashSet<>();
-    for (URI seedNode : initialNodes) {
+    for (URI candidate : candidates) {
       try {
-        List<URI> seedNodes = getNodes(withPathAndQuery(seedNode, "/localnodes", requestQuery));
-        if (!seedNodes.isEmpty()) {
+        List<URI> discoveredNodes =
+            getNodes(withPathAndRawQuery(candidate, "/localnodes", requestQuery));
+        if (!discoveredNodes.isEmpty()) {
           if (!(scope instanceof ClusterScope)) {
-            return seedNodes;
+            return new DiscoveryAttempt(candidates, discoveredNodes, lastException);
           }
-          nodes.addAll(seedNodes);
+          nodes.addAll(discoveredNodes);
         }
       } catch (IOException e) {
         logger.log(
             Level.WARNING,
-            "Failed to contact seed node " + seedNode + " for " + scope.getDescription(),
+            "Failed to contact "
+                + candidateDescription
+                + " "
+                + candidate
+                + " for "
+                + scope.getDescription(),
             e);
         lastException = e;
       } catch (URISyntaxException e) {
         throw new RuntimeException(e);
       }
     }
-    if (!nodes.isEmpty()) {
-      return new ArrayList<>(nodes);
-    }
-    if (lastException != null) {
-      throw lastException;
-    }
-    return Collections.emptyList();
+
+    return new DiscoveryAttempt(candidates, new ArrayList<>(nodes), lastException);
   }
 
-  /**
-   * Merges the given node list with the initial seed nodes, ensuring seed nodes are always present
-   * as fallback candidates for re-discovery. Seed nodes are appended at the end to preserve the
-   * ordering priority of discovered nodes.
-   *
-   * @param nodes the current list of discovered nodes
-   * @return a new list containing all discovered nodes plus any missing seed nodes
-   */
-  private List<URI> mergeWithInitialNodes(List<URI> nodes) {
-    Set<URI> seen = new LinkedHashSet<>(nodes);
-    for (URI seed : initialNodes) {
-      seen.add(seed);
+  private List<URI> liveDiscoveryCandidates() {
+    return new ArrayList<>(new LinkedHashSet<>(liveNodes.get()));
+  }
+
+  private List<URI> initialDiscoveryCandidates(List<URI> alreadyTried) {
+    Set<URI> candidates = new LinkedHashSet<>(initialNodes);
+    candidates.removeAll(alreadyTried);
+    return new ArrayList<>(candidates);
+  }
+
+  private static class DiscoveryAttempt {
+    final List<URI> candidates;
+    final List<URI> nodes;
+    final IOException lastException;
+
+    DiscoveryAttempt(List<URI> candidates, List<URI> nodes, IOException lastException) {
+      this.candidates = candidates;
+      this.nodes = nodes;
+      this.lastException = lastException;
     }
-    return new ArrayList<>(seen);
+  }
+
+  private URI withPathAndRawQuery(URI uri, String path, String rawQuery) throws URISyntaxException {
+    URI withoutQuery =
+        new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), path, null, null);
+    if (rawQuery == null || rawQuery.isEmpty()) {
+      return withoutQuery;
+    }
+    try {
+      return new URI(withoutQuery.toASCIIString() + "?" + rawQuery);
+    } catch (URISyntaxException e) {
+      return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), path, rawQuery, null);
+    }
   }
 
   private List<URI> getNodes(URI uri) throws IOException {

--- a/src/main/java/com/scylladb/alternator/routing/DatacenterScope.java
+++ b/src/main/java/com/scylladb/alternator/routing/DatacenterScope.java
@@ -78,7 +78,7 @@ public final class DatacenterScope implements RoutingScope {
   /** {@inheritDoc} */
   @Override
   public String getLocalNodesQuery() {
-    return "dc=" + datacenter;
+    return "dc=" + RoutingScopeQuery.encodeValue(datacenter);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/scylladb/alternator/routing/RackScope.java
+++ b/src/main/java/com/scylladb/alternator/routing/RackScope.java
@@ -101,7 +101,10 @@ public final class RackScope implements RoutingScope {
   /** {@inheritDoc} */
   @Override
   public String getLocalNodesQuery() {
-    return "dc=" + datacenter + "&rack=" + rack;
+    return "dc="
+        + RoutingScopeQuery.encodeValue(datacenter)
+        + "&rack="
+        + RoutingScopeQuery.encodeValue(rack);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/scylladb/alternator/routing/RoutingScopeQuery.java
+++ b/src/main/java/com/scylladb/alternator/routing/RoutingScopeQuery.java
@@ -1,0 +1,13 @@
+package com.scylladb.alternator.routing;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+final class RoutingScopeQuery {
+
+  private RoutingScopeQuery() {}
+
+  static String encodeValue(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+}

--- a/src/test/java/com/scylladb/alternator/RoutingScopeTest.java
+++ b/src/test/java/com/scylladb/alternator/RoutingScopeTest.java
@@ -119,6 +119,12 @@ public class RoutingScopeTest {
   }
 
   @Test
+  public void testDatacenterScopeEncodesLocalNodesQueryValue() {
+    DatacenterScope scope = DatacenterScope.of("dc&prod=blue zone", null);
+    assertEquals("dc=dc%26prod%3Dblue%20zone", scope.getLocalNodesQuery());
+  }
+
+  @Test
   public void testDatacenterScopeToString() {
     DatacenterScope scope = DatacenterScope.of("dc1", ClusterScope.create());
     assertTrue(scope.toString().contains("dc1"));
@@ -197,6 +203,12 @@ public class RoutingScopeTest {
   public void testRackScopeGetLocalNodesQuery() {
     RackScope scope = RackScope.of("dc1", "rack1", null);
     assertEquals("dc=dc1&rack=rack1", scope.getLocalNodesQuery());
+  }
+
+  @Test
+  public void testRackScopeEncodesLocalNodesQueryValues() {
+    RackScope scope = RackScope.of("dc&prod", "rack=1/blue zone", null);
+    assertEquals("dc=dc%26prod&rack=rack%3D1%2Fblue%20zone", scope.getLocalNodesQuery());
   }
 
   @Test

--- a/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesClusterDiscoveryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesClusterDiscoveryTest.java
@@ -6,6 +6,7 @@ import com.scylladb.alternator.AlternatorConfig;
 import com.scylladb.alternator.routing.ClusterScope;
 import com.scylladb.alternator.routing.DatacenterScope;
 import com.scylladb.alternator.routing.RackScope;
+import com.scylladb.alternator.routing.RoutingScope;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -137,11 +138,82 @@ public class AlternatorLiveNodesClusterDiscoveryTest {
     liveNodes.updateLiveNodes();
 
     assertEquals(
-        new LinkedHashSet<>(Arrays.asList("dc1-node1.example.com", "dc2-node1.example.com")),
+        new LinkedHashSet<>(Arrays.asList("dc1-node1.example.com")),
         hostSet(liveNodes.getLiveNodes()));
     assertEquals(
         new HashSet<>(Arrays.asList("dc1-node1.example.com", "dc2-node1.example.com")),
         capturedHostSet(httpClient.capturedRequests));
+  }
+
+  @Test
+  public void testDiscoveryUsesKnownLiveNodesBeforeInitialSeed() throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    Set<String> failingHosts = new HashSet<>();
+    responses.put("seed.example.com", "[\"node2.example.com\",\"node3.example.com\"]");
+    responses.put("node2.example.com", "[\"node2.example.com\",\"node3.example.com\"]");
+    responses.put("node3.example.com", "[\"node2.example.com\",\"node3.example.com\"]");
+    DiscoveryHttpClient httpClient = new DiscoveryHttpClient(responses, failingHosts);
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHost("seed.example.com")
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(ClusterScope.create())
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+    liveNodes.updateLiveNodes();
+    assertEquals(
+        new LinkedHashSet<>(Arrays.asList("node2.example.com", "node3.example.com")),
+        hostSet(liveNodes.getLiveNodes()));
+
+    failingHosts.add("seed.example.com");
+    httpClient.capturedRequests.clear();
+    liveNodes.updateLiveNodes();
+
+    assertEquals(
+        new LinkedHashSet<>(Arrays.asList("node2.example.com", "node3.example.com")),
+        hostSet(liveNodes.getLiveNodes()));
+    assertEquals(
+        new HashSet<>(Arrays.asList("node2.example.com", "node3.example.com")),
+        capturedHostSet(httpClient.capturedRequests));
+  }
+
+  @Test
+  public void testDiscoveryFallsBackToInitialSeedWhenLiveNodesReturnNoNodes() throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    Set<String> failingHosts = new HashSet<>();
+    responses.put("seed.example.com", "[\"node2.example.com\",\"node3.example.com\"]");
+    responses.put("node2.example.com", "[]");
+    responses.put("node3.example.com", "[]");
+    DiscoveryHttpClient httpClient = new DiscoveryHttpClient(responses, failingHosts);
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHost("seed.example.com")
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(ClusterScope.create())
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+    liveNodes.updateLiveNodes();
+    assertEquals(
+        new LinkedHashSet<>(Arrays.asList("node2.example.com", "node3.example.com")),
+        hostSet(liveNodes.getLiveNodes()));
+
+    failingHosts.add("node2.example.com");
+    responses.put("seed.example.com", "[\"recovered.example.com\"]");
+    httpClient.capturedRequests.clear();
+    liveNodes.updateLiveNodes();
+
+    assertEquals(
+        new LinkedHashSet<>(Arrays.asList("recovered.example.com")),
+        hostSet(liveNodes.getLiveNodes()));
+    assertEquals(
+        Arrays.asList("node2.example.com", "node3.example.com", "seed.example.com"),
+        capturedHosts(httpClient.capturedRequests));
   }
 
   @Test
@@ -165,9 +237,7 @@ public class AlternatorLiveNodesClusterDiscoveryTest {
     liveNodes.updateLiveNodes();
 
     assertEquals(
-        new LinkedHashSet<>(
-            Arrays.asList(
-                "dc1-rack1-node.example.com", "dc2-node1.example.com", "dc1-node1.example.com")),
+        new LinkedHashSet<>(Arrays.asList("dc1-rack1-node.example.com")),
         hostSet(liveNodes.getLiveNodes()));
     assertEquals(
         Arrays.asList("dc2-node1.example.com", "dc1-node1.example.com"),
@@ -176,6 +246,51 @@ public class AlternatorLiveNodesClusterDiscoveryTest {
       assertTrue(request.rawQueryParameters().containsKey("dc"));
       assertTrue(request.rawQueryParameters().containsKey("rack"));
     }
+  }
+
+  @Test
+  public void testScopedLocalNodesQueryValuesAreEncodedOnce() throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    responses.put("seed.example.com", "[\"scoped-node.example.com\"]");
+    DiscoveryHttpClient httpClient = new DiscoveryHttpClient(responses);
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHost("seed.example.com")
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(RackScope.of("dc&prod", "rack=1/blue", null))
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+    liveNodes.updateLiveNodes();
+
+    SdkHttpRequest request = httpClient.capturedRequests.get(0);
+    String encodedQuery = request.encodedQueryParameters().get();
+    assertTrue(encodedQuery.contains("dc=dc%26prod"));
+    assertTrue(encodedQuery.contains("rack=rack%3D1%2Fblue"));
+    assertFalse(encodedQuery.contains("%25"));
+  }
+
+  @Test
+  public void testCustomScopeLocalNodesQueryValuesAreEncodedWhenNeeded() throws Exception {
+    Map<String, String> responses = new HashMap<>();
+    responses.put("seed.example.com", "[\"scoped-node.example.com\"]");
+    DiscoveryHttpClient httpClient = new DiscoveryHttpClient(responses);
+
+    AlternatorConfig config =
+        AlternatorConfig.builder()
+            .withSeedHost("seed.example.com")
+            .withScheme("http")
+            .withPort(8000)
+            .withRoutingScope(customScope("dc=us east"))
+            .build();
+
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+    liveNodes.updateLiveNodes();
+
+    SdkHttpRequest request = httpClient.capturedRequests.get(0);
+    assertEquals("dc=us%20east", request.encodedQueryParameters().get());
   }
 
   @Test
@@ -230,5 +345,29 @@ public class AlternatorLiveNodesClusterDiscoveryTest {
       hosts.add(request.host());
     }
     return hosts;
+  }
+
+  private static RoutingScope customScope(String query) {
+    return new RoutingScope() {
+      @Override
+      public String getName() {
+        return "Custom";
+      }
+
+      @Override
+      public String getDescription() {
+        return "Custom";
+      }
+
+      @Override
+      public RoutingScope getFallback() {
+        return null;
+      }
+
+      @Override
+      public String getLocalNodesQuery() {
+        return query;
+      }
+    };
   }
 }

--- a/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesScopeFallbackTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesScopeFallbackTest.java
@@ -152,9 +152,9 @@ public class AlternatorLiveNodesScopeFallbackTest {
    * Verifies that when all discovered nodes become unreachable, the client should fall back to the
    * original seed nodes for re-discovery.
    *
-   * <p>After a successful discovery replaces liveNodes with new nodes, if all those new nodes
-   * become unreachable, the client should re-inject the seed URLs into its candidate list so it can
-   * recover through the original entry points.
+   * <p>After a successful discovery replaces liveNodes with new nodes, if those live nodes cannot
+   * return a usable /localnodes response, the client should fall back to the original seed URLs so
+   * it can recover through the configured entry points.
    *
    * @throws Exception if an unexpected error occurs
    */
@@ -173,7 +173,7 @@ public class AlternatorLiveNodesScopeFallbackTest {
     assertEquals(1, initialList.size());
     assertEquals("10.0.0.1", initialList.get(0).getHost());
 
-    // After a successful update, liveNodes should contain discovered nodes AND the seed
+    // After a successful update, liveNodes should contain discovered nodes without injecting seeds
     liveNodes.updateLiveNodes();
     List<URI> updatedList = liveNodes.getLiveNodes();
     List<String> hosts = new ArrayList<>();
@@ -183,12 +183,8 @@ public class AlternatorLiveNodesScopeFallbackTest {
     assertTrue("Should contain discovered node 10.0.0.2", hosts.contains("10.0.0.2"));
     assertTrue("Should contain discovered node 10.0.0.3", hosts.contains("10.0.0.3"));
 
-    // The seed node should still be present in liveNodes as a fallback,
-    // so that if 10.0.0.2 and 10.0.0.3 both die, the client can re-discover via 10.0.0.1.
-    assertTrue(
-        "Seed node 10.0.0.1 should be retained as a fallback after discovery, "
-            + "but liveNodes only contains: "
-            + hosts,
+    assertFalse(
+        "Seed node 10.0.0.1 should remain a discovery candidate, not a routing target",
         hosts.contains("10.0.0.1"));
   }
 
@@ -264,14 +260,16 @@ public class AlternatorLiveNodesScopeFallbackTest {
         3,
         requestCount.get());
 
-    // liveNodes should now contain the cluster-scope node and the seed node
+    // liveNodes should now contain only the cluster-scope node
     List<URI> nodes = liveNodes.getLiveNodes();
     List<String> nodeHosts = new ArrayList<>();
     for (URI uri : nodes) {
       nodeHosts.add(uri.getHost());
     }
     assertTrue("Should contain cluster-scope node 10.0.0.5", nodeHosts.contains("10.0.0.5"));
-    assertTrue("Should contain seed node 10.0.0.1 as fallback", nodeHosts.contains("10.0.0.1"));
+    assertFalse(
+        "Seed node 10.0.0.1 should not be added to the routing list",
+        nodeHosts.contains("10.0.0.1"));
   }
 
   /**


### PR DESCRIPTION
## Summary
- keep seed nodes as discovery candidates without injecting them into the live routing list
- fall back to already discovered live nodes when initial seeds fail during /localnodes refresh
- URL-encode dc and rack query parameters once for scoped /localnodes requests

## ScyllaDB behavior checked
- GET /localnodes returns 200 with a JSON array
- missing/nonexistent dc or rack is represented as 200 [] rather than a non-2xx response

## Testing
- JAVA_HOME=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem PATH=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem/bin:$PATH mvn -q com.spotify.fmt:fmt-maven-plugin:format
- JAVA_HOME=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem PATH=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem/bin:$PATH mvn -q -DskipTests compile checkstyle:check
- JAVA_HOME=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem PATH=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem/bin:$PATH mvn -q test
- JAVA_HOME=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem PATH=/home/dmitry.kropachev/.sdkman/candidates/java/11.0.29-tem/bin:$PATH make lint