### PR TITLE
Close Demo2 client before exit

### DIFF
--- a/src/demo/java/com/scylladb/alternator/demo/Demo2.java
+++ b/src/demo/java/com/scylladb/alternator/demo/Demo2.java
@@ -160,21 +160,19 @@ public class Demo2 {
       ddb = getTraditionalClient(URI.create(endpoint), myCredentials);
     }
 
-    // run DescribeEndpoints several times
-    for (int i = 0; i < 10; i++) {
-      DescribeEndpointsRequest request = DescribeEndpointsRequest.builder().build();
-      DescribeEndpointsResponse response = ddb.describeEndpoints(request);
-      System.out.println(response);
+    try {
+      // run DescribeEndpoints several times
+      for (int i = 0; i < 10; i++) {
+        DescribeEndpointsRequest request = DescribeEndpointsRequest.builder().build();
+        DescribeEndpointsResponse response = ddb.describeEndpoints(request);
+        System.out.println(response);
+      }
+    } finally {
+      ddb.close();
     }
-    // FIXME: The AWS SDK leaves behind an IdleConnectionReaper thread,
-    // which causes mvn to hang waiting for it to shut down (which it
-    // won't). Perhaps if we hold the HttpClient object and close() it,
-    // it will get rid of this reaper object.
-    // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/client/builder/SdkSyncClientBuilder.html#httpClient-software.amazon.awssdk.http.SdkHttpClient-
-    // explains that with httpClient(), "This client must be closed by the
-    // user when it is ready to be disposed. The SDK will not close the
-    // HTTP client when the service client is closed." Maybe we should
-    // use httpClientBuilder() instead, which doesn't have this problem?
+
+    System.out.println("Done");
+    System.exit(0);
   }
 
   // A hack to disable SSL certificate checks. Useful when running with


### PR DESCRIPTION
## Summary

- Close the DynamoDB client in `Demo2` after running `DescribeEndpoints`.
- Keep the demo process exit behavior explicit after cleanup.

## Tests

- `git diff --check main...split/demo2-close-client`
