### PR TITLE
ci: fix release target tag input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Checkout Code One Commit Before ${{ inputs.version_tag }}
+      - name: Checkout Code One Commit Before ${{ inputs.target-tag }}
         if: inputs.target-tag != 'main'
         env:
-          RELEASE_TARGET_TAG: ${{ inputs.version_tag }}
+          RELEASE_TARGET_TAG: ${{ inputs.target-tag }}
         run: make checkout-one-commit-before
 
       - name: Set up Java


### PR DESCRIPTION
## Summary
- use the workflow_dispatch target-tag input when checking out the release tag
- remove stale version_tag references from the release workflow

## Testing
- git diff --check origin/main..HEAD