### PR TITLE
test: cover DNS entrypoint discovery

### DIFF
--- a/src/integration-test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryIT.java
@@ -1,0 +1,99 @@
+package com.scylladb.alternator.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import com.scylladb.alternator.AlternatorConfig;
+import com.scylladb.alternator.IntegrationTestConfig;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Integration tests for DNS-backed live-node discovery against a real Alternator cluster. */
+public class AlternatorLiveNodesDnsDiscoveryIT {
+
+  @Before
+  public void setUp() {
+    assumeTrue(
+        "Integration tests disabled. Set INTEGRATION_TESTS=true to enable.",
+        IntegrationTestConfig.ENABLED);
+  }
+
+  @Test
+  public void testDnsEntrypointDiscoversLiveClusterNodes() throws Exception {
+    try (DnsEntrypointProxy proxy = new DnsEntrypointProxy()) {
+      URI seedUri = new URI("http://localhost:" + proxy.getPort());
+      AlternatorConfig config = AlternatorConfig.builder().withSeedNode(seedUri).build();
+      AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config);
+
+      try {
+        liveNodes.updateLiveNodes();
+
+        assertTrue("DNS entrypoint should be contacted", proxy.getRequestCount() > 0);
+        assertFalse("Should discover live cluster nodes", liveNodes.getLiveNodes().isEmpty());
+      } finally {
+        liveNodes.shutdownAndWait();
+      }
+    }
+  }
+
+  private static class DnsEntrypointProxy implements AutoCloseable {
+    private final HttpServer server;
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+
+    DnsEntrypointProxy() throws IOException {
+      server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+      server.createContext("/localnodes", this::handleLocalNodes);
+      server.start();
+    }
+
+    int getPort() {
+      return server.getAddress().getPort();
+    }
+
+    int getRequestCount() {
+      return requestCount.get();
+    }
+
+    @Override
+    public void close() {
+      server.stop(0);
+    }
+
+    private void handleLocalNodes(com.sun.net.httpserver.HttpExchange exchange) throws IOException {
+      requestCount.incrementAndGet();
+      URI upstream =
+          URI.create(
+              "http://"
+                  + IntegrationTestConfig.HOST
+                  + ":"
+                  + IntegrationTestConfig.HTTP_PORT
+                  + "/localnodes");
+      HttpURLConnection connection = (HttpURLConnection) upstream.toURL().openConnection();
+      connection.setConnectTimeout(5000);
+      connection.setReadTimeout(5000);
+
+      int status = connection.getResponseCode();
+      byte[] body;
+      try (InputStream input = connection.getInputStream()) {
+        body = input.readAllBytes();
+      } finally {
+        connection.disconnect();
+      }
+
+      exchange.getResponseHeaders().add("Content-Type", "application/json");
+      exchange.sendResponseHeaders(status, body.length);
+      try (OutputStream output = exchange.getResponseBody()) {
+        output.write(body);
+      }
+    }
+  }
+}

--- a/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryTest.java
@@ -1,0 +1,64 @@
+package com.scylladb.alternator.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import com.scylladb.alternator.AlternatorConfig;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Unit tests for DNS-backed live-node discovery. */
+public class AlternatorLiveNodesDnsDiscoveryTest {
+
+  private HttpServer server;
+  private int port;
+  private final AtomicInteger requestCount = new AtomicInteger(0);
+
+  @Before
+  public void setUp() throws IOException {
+    requestCount.set(0);
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    port = server.getAddress().getPort();
+
+    server.createContext(
+        "/localnodes",
+        exchange -> {
+          requestCount.incrementAndGet();
+          byte[] body = "[\"localhost\",\"node-a.internal\"]".getBytes();
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream os = exchange.getResponseBody()) {
+            os.write(body);
+          }
+        });
+
+    server.start();
+  }
+
+  @After
+  public void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  /** Verifies discovery works when the configured entrypoint is a DNS name. */
+  @Test(timeout = 10000)
+  public void testDnsEntrypointDiscoversDnsNodeRecords() throws Exception {
+    URI seedUri = new URI("http://localhost:" + port);
+    AlternatorConfig config = AlternatorConfig.builder().withSeedNode(seedUri).build();
+    AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config);
+
+    liveNodes.updateLiveNodes();
+
+    assertEquals("DNS seed should be contacted", 1, requestCount.get());
+    assertEquals(2, liveNodes.getLiveNodes().size());
+    assertEquals("localhost", liveNodes.getLiveNodes().get(0).getHost());
+    assertEquals("node-a.internal", liveNodes.getLiveNodes().get(1).getHost());
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #107.
- Add unit coverage for a DNS hostname seed entrypoint and DNS hostname records returned from `/localnodes`.
- Add live-cluster integration coverage that discovers through a resolver-backed `localhost` entrypoint and real `/localnodes` data.

## Tests
- `git diff --check`
- Not run: `mvn -q -Dtest=com.scylladb.alternator.internal.AlternatorLiveNodesDnsDiscoveryTest#testDnsEntrypointDiscoversDnsNodeRecords test` cannot compile in this environment because only JDK 8 is installed while the project targets Java 11 (`invalid target release: 11`).
- Not run locally: `AlternatorLiveNodesDnsDiscoveryIT` requires the live integration cluster.