### PR TITLE
Complete IPv6 and dual-stack discovery tests

### DIFF
--- a/src/integration-test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryIT.java
+++ b/src/integration-test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryIT.java
@@ -20,17 +20,25 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import com.scylladb.alternator.AlternatorConfig;
+import com.scylladb.alternator.AlternatorDynamoDbClient;
+import com.scylladb.alternator.AlternatorDynamoDbClientWrapper;
 import com.scylladb.alternator.IntegrationTestConfig;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.http.conn.DnsResolver;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesRequest;
 
 /** Integration tests for DNS-backed live-node discovery against a real Alternator cluster. */
 public class AlternatorLiveNodesDnsDiscoveryIT {
@@ -60,12 +68,99 @@ public class AlternatorLiveNodesDnsDiscoveryIT {
     }
   }
 
+  @Test
+  public void testIpv6LiteralEntrypointDiscoversLiveClusterNodes() throws Exception {
+    try (DnsEntrypointProxy proxy = new DnsEntrypointProxy(InetAddress.getByName("::1"), 0)) {
+      URI seedUri = new URI("http://[::1]:" + proxy.getPort());
+      AlternatorConfig config = AlternatorConfig.builder().withSeedNode(seedUri).build();
+      AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config);
+
+      try {
+        liveNodes.updateLiveNodes();
+
+        assertTrue("IPv6 entrypoint should be contacted", proxy.getRequestCount() > 0);
+        assertFalse("Should discover live cluster nodes", liveNodes.getLiveNodes().isEmpty());
+      } finally {
+        liveNodes.shutdownAndWait();
+      }
+    }
+  }
+
+  @Test
+  public void testDualStackDnsEntrypointFallsBackToIpv4() throws Exception {
+    InetAddress ipv4 = InetAddress.getByName("127.0.0.1");
+    InetAddress ipv6 = InetAddress.getByName("::1");
+    try (DnsEntrypointProxy ipv4Proxy = new DnsEntrypointProxy(ipv4, 0)) {
+      assertDualStackFallback(ipv4Proxy, ipv6, ipv4);
+    }
+  }
+
+  @Test
+  public void testDualStackDnsEntrypointFallsBackToIpv6() throws Exception {
+    InetAddress ipv4 = InetAddress.getByName("127.0.0.1");
+    InetAddress ipv6 = InetAddress.getByName("::1");
+    try (DnsEntrypointProxy ipv6Proxy = new DnsEntrypointProxy(ipv6, 0)) {
+      assertDualStackFallback(ipv6Proxy, ipv4, ipv6);
+    }
+  }
+
+  @Test
+  public void testDnsEntrypointSupportsDynamoDbOperationsAfterDiscovery() throws Exception {
+    InetAddress ipv4 = InetAddress.getByName("127.0.0.1");
+    try (DnsEntrypointProxy proxy =
+            new DnsEntrypointProxy(ipv4, IntegrationTestConfig.HTTP_PORT);
+        AlternatorDynamoDbClientWrapper wrapper =
+            AlternatorDynamoDbClient.builder()
+                .endpointOverride(URI.create("http://localhost:" + proxy.getPort()))
+                .credentialsProvider(IntegrationTestConfig.CREDENTIALS)
+                .buildWithAlternatorAPI()) {
+      wrapper.getAlternatorLiveNodes().updateLiveNodes();
+
+      wrapper.getClient().listTables(ListTablesRequest.builder().limit(1).build());
+
+      assertTrue("DNS entrypoint should be used for discovery", proxy.getRequestCount() > 0);
+      assertFalse("Should retain discovered live cluster nodes", wrapper.getLiveNodes().isEmpty());
+    }
+  }
+
+  private void assertDualStackFallback(
+      DnsEntrypointProxy reachableProxy, InetAddress... resolvedAddresses) throws Exception {
+    DnsResolver resolver = host -> resolvedAddresses;
+    SdkHttpClient httpClient =
+        ApacheHttpClient.builder()
+            .dnsResolver(resolver)
+            .connectionTimeout(Duration.ofSeconds(2))
+            .socketTimeout(Duration.ofSeconds(5))
+            .build();
+    try {
+      AlternatorConfig config =
+          AlternatorConfig.builder()
+              .withSeedHost("dual.test")
+              .withScheme("http")
+              .withPort(reachableProxy.getPort())
+              .build();
+      AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
+
+      liveNodes.updateLiveNodes();
+
+      assertTrue(
+          "The reachable DNS address should be contacted", reachableProxy.getRequestCount() > 0);
+      assertFalse("Should discover live cluster nodes", liveNodes.getLiveNodes().isEmpty());
+    } finally {
+      httpClient.close();
+    }
+  }
+
   private static class DnsEntrypointProxy implements AutoCloseable {
     private final HttpServer server;
     private final AtomicInteger requestCount = new AtomicInteger(0);
 
     DnsEntrypointProxy() throws IOException {
-      server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+      this(InetAddress.getLoopbackAddress(), 0);
+    }
+
+    DnsEntrypointProxy(InetAddress listenAddress, int port) throws IOException {
+      server = HttpServer.create(new InetSocketAddress(listenAddress, port), 0);
       server.createContext("/localnodes", this::handleLocalNodes);
       server.start();
     }

--- a/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/AlternatorLiveNodesDnsDiscoveryTest.java
@@ -16,8 +16,15 @@
 package com.scylladb.alternator.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.scylladb.alternator.AlternatorConfig;
+import com.scylladb.alternator.routing.ClusterScope;
+import com.scylladb.alternator.routing.DatacenterScope;
+import com.scylladb.alternator.routing.RoutingScope;
+import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -26,13 +33,20 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.http.conn.DnsResolver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 /** Unit tests for DNS-backed live-node discovery. */
@@ -76,12 +90,16 @@ public class AlternatorLiveNodesDnsDiscoveryTest {
     AlternatorConfig config = AlternatorConfig.builder().withSeedNode(seedUri).build();
     AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config);
 
-    liveNodes.updateLiveNodes();
+    try {
+      liveNodes.updateLiveNodes();
 
-    assertEquals("DNS seed should be contacted", 1, requestCount.get());
-    assertEquals(2, liveNodes.getLiveNodes().size());
-    assertEquals("localhost", liveNodes.getLiveNodes().get(0).getHost());
-    assertEquals("node-a.internal", liveNodes.getLiveNodes().get(1).getHost());
+      assertEquals("DNS seed should be contacted", 1, requestCount.get());
+      assertEquals(2, liveNodes.getLiveNodes().size());
+      assertEquals("localhost", liveNodes.getLiveNodes().get(0).getHost());
+      assertEquals("node-a.internal", liveNodes.getLiveNodes().get(1).getHost());
+    } finally {
+      liveNodes.shutdownAndWait();
+    }
   }
 
   /** Verifies raw IPv6 literals are bracketed for discovery, Host, and learned-node routing. */
@@ -126,6 +144,201 @@ public class AlternatorLiveNodesDnsDiscoveryTest {
     assertDnsDiscovery(ipv6, ipv4, ipv6);
   }
 
+  /** Verifies either address family can be selected when both DNS records are reachable. */
+  @Test(timeout = 10000)
+  public void testBothDnsFamiliesReachable() throws Exception {
+    InetAddress ipv4 = InetAddress.getByName("127.0.0.1");
+    InetAddress ipv6 = InetAddress.getByName("::1");
+    HttpServer ipv6Server = startServer(ipv6, 0, "[\"ipv6-node.test\"]", exchange -> {});
+    int dualPort = ipv6Server.getAddress().getPort();
+    HttpServer ipv4Server = startServer(ipv4, dualPort, "[\"ipv4-node.test\"]", exchange -> {});
+    try {
+      assertFirstReachableDnsFamily(dualPort, "ipv6-node.test", ipv6, ipv4);
+      assertFirstReachableDnsFamily(dualPort, "ipv4-node.test", ipv4, ipv6);
+    } finally {
+      ipv4Server.stop(0);
+      ipv6Server.stop(0);
+    }
+  }
+
+  /** Verifies a malformed response retains the seed and a later refresh can recover. */
+  @Test(timeout = 10000)
+  public void testMalformedResponseRetainsSeedThenNextRefreshRecovers() throws Exception {
+    InetAddress ipv4 = InetAddress.getByName("127.0.0.1");
+    InetAddress ipv6 = InetAddress.getByName("::1");
+    HttpServer malformedServer =
+        startServer(
+            ipv4,
+            0,
+            "not-json",
+            exchange -> exchange.getResponseHeaders().set("Connection", "close"));
+    int dualPort = malformedServer.getAddress().getPort();
+    HttpServer validServer =
+        startServer(ipv6, dualPort, "[\"recovered-node.test\"]", exchange -> {});
+    AtomicInteger resolutions = new AtomicInteger();
+    SdkHttpClient httpClient =
+        apacheClient(
+            host ->
+                resolutions.getAndIncrement() == 0
+                    ? new InetAddress[] {ipv4, ipv6}
+                    : new InetAddress[] {ipv6, ipv4});
+    try {
+      AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(dnsConfig(dualPort), httpClient);
+
+      liveNodes.updateLiveNodes();
+      assertEquals("dual.test", liveNodes.nextAsURI().getHost());
+
+      liveNodes.updateLiveNodes();
+      assertEquals("recovered-node.test", liveNodes.nextAsURI().getHost());
+      assertTrue("DNS should be resolved again after malformed response", resolutions.get() >= 2);
+    } finally {
+      httpClient.close();
+      validServer.stop(0);
+      malformedServer.stop(0);
+    }
+  }
+
+  /**
+   * Verifies requests use learned nodes and discovery can recover through the original DNS seed.
+   */
+  @Test(timeout = 10000)
+  public void testLearnedNodeRoutingAndOriginalDnsSeedRecovery() throws Exception {
+    InetAddress ipv4 = InetAddress.getByName("127.0.0.1");
+    InetAddress ipv6 = InetAddress.getByName("::1");
+    AtomicReference<String> seedResponse = new AtomicReference<>("[\"learned.test\"]");
+    AtomicInteger seedDiscoveryRequests = new AtomicInteger();
+    AtomicInteger learnedDiscoveryRequests = new AtomicInteger();
+    AtomicInteger operationRequests = new AtomicInteger();
+    HttpServer seedServer =
+        startServer(
+            ipv4,
+            0,
+            exchange -> seedResponse.get(),
+            exchange -> seedDiscoveryRequests.incrementAndGet());
+    int dualPort = seedServer.getAddress().getPort();
+    HttpServer learnedServer =
+        startServer(
+            ipv6,
+            dualPort,
+            "[\"learned.test\"]",
+            exchange -> learnedDiscoveryRequests.incrementAndGet());
+    learnedServer.createContext(
+        "/operation",
+        exchange -> {
+          operationRequests.incrementAndGet();
+          writeResponse(exchange, "ok");
+        });
+    AtomicBoolean recovering = new AtomicBoolean(false);
+    SdkHttpClient httpClient =
+        apacheClient(
+            host -> {
+              if ("learned.test".equals(host)) {
+                return new InetAddress[] {ipv6};
+              }
+              if ("dual.test".equals(host) && recovering.get()) {
+                return new InetAddress[] {ipv6, ipv4};
+              }
+              return new InetAddress[] {ipv4};
+            });
+    try {
+      AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(dnsConfig(dualPort), httpClient);
+
+      liveNodes.updateLiveNodes();
+      assertEquals("learned.test", liveNodes.nextAsURI().getHost());
+      assertEquals(1, seedDiscoveryRequests.get());
+
+      assertEquals(200, executeGet(httpClient, liveNodes.nextAsURI().resolve("/operation")));
+      assertEquals(1, operationRequests.get());
+      assertEquals(
+          "Normal requests must not return to the discovery seed", 1, seedDiscoveryRequests.get());
+
+      liveNodes.updateLiveNodes();
+      assertEquals(1, learnedDiscoveryRequests.get());
+      assertEquals("learned.test", liveNodes.nextAsURI().getHost());
+
+      learnedServer.stop(0);
+      seedResponse.set("[\"recovered.test\"]");
+      recovering.set(true);
+      liveNodes.updateLiveNodes();
+
+      assertEquals("recovered.test", liveNodes.nextAsURI().getHost());
+      assertEquals(2, seedDiscoveryRequests.get());
+    } finally {
+      httpClient.close();
+      learnedServer.stop(0);
+      seedServer.stop(0);
+    }
+  }
+
+  /** Verifies valid, strict-invalid, and fallback scopes over a dual-stack DNS entrypoint. */
+  @Test(timeout = 10000)
+  public void testScopeBehaviorOverDualStackDns() throws Exception {
+    InetAddress ipv4 = InetAddress.getByName("127.0.0.1");
+    InetAddress ipv6 = InetAddress.getByName("::1");
+    AtomicReference<String> lastQuery = new AtomicReference<>();
+    HttpServer scopeServer =
+        startServer(
+            ipv6,
+            0,
+            exchange -> {
+              String query = exchange.getRequestURI().getRawQuery();
+              lastQuery.set(query);
+              if ("dc=dc1".equals(query)) {
+                return "[\"scoped-node.test\"]";
+              }
+              if (query == null) {
+                return "[\"fallback-node.test\"]";
+              }
+              return "[]";
+            },
+            exchange -> {});
+    int dualPort = scopeServer.getAddress().getPort();
+    DnsResolver resolver = host -> new InetAddress[] {ipv4, ipv6};
+    try {
+      SdkHttpClient validClient = apacheClient(resolver);
+      try {
+        AlternatorLiveNodes valid =
+            new AlternatorLiveNodes(
+                dnsConfig(dualPort, DatacenterScope.of("dc1", null)), validClient);
+        valid.updateLiveNodes();
+        assertEquals("scoped-node.test", valid.nextAsURI().getHost());
+        assertEquals("dc=dc1", lastQuery.get());
+      } finally {
+        validClient.close();
+      }
+
+      SdkHttpClient strictClient = apacheClient(resolver);
+      try {
+        AlternatorLiveNodes strict =
+            new AlternatorLiveNodes(
+                dnsConfig(dualPort, DatacenterScope.of("wrong", null)), strictClient);
+        try {
+          strict.checkIfRackAndDatacenterSetCorrectly();
+          fail("Expected invalid strict scope to be rejected");
+        } catch (AlternatorLiveNodes.ValidationError expected) {
+          assertTrue(expected.getMessage().contains("routing scope may be set incorrectly"));
+        }
+      } finally {
+        strictClient.close();
+      }
+
+      SdkHttpClient fallbackClient = apacheClient(resolver);
+      try {
+        AlternatorLiveNodes fallback =
+            new AlternatorLiveNodes(
+                dnsConfig(dualPort, DatacenterScope.of("wrong", ClusterScope.create())),
+                fallbackClient);
+        fallback.updateLiveNodes();
+        assertEquals("fallback-node.test", fallback.nextAsURI().getHost());
+        assertNull(lastQuery.get());
+      } finally {
+        fallbackClient.close();
+      }
+    } finally {
+      scopeServer.stop(0);
+    }
+  }
+
   /** Verifies an unavailable dual-stack entrypoint returns promptly and preserves its seed. */
   @Test(timeout = 10000)
   public void testAllDnsRecordsUnavailableKeepsSeed() throws Exception {
@@ -139,10 +352,25 @@ public class AlternatorLiveNodesDnsDiscoveryTest {
       AlternatorConfig config = dnsConfig(closedPort);
       AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(config, httpClient);
 
+      long startNanos = System.nanoTime();
       liveNodes.updateLiveNodes();
+      long elapsedMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
 
       assertEquals(1, liveNodes.getLiveNodes().size());
       assertEquals("dual.test", liveNodes.nextAsURI().getHost());
+      assertTrue("Unavailable DNS records must return promptly", elapsedMillis < 5000);
+    } finally {
+      httpClient.close();
+    }
+  }
+
+  private void assertFirstReachableDnsFamily(
+      int dnsPort, String expectedHost, InetAddress... resolvedAddresses) throws Exception {
+    SdkHttpClient httpClient = apacheClient(host -> resolvedAddresses);
+    try {
+      AlternatorLiveNodes liveNodes = new AlternatorLiveNodes(dnsConfig(dnsPort), httpClient);
+      liveNodes.updateLiveNodes();
+      assertEquals(expectedHost, liveNodes.nextAsURI().getHost());
     } finally {
       httpClient.close();
     }
@@ -180,6 +408,15 @@ public class AlternatorLiveNodesDnsDiscoveryTest {
         .build();
   }
 
+  private AlternatorConfig dnsConfig(int dnsPort, RoutingScope routingScope) {
+    return AlternatorConfig.builder()
+        .withSeedHosts(Arrays.asList("dual.test"))
+        .withScheme("http")
+        .withPort(dnsPort)
+        .withRoutingScope(routingScope)
+        .build();
+  }
+
   private SdkHttpClient apacheClient(DnsResolver dnsResolver) {
     ApacheHttpClient.Builder builder =
         ApacheHttpClient.builder()
@@ -194,22 +431,63 @@ public class AlternatorLiveNodesDnsDiscoveryTest {
   private HttpServer startServer(
       InetAddress listenAddress, String responseBody, ExchangeObserver observer)
       throws IOException {
-    HttpServer httpServer = HttpServer.create(new InetSocketAddress(listenAddress, 0), 0);
+    return startServer(listenAddress, 0, responseBody, observer);
+  }
+
+  private HttpServer startServer(
+      InetAddress listenAddress, int listenPort, String responseBody, ExchangeObserver observer)
+      throws IOException {
+    return startServer(listenAddress, listenPort, exchange -> responseBody, observer);
+  }
+
+  private HttpServer startServer(
+      InetAddress listenAddress,
+      int listenPort,
+      ResponseProvider responseProvider,
+      ExchangeObserver observer)
+      throws IOException {
+    HttpServer httpServer = HttpServer.create(new InetSocketAddress(listenAddress, listenPort), 0);
     httpServer.createContext(
         "/localnodes",
         exchange -> {
           observer.observe(exchange);
-          byte[] body = responseBody.getBytes();
-          exchange.sendResponseHeaders(200, body.length);
-          try (OutputStream output = exchange.getResponseBody()) {
-            output.write(body);
-          }
+          writeResponse(exchange, responseProvider.response(exchange));
         });
     httpServer.start();
     return httpServer;
   }
 
+  private int executeGet(SdkHttpClient httpClient, URI uri) throws IOException {
+    SdkHttpRequest request =
+        SdkHttpRequest.builder()
+            .uri(uri)
+            .method(SdkHttpMethod.GET)
+            .putHeader("Host", uri.getHost() + ":" + uri.getPort())
+            .build();
+    ExecutableHttpRequest executable =
+        httpClient.prepareRequest(HttpExecuteRequest.builder().request(request).build());
+    HttpExecuteResponse response = executable.call();
+    if (response.responseBody().isPresent()) {
+      try (AbortableInputStream ignored = response.responseBody().get()) {
+        // Closing body releases connection.
+      }
+    }
+    return response.httpResponse().statusCode();
+  }
+
+  private static void writeResponse(HttpExchange exchange, String responseBody) throws IOException {
+    byte[] body = responseBody.getBytes();
+    exchange.sendResponseHeaders(200, body.length);
+    try (OutputStream output = exchange.getResponseBody()) {
+      output.write(body);
+    }
+  }
+
   private interface ExchangeObserver {
-    void observe(com.sun.net.httpserver.HttpExchange exchange);
+    void observe(HttpExchange exchange);
+  }
+
+  private interface ResponseProvider {
+    String response(HttpExchange exchange);
   }
 }

--- a/src/test/java/com/scylladb/alternator/internal/LocalNodesResponseParserTest.java
+++ b/src/test/java/com/scylladb/alternator/internal/LocalNodesResponseParserTest.java
@@ -53,6 +53,11 @@ public class LocalNodesResponseParserTest {
   }
 
   @Test
+  public void returnsEmptyListWhenAllHostEntriesAreUnusable() throws Exception {
+    assertTrue(parser.parse("[\"bad host\",\"also bad host\"]").isEmpty());
+  }
+
+  @Test
   public void rejectsMalformedBodies() throws Exception {
     assertMalformed("");
     assertMalformed("not-json");


### PR DESCRIPTION
Jira: [DRIVER-917](https://scylladb.atlassian.net/browse/DRIVER-917)
Parent Jira issue: [DRIVER-823](https://scylladb.atlassian.net/browse/DRIVER-823)

Follow-up to #154. Completes and strengthens coverage for IPv6 and dual-stack DNS entrypoint behavior:

- cover all-reachable and unavailable cross-family DNS paths
- verify malformed response retention and later recovery accurately
- verify learned-node routing and original DNS-seed recovery
- cover valid, strict-invalid, and fallback routing scopes
- exercise IPv4 and IPv6 fallback against a live Scylla cluster
- run a real DynamoDB operation after DNS discovery
- cover unusable `/localnodes` host lists and close polling resources

Verification performed locally:

- targeted unit tests on Java 11 and Java 17
- formatting, Checkstyle, and test compilation
- five live DNS discovery integration tests against a three-node Scylla cluster

Closes #155

[DRIVER-917]: https://scylladb.atlassian.net/browse/DRIVER-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DRIVER-823]: https://scylladb.atlassian.net/browse/DRIVER-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ